### PR TITLE
Add Sorts: Like Ratio, Likes, and Dislikes for both hidden group and user experiences

### DIFF
--- a/src/content/features/groups/hiddenGroupGames.js
+++ b/src/content/features/groups/hiddenGroupGames.js
@@ -223,21 +223,22 @@ class HiddenGamesManager {
             await api.getGameDetails(this.allGames, this.cache.likes, this.cache.players);
         }
 
+        const orderMultiplier = order === 'desc' ? -1 : 1;
         let processed = [...this.allGames];
         if (sort === "like-ratio") {
-            processed.sort((a, b) => (this.cache.likes.get(b.id)?.ratio || 0) - (this.cache.likes.get(a.id)?.ratio || 0));
+            processed.sort((a, b) => ((this.cache.likes.get(a.id)?.ratio || 0) - (this.cache.likes.get(b.id)?.ratio || 0)) * orderMultiplier);
         } else if (sort === "likes") {
-            processed.sort((a, b) => (this.cache.likes.get(b.id)?.upVotes || 0) - (this.cache.likes.get(a.id)?.upVotes || 0));
+            processed.sort((a, b) => ((this.cache.likes.get(a.id)?.upVotes || 0) - (this.cache.likes.get(b.id)?.upVotes || 0)) * orderMultiplier);
         } else if (sort === "dislikes") {
-            processed.sort((a, b) => (this.cache.likes.get(b.id)?.downVotes || 0) - (this.cache.likes.get(a.id)?.downVotes || 0));
+            processed.sort((a, b) => ((this.cache.likes.get(a.id)?.downVotes || 0) - (this.cache.likes.get(b.id)?.downVotes || 0)) * orderMultiplier);
         } else if (sort === "players") {
-            processed.sort((a, b) => (this.cache.players.get(b.id) || 0) - (this.cache.players.get(a.id) || 0));
+            processed.sort((a, b) => ((this.cache.players.get(a.id) || 0) - (this.cache.players.get(b.id) || 0)) * orderMultiplier);
         } else if (sort === "name") {
-            processed.sort((a, b) => a.name.localeCompare(b.name));
-        }
-
-        if ((order === "asc" && sort !== "name") || (order === "desc" && sort === "name")) {
-            processed.reverse();
+            processed.sort((a, b) => a.name.localeCompare(b.name) * orderMultiplier);
+        } else {
+            if (order === "asc") {
+                processed.reverse();
+            }
         }
 
         this.filteredGames = processed;

--- a/src/content/features/profile/hiddengames.js
+++ b/src/content/features/profile/hiddengames.js
@@ -348,13 +348,13 @@ class HiddenGamesManager {
         let sorted = [...this.allGames];
         
         if (sort === 'like-ratio') {
-            sorted.sort((a, b) => ((this.cache.likes.get(b.id)?.ratio || 0) - (this.cache.likes.get(a.id)?.ratio || 0)));
+            sorted.sort((a, b) => ((this.cache.likes.get(a.id)?.ratio || 0) - (this.cache.likes.get(b.id)?.ratio || 0)) * orderMultiplier);
         } else if (sort === "likes") {
-            sorted.sort((a, b) => (this.cache.likes.get(b.id)?.upVotes || 0) - (this.cache.likes.get(a.id)?.upVotes || 0));
+            sorted.sort((a, b) => ((this.cache.likes.get(a.id)?.upVotes || 0) - (this.cache.likes.get(b.id)?.upVotes || 0)) * orderMultiplier);
         } else if (sort === "dislikes") {
-            sorted.sort((a, b) => (this.cache.likes.get(b.id)?.downVotes || 0) - (this.cache.likes.get(a.id)?.downVotes || 0));
+            sorted.sort((a, b) => ((this.cache.likes.get(a.id)?.downVotes || 0) - (this.cache.likes.get(b.id)?.downVotes || 0)) * orderMultiplier);
         } else if (sort === 'players') {
-            sorted.sort((a, b) => ((this.cache.players.get(b.id) || 0) - (this.cache.players.get(a.id) || 0)));
+            sorted.sort((a, b) => ((this.cache.players.get(a.id) || 0) - (this.cache.players.get(b.id) || 0)) * orderMultiplier);
         } else if (sort === 'name') {
             sorted.sort((a, b) => a.name.localeCompare(b.name) * (orderMultiplier));
         } else { 


### PR DESCRIPTION
This adds more sorts for the hidden experiences for both groups and users

Users:
<img width="547" height="373" alt="Screenshot 2025-12-26 124458" src="https://github.com/user-attachments/assets/c8674381-d288-4d8d-b76b-813a6997072b" />

Groups:
<img width="560" height="396" alt="Screenshot 2025-12-26 122853" src="https://github.com/user-attachments/assets/d9382a5a-7779-4901-ae31-1d683c75ef12" />

Also im sorry for formatting the files with prettier oops