### PR TITLE
Replace i18next in locale system

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -283,8 +283,6 @@
         },
         "node_modules/@esbuild/linux-x64": {
             "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-            "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
             "cpu": [
                 "x64"
             ],
@@ -443,8 +441,6 @@
         },
         "node_modules/@eslint-community/eslint-utils": {
             "version": "4.9.1",
-            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
-            "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -462,8 +458,6 @@
         },
         "node_modules/@eslint-community/regexpp": {
             "version": "4.12.2",
-            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
-            "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -472,8 +466,6 @@
         },
         "node_modules/@eslint/config-array": {
             "version": "0.23.5",
-            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
-            "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -487,8 +479,6 @@
         },
         "node_modules/@eslint/config-helpers": {
             "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
-            "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -500,8 +490,6 @@
         },
         "node_modules/@eslint/core": {
             "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
-            "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -513,8 +501,6 @@
         },
         "node_modules/@eslint/eslintrc": {
             "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
-            "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -537,8 +523,6 @@
         },
         "node_modules/@eslint/eslintrc/node_modules/globals": {
             "version": "13.24.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-            "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -553,8 +537,6 @@
         },
         "node_modules/@eslint/js": {
             "version": "8.57.1",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
-            "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -563,8 +545,6 @@
         },
         "node_modules/@eslint/object-schema": {
             "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
-            "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -573,8 +553,6 @@
         },
         "node_modules/@eslint/plugin-kit": {
             "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
-            "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -587,8 +565,6 @@
         },
         "node_modules/@humanfs/core": {
             "version": "0.19.1",
-            "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-            "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -597,8 +573,6 @@
         },
         "node_modules/@humanfs/node": {
             "version": "0.16.7",
-            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-            "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -611,9 +585,6 @@
         },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.13.0",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
-            "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
-            "deprecated": "Use @eslint/config-array instead",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -627,8 +598,6 @@
         },
         "node_modules/@humanwhocodes/module-importer": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
-            "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -641,16 +610,11 @@
         },
         "node_modules/@humanwhocodes/object-schema": {
             "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
-            "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
-            "deprecated": "Use @eslint/object-schema instead",
             "dev": true,
             "license": "BSD-3-Clause"
         },
         "node_modules/@humanwhocodes/retry": {
             "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
-            "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -663,8 +627,6 @@
         },
         "node_modules/@jest/schemas": {
             "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-            "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -676,8 +638,6 @@
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -690,8 +650,6 @@
         },
         "node_modules/@nodelib/fs.stat": {
             "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -700,8 +658,6 @@
         },
         "node_modules/@nodelib/fs.walk": {
             "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -714,8 +670,6 @@
         },
         "node_modules/@parcel/watcher": {
             "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
-            "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -910,8 +864,6 @@
         },
         "node_modules/@parcel/watcher-linux-x64-glibc": {
             "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz",
-            "integrity": "sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==",
             "cpu": [
                 "x64"
             ],
@@ -930,8 +882,6 @@
         },
         "node_modules/@parcel/watcher-linux-x64-musl": {
             "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz",
-            "integrity": "sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==",
             "cpu": [
                 "x64"
             ],
@@ -1010,42 +960,31 @@
         },
         "node_modules/@sinclair/typebox": {
             "version": "0.27.10",
-            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-            "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/esrecurse": {
             "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
-            "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/estree": {
             "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-            "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/json-schema": {
             "version": "7.0.15",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-            "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/trusted-types": {
             "version": "2.0.7",
-            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-            "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+            "license": "MIT",
             "optional": true
         },
         "node_modules/@typescript-eslint/scope-manager": {
             "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
-            "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1062,8 +1001,6 @@
         },
         "node_modules/@typescript-eslint/types": {
             "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
-            "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1076,8 +1013,6 @@
         },
         "node_modules/@typescript-eslint/typescript-estree": {
             "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
-            "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -1105,8 +1040,6 @@
         },
         "node_modules/@typescript-eslint/visitor-keys": {
             "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
-            "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1123,15 +1056,11 @@
         },
         "node_modules/@ungap/structured-clone": {
             "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
-            "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/acorn": {
             "version": "8.16.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-            "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "devOptional": true,
             "license": "MIT",
             "bin": {
@@ -1143,8 +1072,6 @@
         },
         "node_modules/acorn-jsx": {
             "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-            "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
             "dev": true,
             "license": "MIT",
             "peerDependencies": {
@@ -1153,8 +1080,6 @@
         },
         "node_modules/ajv": {
             "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-            "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1170,8 +1095,6 @@
         },
         "node_modules/ansi-regex": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1180,8 +1103,6 @@
         },
         "node_modules/ansi-styles": {
             "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1196,15 +1117,11 @@
         },
         "node_modules/argparse": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "dev": true,
             "license": "Python-2.0"
         },
         "node_modules/array-union": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1213,8 +1130,6 @@
         },
         "node_modules/braces": {
             "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -1226,8 +1141,6 @@
         },
         "node_modules/callsites": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1236,8 +1149,6 @@
         },
         "node_modules/chalk": {
             "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1253,8 +1164,6 @@
         },
         "node_modules/chokidar": {
             "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-            "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -1269,8 +1178,6 @@
         },
         "node_modules/color-convert": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1282,15 +1189,11 @@
         },
         "node_modules/color-name": {
             "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/common-tags": {
             "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
-            "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1299,9 +1202,8 @@
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -1313,8 +1215,6 @@
         },
         "node_modules/debug": {
             "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
@@ -1330,15 +1230,11 @@
         },
         "node_modules/deep-is": {
             "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-            "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/detect-libc": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-            "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
             "license": "Apache-2.0",
             "optional": true,
             "bin": {
@@ -1350,8 +1246,6 @@
         },
         "node_modules/dir-glob": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1363,15 +1257,11 @@
         },
         "node_modules/dlv": {
             "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-            "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/doctrine": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-            "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -1383,8 +1273,6 @@
         },
         "node_modules/dompurify": {
             "version": "3.4.4",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.4.tgz",
-            "integrity": "sha512-r8K7KGKEcztXfA/nfabSYB2hg9tDphORJTdf8xprN/luSLGmNhOBN8dm1/SYjqLLet6YUFEXOcrdTuwryp/Bew==",
             "license": "(MPL-2.0 OR Apache-2.0)",
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"
@@ -1392,8 +1280,6 @@
         },
         "node_modules/esbuild": {
             "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-            "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
             "devOptional": true,
             "hasInstallScript": true,
             "license": "MIT",
@@ -1434,8 +1320,6 @@
         },
         "node_modules/escape-string-regexp": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1447,8 +1331,6 @@
         },
         "node_modules/eslint": {
             "version": "10.4.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
-            "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1503,8 +1385,6 @@
         },
         "node_modules/eslint-config-prettier": {
             "version": "10.1.8",
-            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
-            "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -1519,8 +1399,6 @@
         },
         "node_modules/eslint-scope": {
             "version": "7.2.2",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
-            "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -1536,8 +1414,6 @@
         },
         "node_modules/eslint-visitor-keys": {
             "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -1549,8 +1425,6 @@
         },
         "node_modules/eslint/node_modules/eslint-scope": {
             "version": "9.1.2",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
-            "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -1568,8 +1442,6 @@
         },
         "node_modules/eslint/node_modules/eslint-visitor-keys": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-            "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -1581,8 +1453,6 @@
         },
         "node_modules/eslint/node_modules/espree": {
             "version": "11.2.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
-            "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -1599,8 +1469,6 @@
         },
         "node_modules/espree": {
             "version": "9.6.1",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-            "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -1617,8 +1485,6 @@
         },
         "node_modules/esquery": {
             "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
-            "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -1630,8 +1496,6 @@
         },
         "node_modules/esrecurse": {
             "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-            "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -1643,8 +1507,6 @@
         },
         "node_modules/estraverse": {
             "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
             "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
@@ -1653,8 +1515,6 @@
         },
         "node_modules/esutils": {
             "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
             "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
@@ -1669,15 +1529,11 @@
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-glob": {
             "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-            "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1693,8 +1549,6 @@
         },
         "node_modules/fast-glob/node_modules/glob-parent": {
             "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -1706,22 +1560,16 @@
         },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-levenshtein": {
             "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-            "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/fastq": {
             "version": "1.20.1",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
-            "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -1730,8 +1578,6 @@
         },
         "node_modules/file-entry-cache": {
             "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
-            "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1743,8 +1589,6 @@
         },
         "node_modules/fill-range": {
             "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -1756,8 +1600,6 @@
         },
         "node_modules/find-up": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-            "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1773,8 +1615,6 @@
         },
         "node_modules/flat-cache": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
-            "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1787,27 +1627,20 @@
         },
         "node_modules/flatted": {
             "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.4.tgz",
-            "integrity": "sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/fzstd": {
             "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/fzstd/-/fzstd-0.1.1.tgz",
-            "integrity": "sha512-dkuVSOKKwh3eas5VkJy1AW1vFpet8TA/fGmVA5krThl8YcOVE/8ZIoEA1+U1vEn5ckxxhLirSdY837azmbaNHA=="
+            "license": "MIT"
         },
         "node_modules/glob": {
             "version": "13.0.6",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
@@ -1824,8 +1657,6 @@
         },
         "node_modules/glob-parent": {
             "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-            "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -1837,8 +1668,6 @@
         },
         "node_modules/globals": {
             "version": "17.6.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
-            "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1850,8 +1679,6 @@
         },
         "node_modules/globby": {
             "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-            "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1871,20 +1698,15 @@
         },
         "node_modules/globrex": {
             "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-            "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="
+            "license": "MIT"
         },
         "node_modules/graphemer": {
             "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-            "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/has-ansi": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-            "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1896,8 +1718,6 @@
         },
         "node_modules/has-ansi/node_modules/ansi-regex": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1906,8 +1726,6 @@
         },
         "node_modules/has-flag": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1916,8 +1734,6 @@
         },
         "node_modules/ignore": {
             "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-            "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1926,15 +1742,11 @@
         },
         "node_modules/immutable": {
             "version": "5.1.5",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
-            "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
             "devOptional": true,
             "license": "MIT"
         },
         "node_modules/import-fresh": {
             "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-            "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1950,8 +1762,6 @@
         },
         "node_modules/imurmurhash": {
             "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-            "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1960,8 +1770,6 @@
         },
         "node_modules/indent-string": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1970,9 +1778,6 @@
         },
         "node_modules/inflight": {
             "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-            "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -1982,15 +1787,11 @@
         },
         "node_modules/inherits": {
             "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/is-extglob": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
             "devOptional": true,
             "license": "MIT",
             "engines": {
@@ -1999,8 +1800,6 @@
         },
         "node_modules/is-glob": {
             "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -2012,8 +1811,6 @@
         },
         "node_modules/is-number": {
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "devOptional": true,
             "license": "MIT",
             "engines": {
@@ -2022,8 +1819,6 @@
         },
         "node_modules/is-path-inside": {
             "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-            "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2032,14 +1827,11 @@
         },
         "node_modules/isexe": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-            "dev": true
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/js-yaml": {
             "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2051,29 +1843,21 @@
         },
         "node_modules/json-buffer": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-            "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-            "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/keyv": {
             "version": "4.5.4",
-            "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-            "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2082,8 +1866,6 @@
         },
         "node_modules/levn": {
             "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
-            "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2096,8 +1878,6 @@
         },
         "node_modules/locate-path": {
             "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-            "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2112,22 +1892,16 @@
         },
         "node_modules/lodash": {
             "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/loglevel": {
             "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
-            "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2140,8 +1914,6 @@
         },
         "node_modules/loglevel-colored-level-prefix": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/loglevel-colored-level-prefix/-/loglevel-colored-level-prefix-1.0.0.tgz",
-            "integrity": "sha512-u45Wcxxc+SdAlh4yeF/uKlC1SPUPCy0gullSNKXod5I4bmifzk+Q4lSLExNEVn19tGaJipbZ4V4jbFn79/6mVA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2151,8 +1923,6 @@
         },
         "node_modules/loglevel-colored-level-prefix/node_modules/ansi-regex": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2161,8 +1931,6 @@
         },
         "node_modules/loglevel-colored-level-prefix/node_modules/ansi-styles": {
             "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-            "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2171,8 +1939,6 @@
         },
         "node_modules/loglevel-colored-level-prefix/node_modules/chalk": {
             "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-            "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2188,8 +1954,6 @@
         },
         "node_modules/loglevel-colored-level-prefix/node_modules/escape-string-regexp": {
             "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2198,8 +1962,6 @@
         },
         "node_modules/loglevel-colored-level-prefix/node_modules/strip-ansi": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2211,8 +1973,6 @@
         },
         "node_modules/loglevel-colored-level-prefix/node_modules/supports-color": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-            "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2221,8 +1981,6 @@
         },
         "node_modules/lru-cache": {
             "version": "11.3.6",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
-            "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -2231,8 +1989,6 @@
         },
         "node_modules/marked": {
             "version": "18.0.3",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.3.tgz",
-            "integrity": "sha512-7VT90JOkDeaRWpfjOReRGPEKn0ecdARBkDGL+tT1wZY0efPPqkUxLUSmzy/C7TIylQYJC9STISEsCHrqb/7VIA==",
             "license": "MIT",
             "bin": {
                 "marked": "bin/marked.js"
@@ -2243,8 +1999,6 @@
         },
         "node_modules/merge2": {
             "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2253,8 +2007,6 @@
         },
         "node_modules/micromatch": {
             "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -2267,8 +2019,6 @@
         },
         "node_modules/minimatch": {
             "version": "9.0.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -2283,15 +2033,11 @@
         },
         "node_modules/minimatch/node_modules/balanced-match": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/minimatch/node_modules/brace-expansion": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2300,8 +2046,6 @@
         },
         "node_modules/minipass": {
             "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-            "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -2310,28 +2054,20 @@
         },
         "node_modules/ms": {
             "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "license": "MIT"
         },
         "node_modules/natural-compare": {
             "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-            "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/node-addon-api": {
             "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-            "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
             "license": "MIT",
             "optional": true
         },
         "node_modules/once": {
             "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -2340,8 +2076,6 @@
         },
         "node_modules/optionator": {
             "version": "0.9.4",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
-            "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2358,8 +2092,6 @@
         },
         "node_modules/p-limit": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-            "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2374,8 +2106,6 @@
         },
         "node_modules/p-locate": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-            "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2390,15 +2120,11 @@
         },
         "node_modules/package-json-from-dist": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-            "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
             "dev": true,
             "license": "BlueOak-1.0.0"
         },
         "node_modules/parent-module": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2410,8 +2136,6 @@
         },
         "node_modules/path-exists": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2420,8 +2144,6 @@
         },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2430,17 +2152,14 @@
         },
         "node_modules/path-key": {
             "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/path-scurry": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-            "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
@@ -2456,8 +2175,6 @@
         },
         "node_modules/path-type": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2466,8 +2183,6 @@
         },
         "node_modules/picomatch": {
             "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "devOptional": true,
             "license": "MIT",
             "engines": {
@@ -2479,8 +2194,6 @@
         },
         "node_modules/prelude-ls": {
             "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-            "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2489,8 +2202,6 @@
         },
         "node_modules/prettier": {
             "version": "3.8.3",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-            "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -2505,8 +2216,6 @@
         },
         "node_modules/prettier-eslint": {
             "version": "16.4.2",
-            "resolved": "https://registry.npmjs.org/prettier-eslint/-/prettier-eslint-16.4.2.tgz",
-            "integrity": "sha512-vtJAQEkaN8fW5QKl08t7A5KCjlZuDUNeIlr9hgolMS5s3+uzbfRHDwaRnzrdqnY2YpHDmeDS/8zY0MKQHXJtaA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2544,8 +2253,6 @@
         },
         "node_modules/prettier-eslint/node_modules/@typescript-eslint/parser": {
             "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
-            "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -2573,9 +2280,6 @@
         },
         "node_modules/prettier-eslint/node_modules/eslint": {
             "version": "8.57.1",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
-            "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
-            "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2630,8 +2334,6 @@
         },
         "node_modules/prettier-eslint/node_modules/file-entry-cache": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-            "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2643,8 +2345,6 @@
         },
         "node_modules/prettier-eslint/node_modules/flat-cache": {
             "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
-            "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2658,9 +2358,6 @@
         },
         "node_modules/prettier-eslint/node_modules/glob": {
             "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -2680,8 +2377,6 @@
         },
         "node_modules/prettier-eslint/node_modules/globals": {
             "version": "13.24.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-            "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2696,9 +2391,6 @@
         },
         "node_modules/prettier-eslint/node_modules/rimraf": {
             "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-            "deprecated": "Rimraf versions prior to v4 are no longer supported",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -2713,8 +2405,6 @@
         },
         "node_modules/pretty-format": {
             "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-            "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2728,8 +2418,6 @@
         },
         "node_modules/pretty-format/node_modules/ansi-styles": {
             "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2741,8 +2429,6 @@
         },
         "node_modules/punycode": {
             "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2751,8 +2437,6 @@
         },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
             "dev": true,
             "funding": [
                 {
@@ -2772,16 +2456,14 @@
         },
         "node_modules/react": {
             "version": "19.2.6",
-            "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
-            "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/react-dom": {
             "version": "19.2.6",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
-            "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+            "license": "MIT",
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
@@ -2791,15 +2473,11 @@
         },
         "node_modules/react-is": {
             "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/readdirp": {
             "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-            "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
             "devOptional": true,
             "license": "MIT",
             "engines": {
@@ -2812,15 +2490,11 @@
         },
         "node_modules/require-relative": {
             "version": "0.8.7",
-            "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
-            "integrity": "sha512-AKGr4qvHiryxRb19m3PsLRGuKVAbJLUD7E6eOaHkfKhwc+vSgVOCY5xNvm9EkolBKTOf0GrQAZKLimOCz81Khg==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/resolve-from": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2829,8 +2503,6 @@
         },
         "node_modules/reusify": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-            "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2840,8 +2512,6 @@
         },
         "node_modules/rimraf": {
             "version": "6.1.3",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
-            "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
@@ -2860,8 +2530,6 @@
         },
         "node_modules/roavatar-renderer": {
             "version": "1.3.6",
-            "resolved": "https://registry.npmjs.org/roavatar-renderer/-/roavatar-renderer-1.3.6.tgz",
-            "integrity": "sha512-CmHIRZBqWgzJoVhfqCOALboELPp/0UWicDxiaJJcxr6OxFg+fkq0K8+FiOCuCD0WD03nY5bBlMJlKyEx/T//EA==",
             "license": "GPL-3.0-only",
             "dependencies": {
                 "fzstd": "^0.1.1",
@@ -2873,14 +2541,10 @@
         },
         "node_modules/roblox-bat": {
             "version": "0.6.5",
-            "resolved": "https://registry.npmjs.org/roblox-bat/-/roblox-bat-0.6.5.tgz",
-            "integrity": "sha512-aHcCSTT92uze1u4zKyG6AUR+IGzTTBnVSAZj6U/a9wIhQT7aid0iKrVu2ts4RXD+hMrV0xSN9YnpCR6hhQkW9Q==",
             "license": "MIT"
         },
         "node_modules/run-parallel": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
             "dev": true,
             "funding": [
                 {
@@ -2903,8 +2567,6 @@
         },
         "node_modules/sass": {
             "version": "1.99.0",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.99.0.tgz",
-            "integrity": "sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -2924,13 +2586,10 @@
         },
         "node_modules/scheduler": {
             "version": "0.27.0",
-            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-            "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
+            "license": "MIT"
         },
         "node_modules/semver": {
             "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -2942,9 +2601,8 @@
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "shebang-regex": "^3.0.0"
             },
@@ -2954,17 +2612,14 @@
         },
         "node_modules/shebang-regex": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/slash": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2973,8 +2628,6 @@
         },
         "node_modules/source-map-js": {
             "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
             "devOptional": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -2983,8 +2636,6 @@
         },
         "node_modules/strip-ansi": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2996,8 +2647,6 @@
         },
         "node_modules/strip-json-comments": {
             "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3009,8 +2658,6 @@
         },
         "node_modules/supports-color": {
             "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3022,20 +2669,15 @@
         },
         "node_modules/text-table": {
             "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-            "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/three": {
             "version": "0.180.0",
-            "resolved": "https://registry.npmjs.org/three/-/three-0.180.0.tgz",
-            "integrity": "sha512-o+qycAMZrh+TsE01GqWUxUIKR1AL0S8pq7zDkYOQw8GqfX8b8VoCKYUoHbhiX5j+7hr8XsuHDVU6+gkQJQKg9w=="
+            "license": "MIT"
         },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -3047,8 +2689,6 @@
         },
         "node_modules/ts-api-utils": {
             "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
-            "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3060,8 +2700,7 @@
         },
         "node_modules/tsconfck": {
             "version": "3.1.6",
-            "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
-            "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+            "license": "MIT",
             "bin": {
                 "tsconfck": "bin/tsconfck.js"
             },
@@ -3079,15 +2718,11 @@
         },
         "node_modules/tslib": {
             "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "devOptional": true,
             "license": "0BSD"
         },
         "node_modules/type-check": {
             "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-            "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3099,8 +2734,6 @@
         },
         "node_modules/type-fest": {
             "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
             "dev": true,
             "license": "(MIT OR CC0-1.0)",
             "engines": {
@@ -3112,8 +2745,6 @@
         },
         "node_modules/typescript": {
             "version": "5.9.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "devOptional": true,
             "license": "Apache-2.0",
             "peer": true,
@@ -3127,8 +2758,6 @@
         },
         "node_modules/uri-js": {
             "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -3137,8 +2766,7 @@
         },
         "node_modules/vite-tsconfig-paths": {
             "version": "5.1.4",
-            "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-5.1.4.tgz",
-            "integrity": "sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==",
+            "license": "MIT",
             "dependencies": {
                 "debug": "^4.1.1",
                 "globrex": "^0.1.2",
@@ -3155,8 +2783,6 @@
         },
         "node_modules/vue-eslint-parser": {
             "version": "9.4.3",
-            "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-9.4.3.tgz",
-            "integrity": "sha512-2rYRLWlIpaiN8xbPiDyXZXRgLGOtWxERV7ND5fFAv5qo1D2N9Fu9MNajBNc6o13lZ+24DAWCkQCvj4klgmcITg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3180,9 +2806,8 @@
         },
         "node_modules/which": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "isexe": "^2.0.0"
             },
@@ -3195,8 +2820,6 @@
         },
         "node_modules/word-wrap": {
             "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
-            "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3205,15 +2828,11 @@
         },
         "node_modules/wrappy": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/yocto-queue": {
             "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-            "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "2.5.1",
             "dependencies": {
                 "dompurify": "^3.4.3",
-                "i18next": "26.2.0",
+                "ezlocale": "1.0.3",
                 "marked": "^18.0.3",
                 "roavatar-renderer": "^1.3.6",
                 "roblox-bat": "0.6.5"
@@ -32,7 +32,6 @@
             "cpu": [
                 "ppc64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -49,7 +48,6 @@
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -66,7 +64,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -83,7 +80,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -100,7 +96,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -117,7 +112,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -134,7 +128,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -151,7 +144,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -168,7 +160,6 @@
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -185,7 +176,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -202,7 +192,6 @@
             "cpu": [
                 "ia32"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -219,7 +208,6 @@
             "cpu": [
                 "loong64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -236,7 +224,6 @@
             "cpu": [
                 "mips64el"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -253,7 +240,6 @@
             "cpu": [
                 "ppc64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -270,7 +256,6 @@
             "cpu": [
                 "riscv64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -287,7 +272,6 @@
             "cpu": [
                 "s390x"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -304,7 +288,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -321,7 +304,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -338,7 +320,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -355,7 +336,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -372,7 +352,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -389,7 +368,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -406,7 +384,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -423,7 +400,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -440,7 +416,6 @@
             "cpu": [
                 "ia32"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -457,7 +432,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -509,22 +483,6 @@
             },
             "engines": {
                 "node": "^20.19.0 || ^22.13.0 || >=24"
-            }
-        },
-        "node_modules/@eslint/config-array/node_modules/minimatch": {
-            "version": "9.0.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.2"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/@eslint/config-helpers": {
@@ -591,22 +549,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-            "version": "9.0.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.2"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/@eslint/js": {
@@ -681,22 +623,6 @@
             },
             "engines": {
                 "node": ">=10.10.0"
-            }
-        },
-        "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
-            "version": "9.0.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.2"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/@humanwhocodes/module-importer": {
@@ -790,7 +716,6 @@
             "version": "2.5.1",
             "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
             "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
-            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -830,7 +755,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -851,7 +775,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -872,7 +795,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -893,7 +815,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -914,7 +835,6 @@
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -935,7 +855,6 @@
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -956,7 +875,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -977,7 +895,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -998,7 +915,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1019,7 +935,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1040,7 +955,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1061,7 +975,6 @@
             "cpu": [
                 "ia32"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1082,7 +995,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1191,22 +1103,6 @@
                 }
             }
         },
-        "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-            "version": "9.0.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.2"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/@typescript-eslint/visitor-keys": {
             "version": "6.21.0",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
@@ -1236,7 +1132,7 @@
             "version": "8.16.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
@@ -1315,28 +1211,11 @@
                 "node": ">=8"
             }
         },
-        "node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/brace-expansion": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
         "node_modules/braces": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
             "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "fill-range": "^7.1.1"
@@ -1376,7 +1255,7 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
             "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "readdirp": "^4.0.1"
@@ -1460,7 +1339,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
             "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
-            "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "bin": {
@@ -1504,9 +1382,9 @@
             }
         },
         "node_modules/dompurify": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.3.tgz",
-            "integrity": "sha512-VVwJidIJcp1hpg2OMXML3ZVRPYSZiq4aX7qBh83BSIpOaRDqI+qxhXjjIWnpzkOXhmp0L81lnoME1mnCc9H48A==",
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.4.tgz",
+            "integrity": "sha512-r8K7KGKEcztXfA/nfabSYB2hg9tDphORJTdf8xprN/luSLGmNhOBN8dm1/SYjqLLet6YUFEXOcrdTuwryp/Bew==",
             "license": "(MPL-2.0 OR Apache-2.0)",
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"
@@ -1516,7 +1394,7 @@
             "version": "0.28.0",
             "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
             "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
-            "dev": true,
+            "devOptional": true,
             "hasInstallScript": true,
             "license": "MIT",
             "bin": {
@@ -1719,22 +1597,6 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
-        "node_modules/eslint/node_modules/minimatch": {
-            "version": "9.0.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.2"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/espree": {
             "version": "9.6.1",
             "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
@@ -1798,6 +1660,12 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/ezlocale": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/ezlocale/-/ezlocale-1.0.3.tgz",
+            "integrity": "sha512-kB5AFxvTwXFkAaN6ViC8A6z0NW29rqIQ4rIH6CqpYlXrnTzZ6QyROguckxTZkpqHTjVJfm1Fbkimc4ONnvsnIQ==",
+            "license": "MIT"
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -1877,7 +1745,7 @@
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
             "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "to-regex-range": "^5.0.1"
@@ -1918,9 +1786,9 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-            "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.4.tgz",
+            "integrity": "sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==",
             "dev": true,
             "license": "ISC"
         },
@@ -1965,22 +1833,6 @@
             },
             "engines": {
                 "node": ">=10.13.0"
-            }
-        },
-        "node_modules/glob/node_modules/minimatch": {
-            "version": "9.0.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.2"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/globals": {
@@ -2062,34 +1914,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/i18next": {
-            "version": "26.2.0",
-            "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.2.0.tgz",
-            "integrity": "sha512-zwBHldHdTmwN7r6UNc7lC6GWNN+YYg3DrRSeHR5PRRBf5QnJZcYHrQc0uaU26qZeYxR7iFZD+Y315dPnKP47wA==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://www.locize.com/i18next"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://www.locize.com"
-                }
-            ],
-            "license": "MIT",
-            "peerDependencies": {
-                "typescript": "^5 || ^6"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/ignore": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2104,7 +1928,7 @@
             "version": "5.1.5",
             "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
             "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/import-fresh": {
@@ -2167,7 +1991,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -2177,7 +2001,7 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "is-extglob": "^2.1.1"
@@ -2190,7 +2014,7 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.12.0"
@@ -2287,9 +2111,9 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.18.1",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+            "version": "4.17.23",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
             "dev": true,
             "license": "MIT"
         },
@@ -2396,9 +2220,9 @@
             }
         },
         "node_modules/lru-cache": {
-            "version": "11.2.6",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-            "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+            "version": "11.3.6",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+            "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -2431,7 +2255,7 @@
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
             "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "braces": "^3.0.3",
@@ -2439,6 +2263,39 @@
             },
             "engines": {
                 "node": ">=8.6"
+            }
+        },
+        "node_modules/minimatch": {
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.2"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/minimatch/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/minimatch/node_modules/brace-expansion": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
             }
         },
         "node_modules/minipass": {
@@ -2468,7 +2325,6 @@
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
             "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-            "dev": true,
             "license": "MIT",
             "optional": true
         },
@@ -2612,7 +2468,7 @@
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -2838,22 +2694,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/prettier-eslint/node_modules/minimatch": {
-            "version": "9.0.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.2"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/prettier-eslint/node_modules/rimraf": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -2960,7 +2800,7 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
             "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 14.18.0"
@@ -3065,7 +2905,7 @@
             "version": "1.99.0",
             "resolved": "https://registry.npmjs.org/sass/-/sass-1.99.0.tgz",
             "integrity": "sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "chokidar": "^4.0.0",
@@ -3135,7 +2975,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
             "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-            "dev": true,
+            "devOptional": true,
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
@@ -3196,7 +3036,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "is-number": "^7.0.0"
@@ -3241,7 +3081,7 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "dev": true,
+            "devOptional": true,
             "license": "0BSD"
         },
         "node_modules/type-check": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,18 +8,11 @@
             "name": "rovalra",
             "version": "2.5.1",
             "dependencies": {
-<<<<<<< HEAD
                 "dompurify": "^3.4.3",
                 "ezlocale": "1.0.3",
                 "marked": "^18.0.3",
                 "roavatar-renderer": "^1.3.6",
                 "roblox-bat": "0.6.5"
-=======
-                "dompurify": "^3.3.2",
-                "ezlocale": ">=2.1.0",
-                "marked": "^17.0.4",
-                "roavatar-renderer": "1.2.0"
->>>>>>> c3f5f68 (locale: first functional version)
             },
             "devDependencies": {
                 "esbuild": "^0.28.0",
@@ -1529,15 +1522,9 @@
             }
         },
         "node_modules/ezlocale": {
-<<<<<<< HEAD
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/ezlocale/-/ezlocale-1.0.3.tgz",
             "integrity": "sha512-kB5AFxvTwXFkAaN6ViC8A6z0NW29rqIQ4rIH6CqpYlXrnTzZ6QyROguckxTZkpqHTjVJfm1Fbkimc4ONnvsnIQ==",
-=======
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/ezlocale/-/ezlocale-2.1.0.tgz",
-            "integrity": "sha512-m0sWntF9u93cH7/OGpnuYw1sYuZaPOd1GlbQvaaxOufYr3TayQJrplnctBBmOMH9aEaTMIFinWx9sHtUU+gQOA==",
->>>>>>> c3f5f68 (locale: first functional version)
             "license": "MIT"
         },
         "node_modules/fast-deep-equal": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,18 @@
             "name": "rovalra",
             "version": "2.5.1",
             "dependencies": {
+<<<<<<< HEAD
                 "dompurify": "^3.4.3",
                 "ezlocale": "1.0.3",
                 "marked": "^18.0.3",
                 "roavatar-renderer": "^1.3.6",
                 "roblox-bat": "0.6.5"
+=======
+                "dompurify": "^3.3.2",
+                "ezlocale": ">=2.1.0",
+                "marked": "^17.0.4",
+                "roavatar-renderer": "1.2.0"
+>>>>>>> c3f5f68 (locale: first functional version)
             },
             "devDependencies": {
                 "esbuild": "^0.28.0",
@@ -1522,9 +1529,15 @@
             }
         },
         "node_modules/ezlocale": {
+<<<<<<< HEAD
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/ezlocale/-/ezlocale-1.0.3.tgz",
             "integrity": "sha512-kB5AFxvTwXFkAaN6ViC8A6z0NW29rqIQ4rIH6CqpYlXrnTzZ6QyROguckxTZkpqHTjVJfm1Fbkimc4ONnvsnIQ==",
+=======
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/ezlocale/-/ezlocale-2.1.0.tgz",
+            "integrity": "sha512-m0sWntF9u93cH7/OGpnuYw1sYuZaPOd1GlbQvaaxOufYr3TayQJrplnctBBmOMH9aEaTMIFinWx9sHtUU+gQOA==",
+>>>>>>> c3f5f68 (locale: first functional version)
             "license": "MIT"
         },
         "node_modules/fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "dompurify": "^3.4.3",
-        "i18next": "26.2.0",
+        "ezlocale": "1.0.3",
         "marked": "^18.0.3",
         "roavatar-renderer": "^1.3.6",
         "roblox-bat": "0.6.5"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
         "sass": "^1.99.0"
     },
     "dependencies": {
-<<<<<<< HEAD
         "dompurify": "^3.4.3",
         "ezlocale": "1.0.3",
         "marked": "^18.0.3",
@@ -32,12 +31,6 @@
         "lodash": "^4.17.21",
         "minimatch": "^9.0.5",
         "picomatch": "^4.0.2"
-=======
-        "dompurify": "^3.3.2",
-        "marked": "^17.0.4",
-        "roavatar-renderer": "1.2.0",
-        "ezlocale": ">=2.1.0"
->>>>>>> c3f5f68 (locale: first functional version)
     },
     "lint-staged": {
         "*.js": "eslint --fix",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
         "sass": "^1.99.0"
     },
     "dependencies": {
+<<<<<<< HEAD
         "dompurify": "^3.4.3",
         "ezlocale": "1.0.3",
         "marked": "^18.0.3",
@@ -31,6 +32,12 @@
         "lodash": "^4.17.21",
         "minimatch": "^9.0.5",
         "picomatch": "^4.0.2"
+=======
+        "dompurify": "^3.3.2",
+        "marked": "^17.0.4",
+        "roavatar-renderer": "1.2.0",
+        "ezlocale": ">=2.1.0"
+>>>>>>> c3f5f68 (locale: first functional version)
     },
     "lint-staged": {
         "*.js": "eslint --fix",

--- a/public/Assets/locales/en.json
+++ b/public/Assets/locales/en.json
@@ -56,7 +56,11 @@
         "loading": "Loading..."
     },
     "hiddenGroupGames": {
+<<<<<<< HEAD
         "overlayTitle": "Hidden Group Experiences ({{count}} Total)",
+=======
+        "overlayTitle": "Hidden Group Experiences (%d Total)",
+>>>>>>> 467cd40 (locale: use printf-style formatting)
         "noHiddenGames": "This group has no hidden experiences.",
         "buttonText": "Hidden Experiences",
         "labels": {
@@ -87,7 +91,7 @@
         "errorLoadingItems": "Could not load items.",
         "buttonText": "Show Outfits",
         "overlayTitle": "User Outfits",
-        "overlayTitleUser": "{{displayName}}'s Outfits",
+        "overlayTitleUser": "%s's Outfits",
         "noOutfits": "This user has no outfits.",
         "inventoryPrivate": "User's inventory is private.",
         "errorNoUserId": "Could not determine the User ID from the page.",
@@ -96,7 +100,7 @@
     "donationLink": {
         "donate": "Donate",
         "overlayTitle": "Pls Donate",
-        "description": "This will launch \"PLS DONATE\" where you can give an offline donation.\n\nDue to fees from Roblox (30%) and the game (10%), the user receives 60% of the donated amount.\n\nUpon joining, the \"Offline Donations\" UI will appear with their username pre-filled. Simply click the gift button to open their stand and purchase a gamepass to donate.",
+        "description": "This will launch \"PLS DONATE\" where you can give an offline donation.\n\nDue to fees from Roblox (30%%) and the game (10%%), the user receives 60%% of the donated amount.\n\nUpon joining, the \"Offline Donations\" UI will appear with their username pre-filled. Simply click the gift button to open their stand and purchase a gamepass to donate.",
         "joinButton": "Join Pls Donate",
         "goBackButton": "Go Back"
     },
@@ -114,13 +118,17 @@
         "private": "Private",
         "openInRolimons": "Open in Rolimon's",
         "thisUser": "this user",
-        "rolimonsRedirect": "You are about to be redirected to {{username}}'s profile on Rolimon's, an external website for trading and item values.<br><br>Do you want to continue?",
+        "rolimonsRedirect": "You are about to be redirected to %s's profile on Rolimon's, an external website for trading and item values.<br><br>Do you want to continue?",
         "continueToRolimons": "Continue to Rolimon's",
         "user": "User",
         "loadingItems": "Loading more items...",
         "noItemsMatch": "No items match your search.",
+<<<<<<< HEAD
         "collectiblesTitle": "{{displayName}}'s Collectibles ({{totalRapString}} RAP)",
         "collectiblesTitleValue": "{{displayName}}'s Collectibles ({{totalRapString}} Value)",
+=======
+        "collectiblesTitle": "%s's Collectibles (%s RAP)",
+>>>>>>> 467cd40 (locale: use printf-style formatting)
         "inventoryPrivateOrNoLimiteds": "This user's inventory is private or has no limiteds.",
         "searchByName": "Search by item name"
     },
@@ -131,13 +139,13 @@
         "cancelling": "Cancelling...",
         "activating": "Activating",
         "inactivating": "Inactivating",
-        "progressText": "{{actionText}} server {{current}} of {{total}}...",
+        "progressText": "%s server %d of %d...",
         "unknownApiError": "An unknown API error occurred.",
-        "processCancelled": "Process Cancelled. <span class=\"success-text\">{{count}} server(s) processed.</span>",
-        "completed": "Completed: <span class=\"success-text\">{{successCount}} succeeded</span>, <span class=\"error-text\">{{errorCount}} failed</span>.",
+        "processCancelled": "Process Cancelled. <span class=\"success-text\">%d server(s) processed.</span>",
+        "completed": "Completed: <span class=\"success-text\">%d succeeded</span>, <span class=\"error-text\">%d failed</span>.",
         "processingComplete": "Processing Complete",
         "confirmationTitle": "Confirm Action",
-        "confirmationMessage": "You are about to set {{count}} private server(s) as {{action}}.",
+        "confirmationMessage": "You are about to set %d private server(s) as %s.",
         "confirmationJoinable": "This will make the private server joinable.",
         "confirmationUnjoinable": "This will make the private server unjoinable.",
         "confirmationReversible": "You can always change this back later.",
@@ -148,7 +156,7 @@
         "bulkActivate": "Bulk Activate",
         "setInactive": "Set Inactive",
         "setActive": "Set Active",
-        "noServersFound": "No {{status}} private servers found.",
+        "noServersFound": "No %s private servers found.",
         "byCreator": "By "
     },
     "firstAccount": {
@@ -156,7 +164,7 @@
         "yes": "Yes",
         "no": "No",
         "tooltip": "This shows if Roblox thinks your account is your first account. <br>This info comes directly from Roblox but may not be accurate.",
-        "createdDate": "First account created: {{date}}"
+        "createdDate": "First account created: %s"
     },
     "legacyThemeSwitcher": {
         "label": "Theme",
@@ -170,7 +178,7 @@
     "pendingRobux": {
         "tooltip": "This is an estimate of how many Robux from your pending balance will become available tomorrow, based on your transaction data. The actual amount may vary. And this may be inaccurate.",
         "loading": "Loading...",
-        "error": "Error: {{message}}",
+        "error": "Error: %s",
         "insufficientData": "Insufficient data",
         "insufficientDataTooltip": "Not enough transaction history to make an accurate estimate. Please wait for more transactions to complete.",
         "label": "Unpending Robux tomorrow"
@@ -226,7 +234,7 @@
         "pack": "Pack",
         "stipend": "Stipend",
         "errorUserId": "Could not retrieve user ID.",
-        "errorRetries": "Failed after multiple retries. Last error: {{error}}"
+        "errorRetries": "Failed after multiple retries. Last error: %s"
     },
     "totalSpentGames": {
         "label": "Total Spent",
@@ -299,7 +307,7 @@
         },
         "search": {
             "minLength": "Please enter at least 2 characters to search.",
-            "noResults": "No settings found for \"{{query}}\"."
+            "noResults": "No settings found for \"%s\"."
         }
     },
     "qolToggles": {
@@ -328,7 +336,7 @@
     },
     "quickSearch": {
         "aborted": "Aborted",
-        "apiRequestFailed": "API request failed with status {{status}}",
+        "apiRequestFailed": "API request failed with status %s",
         "friendSearchError": "RoValra: Friend Search Error",
         "userSearchError": "RoValra: User Search Error",
         "gameSearchError": "RoValra: Game Search Error",
@@ -349,7 +357,7 @@
     "regionPlayButton": {
         "ariaLabel": "Select or Join Preferred Server Region",
         "tooltip": "Join Preferred Region",
-        "tooltipWithRegion": "Join Preferred Region<br><b>{{regionName}}</b>",
+        "tooltipWithRegion": "Join Preferred Region<br><b>%s</b>",
         "tooltipBestRegion": "Join Preferred Region<br><b>Best Region (Auto)</b>"
     },
     "quickPlay": {
@@ -394,7 +402,7 @@
         "noSubplaces": "No subplaces found.",
         "failedToLoad": "Failed to load subplaces.",
         "banner": {
-            "title": "You are currently viewing a subplace of [{{rootPlaceName}}]({{rootPlaceUrl}}).",
+            "title": "You are currently viewing a subplace of [%s](%s).",
             "descriptionDefault": "Some experiences may disable joining subplaces.",
             "descriptionRestricted": "This subplace cannot be joined due to join restrictions.",
             "descriptionJoinable": "This subplace can be joined.",
@@ -417,7 +425,7 @@
         "allServersInactive": "All servers in this region went inactive",
         "loadErrorApi": "Failed to load servers from RoValra API.",
         "join": "Join",
-        "peopleMax": "{{playing}} of {{maxPlayers}} people max",
+        "peopleMax": "%s of %s people max",
         "playerCountUnknownTooltip": "Player count is unknown, this is a Roblox limitation. The thumbnails are not representative of the people in game.",
         "playerCountUnknownLabel": "Player count unknown"
     },
@@ -426,7 +434,7 @@
         "refresh": "Refresh",
         "noneFound": "No Recent Servers Found.",
         "noActiveFound": "No active recent servers found.",
-        "lastJoined": "Last Joined: {{time}}",
+        "lastJoined": "Last Joined: %s",
         "meAlt": "Me",
         "secondsAgo": "{{count}}s ago",
         "minutesAgo": "{{count}}m ago",
@@ -448,32 +456,32 @@
     },
     "botDetector": {
         "tooltip": "Bots are accounts running automated scripts to farm items. A single user can sometimes run 50+ bots. Keep in mind that this is not a fault of the game developers. This information can be inaccurate if an experience is mainly played by new Roblox accounts.",
-        "lotsOfBots": "<span style=\"color: var(--rovalra-main-text-color)\">{{gameName}}</span> has a lot of bots",
-        "someBots": "<span style=\"color: var(--rovalra-main-text-color)\">{{gameName}}</span> has some bots but mostly real players",
+        "lotsOfBots": "<span style=\"color: var(--rovalra-main-text-color)\">%s</span> has a lot of bots",
+        "someBots": "<span style=\"color: var(--rovalra-main-text-color)\">%s</span> has some bots but mostly real players",
         "thisGame": "This game"
     },
     "antiBots": {
-        "reviewMembers": "Review {{count}} selected members:",
+        "reviewMembers": "Review %d selected members:",
         "botWarning": "<strong>Warning:</strong> Ensure these are bots before taking action.",
         "banMembers": "Ban Members",
         "kickMembers": "Kick Members",
         "cancel": "Cancel",
-        "actionRequired": "Action Required ({{count}})",
+        "actionRequired": "Action Required (%d)",
         "noPermission": "You do not have permission to ban or kick members.",
-        "confirmBan": "You are about to <strong>ban {{count}} member(s)</strong>. They will be permanently blocked.",
-        "confirmKick": "You are about to <strong>kick {{count}} member(s)</strong>. They can rejoin anytime.",
+        "confirmBan": "You are about to <strong>ban %d member(s)</strong>. They will be permanently blocked.",
+        "confirmKick": "You are about to <strong>kick %d member(s)</strong>. They can rejoin anytime.",
         "banReminder": "<br><br><div class=\"rovalra-ban-warning\" style=\"margin-top:0;\"><strong>Reminder:</strong> Verify bot scores before banning.</div>",
-        "yesAction": "Yes, {{action}}",
+        "yesAction": "Yes, %d",
         "confirmAction": "Confirm Action",
-        "processing": "Processing {{current}} of {{total}}: {{displayName}}... ETA: {{time}}s",
-        "rateLimited": "Rate limited. Retrying in {{delay}}s...",
-        "apiError": "API Error {{status}}",
+        "processing": "Processing %d of %d: %s... ETA: %ds",
+        "rateLimited": "Rate limited. Retrying in %ds...",
+        "apiError": "API Error %s",
         "unknownError": "Unknown Error",
-        "processComplete": "{{successCount}} of {{totalMembers}} members were successfully {{actionType}}ed.",
-        "processFailed": "{{failedCount}} failed.",
+        "processComplete": "%d of %d members were successfully %sed.",
+        "processFailed": "%d failed.",
         "close": "Close",
-        "score": "Score: {{score}}/100",
-        "actionCount": "Action ({{count}})",
+        "score": "Score: %d/100",
+        "actionCount": "Action (%d)",
         "unselectAll": "Unselect All",
         "selectAll": "Select All",
         "antiBots": "Anti Bots",
@@ -481,12 +489,12 @@
         "quickAction": "Quick Action",
         "members": "Members",
         "loadingMembers": "Loading Members...",
-        "selectMembersForAction": "Select Members for Action ({{count}} Loaded)",
+        "selectMembersForAction": "Select Members for Action (%d Loaded)",
         "noMembersFound": "No members found.",
         "initializingScan": "Initializing Scan...",
-        "scanStatus": "Scanned: {{loaded}} ({{percent}}%) | Analyzed: {{processed}}",
+        "scanStatus": "Scanned: {%d (%d%%) | Analyzed: %d",
         "finalizingAnalysis": "Finalizing analysis...",
-        "botsFound": "{{count}} Likely Bots Found",
+        "botsFound": "%d Likely Bots Found",
         "noBotsFound": "No Likely Bots Found",
         "noBotsDetected": "No bots detected.",
         "errorRetry": "Error - Retry",
@@ -495,7 +503,7 @@
         "scoreImpact": "This will select approximately <span id=\"rovalra-score-ban-count\">0</span> members.",
         "confirm": "Confirm",
         "banKickByScore": "Ban/Kick by Score",
-        "confirmCount": "Confirm ({{count}})"
+        "confirmCount": "Confirm (%d)"
     },
     "revertLogo": {
         "haveFun": "Have Fun!",
@@ -534,7 +542,7 @@
     },
     "priceFloor": {
         "label": "Price Floor:",
-        "status": "This item is {{status}} the price floor{{difference}}.",
+        "status": "This item is %s the price floor %s.",
         "statusTypes": {
             "above": "above",
             "below": "below",
@@ -546,7 +554,7 @@
     "parentItem": {
         "multipleBundles": "This item is part of multiple bundles",
         "multipleBundlesDescription": "This item is likely used as a template and is included in multiple bundles.",
-        "partOfBundle": "This item is part of the [{{bundleName}}]({{bundleUrl}}) bundle",
+        "partOfBundle": "This item is part of the [%s](%s) bundle",
         "viewingFromBundle": "You are currently viewing an item from a bundle."
     },
     "rovalraBadges": {

--- a/public/Assets/locales/en.json
+++ b/public/Assets/locales/en.json
@@ -492,7 +492,7 @@
         "selectMembersForAction": "Select Members for Action (%d Loaded)",
         "noMembersFound": "No members found.",
         "initializingScan": "Initializing Scan...",
-        "scanStatus": "Scanned: {%d (%d%%) | Analyzed: %d",
+        "scanStatus": "Scanned: %d (%d%%) | Analyzed: %d",
         "finalizingAnalysis": "Finalizing analysis...",
         "botsFound": "%d Likely Bots Found",
         "noBotsFound": "No Likely Bots Found",

--- a/public/Assets/locales/en.json
+++ b/public/Assets/locales/en.json
@@ -56,11 +56,7 @@
         "loading": "Loading..."
     },
     "hiddenGroupGames": {
-<<<<<<< HEAD
         "overlayTitle": "Hidden Group Experiences ({{count}} Total)",
-=======
-        "overlayTitle": "Hidden Group Experiences (%d Total)",
->>>>>>> 467cd40 (locale: use printf-style formatting)
         "noHiddenGames": "This group has no hidden experiences.",
         "buttonText": "Hidden Experiences",
         "labels": {
@@ -91,7 +87,7 @@
         "errorLoadingItems": "Could not load items.",
         "buttonText": "Show Outfits",
         "overlayTitle": "User Outfits",
-        "overlayTitleUser": "%s's Outfits",
+        "overlayTitleUser": "{{displayName}}'s Outfits",
         "noOutfits": "This user has no outfits.",
         "inventoryPrivate": "User's inventory is private.",
         "errorNoUserId": "Could not determine the User ID from the page.",
@@ -100,7 +96,7 @@
     "donationLink": {
         "donate": "Donate",
         "overlayTitle": "Pls Donate",
-        "description": "This will launch \"PLS DONATE\" where you can give an offline donation.\n\nDue to fees from Roblox (30%%) and the game (10%%), the user receives 60%% of the donated amount.\n\nUpon joining, the \"Offline Donations\" UI will appear with their username pre-filled. Simply click the gift button to open their stand and purchase a gamepass to donate.",
+        "description": "This will launch \"PLS DONATE\" where you can give an offline donation.\n\nDue to fees from Roblox (30%) and the game (10%), the user receives 60% of the donated amount.\n\nUpon joining, the \"Offline Donations\" UI will appear with their username pre-filled. Simply click the gift button to open their stand and purchase a gamepass to donate.",
         "joinButton": "Join Pls Donate",
         "goBackButton": "Go Back"
     },
@@ -118,17 +114,13 @@
         "private": "Private",
         "openInRolimons": "Open in Rolimon's",
         "thisUser": "this user",
-        "rolimonsRedirect": "You are about to be redirected to %s's profile on Rolimon's, an external website for trading and item values.<br><br>Do you want to continue?",
+        "rolimonsRedirect": "You are about to be redirected to {{username}}'s profile on Rolimon's, an external website for trading and item values.<br><br>Do you want to continue?",
         "continueToRolimons": "Continue to Rolimon's",
         "user": "User",
         "loadingItems": "Loading more items...",
         "noItemsMatch": "No items match your search.",
-<<<<<<< HEAD
         "collectiblesTitle": "{{displayName}}'s Collectibles ({{totalRapString}} RAP)",
         "collectiblesTitleValue": "{{displayName}}'s Collectibles ({{totalRapString}} Value)",
-=======
-        "collectiblesTitle": "%s's Collectibles (%s RAP)",
->>>>>>> 467cd40 (locale: use printf-style formatting)
         "inventoryPrivateOrNoLimiteds": "This user's inventory is private or has no limiteds.",
         "searchByName": "Search by item name"
     },
@@ -139,13 +131,13 @@
         "cancelling": "Cancelling...",
         "activating": "Activating",
         "inactivating": "Inactivating",
-        "progressText": "%s server %d of %d...",
+        "progressText": "{{actionText}} server {{current}} of {{total}}...",
         "unknownApiError": "An unknown API error occurred.",
-        "processCancelled": "Process Cancelled. <span class=\"success-text\">%d server(s) processed.</span>",
-        "completed": "Completed: <span class=\"success-text\">%d succeeded</span>, <span class=\"error-text\">%d failed</span>.",
+        "processCancelled": "Process Cancelled. <span class=\"success-text\">{{count}} server(s) processed.</span>",
+        "completed": "Completed: <span class=\"success-text\">{{successCount}} succeeded</span>, <span class=\"error-text\">{{errorCount}} failed</span>.",
         "processingComplete": "Processing Complete",
         "confirmationTitle": "Confirm Action",
-        "confirmationMessage": "You are about to set %d private server(s) as %s.",
+        "confirmationMessage": "You are about to set {{count}} private server(s) as {{action}}.",
         "confirmationJoinable": "This will make the private server joinable.",
         "confirmationUnjoinable": "This will make the private server unjoinable.",
         "confirmationReversible": "You can always change this back later.",
@@ -156,7 +148,7 @@
         "bulkActivate": "Bulk Activate",
         "setInactive": "Set Inactive",
         "setActive": "Set Active",
-        "noServersFound": "No %s private servers found.",
+        "noServersFound": "No {{status}} private servers found.",
         "byCreator": "By "
     },
     "firstAccount": {
@@ -164,7 +156,7 @@
         "yes": "Yes",
         "no": "No",
         "tooltip": "This shows if Roblox thinks your account is your first account. <br>This info comes directly from Roblox but may not be accurate.",
-        "createdDate": "First account created: %s"
+        "createdDate": "First account created: {{date}}"
     },
     "legacyThemeSwitcher": {
         "label": "Theme",
@@ -178,7 +170,7 @@
     "pendingRobux": {
         "tooltip": "This is an estimate of how many Robux from your pending balance will become available tomorrow, based on your transaction data. The actual amount may vary. And this may be inaccurate.",
         "loading": "Loading...",
-        "error": "Error: %s",
+        "error": "Error: {{message}}",
         "insufficientData": "Insufficient data",
         "insufficientDataTooltip": "Not enough transaction history to make an accurate estimate. Please wait for more transactions to complete.",
         "label": "Unpending Robux tomorrow"
@@ -234,7 +226,7 @@
         "pack": "Pack",
         "stipend": "Stipend",
         "errorUserId": "Could not retrieve user ID.",
-        "errorRetries": "Failed after multiple retries. Last error: %s"
+        "errorRetries": "Failed after multiple retries. Last error: {{error}}"
     },
     "totalSpentGames": {
         "label": "Total Spent",
@@ -307,7 +299,7 @@
         },
         "search": {
             "minLength": "Please enter at least 2 characters to search.",
-            "noResults": "No settings found for \"%s\"."
+            "noResults": "No settings found for \"{{query}}\"."
         }
     },
     "qolToggles": {
@@ -336,7 +328,7 @@
     },
     "quickSearch": {
         "aborted": "Aborted",
-        "apiRequestFailed": "API request failed with status %s",
+        "apiRequestFailed": "API request failed with status {{status}}",
         "friendSearchError": "RoValra: Friend Search Error",
         "userSearchError": "RoValra: User Search Error",
         "gameSearchError": "RoValra: Game Search Error",
@@ -357,7 +349,7 @@
     "regionPlayButton": {
         "ariaLabel": "Select or Join Preferred Server Region",
         "tooltip": "Join Preferred Region",
-        "tooltipWithRegion": "Join Preferred Region<br><b>%s</b>",
+        "tooltipWithRegion": "Join Preferred Region<br><b>{{regionName}}</b>",
         "tooltipBestRegion": "Join Preferred Region<br><b>Best Region (Auto)</b>"
     },
     "quickPlay": {
@@ -402,7 +394,7 @@
         "noSubplaces": "No subplaces found.",
         "failedToLoad": "Failed to load subplaces.",
         "banner": {
-            "title": "You are currently viewing a subplace of [%s](%s).",
+            "title": "You are currently viewing a subplace of [{{rootPlaceName}}]({{rootPlaceUrl}}).",
             "descriptionDefault": "Some experiences may disable joining subplaces.",
             "descriptionRestricted": "This subplace cannot be joined due to join restrictions.",
             "descriptionJoinable": "This subplace can be joined.",
@@ -425,7 +417,7 @@
         "allServersInactive": "All servers in this region went inactive",
         "loadErrorApi": "Failed to load servers from RoValra API.",
         "join": "Join",
-        "peopleMax": "%s of %s people max",
+        "peopleMax": "{{playing}} of {{maxPlayers}} people max",
         "playerCountUnknownTooltip": "Player count is unknown, this is a Roblox limitation. The thumbnails are not representative of the people in game.",
         "playerCountUnknownLabel": "Player count unknown"
     },
@@ -434,7 +426,7 @@
         "refresh": "Refresh",
         "noneFound": "No Recent Servers Found.",
         "noActiveFound": "No active recent servers found.",
-        "lastJoined": "Last Joined: %s",
+        "lastJoined": "Last Joined: {{time}}",
         "meAlt": "Me",
         "secondsAgo": "{{count}}s ago",
         "minutesAgo": "{{count}}m ago",
@@ -456,32 +448,32 @@
     },
     "botDetector": {
         "tooltip": "Bots are accounts running automated scripts to farm items. A single user can sometimes run 50+ bots. Keep in mind that this is not a fault of the game developers. This information can be inaccurate if an experience is mainly played by new Roblox accounts.",
-        "lotsOfBots": "<span style=\"color: var(--rovalra-main-text-color)\">%s</span> has a lot of bots",
-        "someBots": "<span style=\"color: var(--rovalra-main-text-color)\">%s</span> has some bots but mostly real players",
+        "lotsOfBots": "<span style=\"color: var(--rovalra-main-text-color)\">{{gameName}}</span> has a lot of bots",
+        "someBots": "<span style=\"color: var(--rovalra-main-text-color)\">{{gameName}}</span> has some bots but mostly real players",
         "thisGame": "This game"
     },
     "antiBots": {
-        "reviewMembers": "Review %d selected members:",
+        "reviewMembers": "Review {{count}} selected members:",
         "botWarning": "<strong>Warning:</strong> Ensure these are bots before taking action.",
         "banMembers": "Ban Members",
         "kickMembers": "Kick Members",
         "cancel": "Cancel",
-        "actionRequired": "Action Required (%d)",
+        "actionRequired": "Action Required ({{count}})",
         "noPermission": "You do not have permission to ban or kick members.",
-        "confirmBan": "You are about to <strong>ban %d member(s)</strong>. They will be permanently blocked.",
-        "confirmKick": "You are about to <strong>kick %d member(s)</strong>. They can rejoin anytime.",
+        "confirmBan": "You are about to <strong>ban {{count}} member(s)</strong>. They will be permanently blocked.",
+        "confirmKick": "You are about to <strong>kick {{count}} member(s)</strong>. They can rejoin anytime.",
         "banReminder": "<br><br><div class=\"rovalra-ban-warning\" style=\"margin-top:0;\"><strong>Reminder:</strong> Verify bot scores before banning.</div>",
-        "yesAction": "Yes, %d",
+        "yesAction": "Yes, {{action}}",
         "confirmAction": "Confirm Action",
-        "processing": "Processing %d of %d: %s... ETA: %ds",
-        "rateLimited": "Rate limited. Retrying in %ds...",
-        "apiError": "API Error %s",
+        "processing": "Processing {{current}} of {{total}}: {{displayName}}... ETA: {{time}}s",
+        "rateLimited": "Rate limited. Retrying in {{delay}}s...",
+        "apiError": "API Error {{status}}",
         "unknownError": "Unknown Error",
-        "processComplete": "%d of %d members were successfully %sed.",
-        "processFailed": "%d failed.",
+        "processComplete": "{{successCount}} of {{totalMembers}} members were successfully {{actionType}}ed.",
+        "processFailed": "{{failedCount}} failed.",
         "close": "Close",
-        "score": "Score: %d/100",
-        "actionCount": "Action (%d)",
+        "score": "Score: {{score}}/100",
+        "actionCount": "Action ({{count}})",
         "unselectAll": "Unselect All",
         "selectAll": "Select All",
         "antiBots": "Anti Bots",
@@ -489,12 +481,12 @@
         "quickAction": "Quick Action",
         "members": "Members",
         "loadingMembers": "Loading Members...",
-        "selectMembersForAction": "Select Members for Action (%d Loaded)",
+        "selectMembersForAction": "Select Members for Action ({{count}} Loaded)",
         "noMembersFound": "No members found.",
         "initializingScan": "Initializing Scan...",
-        "scanStatus": "Scanned: %d (%d%%) | Analyzed: %d",
+        "scanStatus": "Scanned: {{loaded}} ({{percent}}%) | Analyzed: {{processed}}",
         "finalizingAnalysis": "Finalizing analysis...",
-        "botsFound": "%d Likely Bots Found",
+        "botsFound": "{{count}} Likely Bots Found",
         "noBotsFound": "No Likely Bots Found",
         "noBotsDetected": "No bots detected.",
         "errorRetry": "Error - Retry",
@@ -503,7 +495,7 @@
         "scoreImpact": "This will select approximately <span id=\"rovalra-score-ban-count\">0</span> members.",
         "confirm": "Confirm",
         "banKickByScore": "Ban/Kick by Score",
-        "confirmCount": "Confirm (%d)"
+        "confirmCount": "Confirm ({{count}})"
     },
     "revertLogo": {
         "haveFun": "Have Fun!",
@@ -542,7 +534,7 @@
     },
     "priceFloor": {
         "label": "Price Floor:",
-        "status": "This item is %s the price floor %s.",
+        "status": "This item is {{status}} the price floor{{difference}}.",
         "statusTypes": {
             "above": "above",
             "below": "below",
@@ -554,7 +546,7 @@
     "parentItem": {
         "multipleBundles": "This item is part of multiple bundles",
         "multipleBundlesDescription": "This item is likely used as a template and is included in multiple bundles.",
-        "partOfBundle": "This item is part of the [%s](%s) bundle",
+        "partOfBundle": "This item is part of the [{{bundleName}}]({{bundleUrl}}) bundle",
         "viewingFromBundle": "You are currently viewing an item from a bundle."
     },
     "rovalraBadges": {
@@ -763,7 +755,9 @@
         "tooltip": "Total Community Place Visits"
     },
     "groups": {
-        "createdLabel": "Created"
+        "createdLabel": "Created",
+        "joinedLabel": "Joined",
+        "unknown": "Unknown"
     },
     "profile": {
         "currencyTransfer": "Send Robux",

--- a/src/content/core/locale/i18n.js
+++ b/src/content/core/locale/i18n.js
@@ -4,6 +4,7 @@ let initialized = false;
 
 const localePromise = (async () => {
     if (initialized) return;
+    initialized = true;
 
     try {
         const settings = await new Promise(
@@ -22,18 +23,16 @@ const localePromise = (async () => {
         const translations_EN = await response_EN.json();
 
         await ezlocale.init();
-        await ezlocale.add_locale(language, translations);
+        if (language != 'en')  await ezlocale.add_locale(language, translations);  // avoid readding the `en` locale
         await ezlocale.add_locale('en', translations_EN);
         await ezlocale.config({
             'lang.current': language,
             'lang.fallback': 'en'
         });
 
-        initialized = true;
     } catch (error) {
         console.error('RoValra: Failed to initialize i18n', error);
 
-        initialized = true;
         throw error;
     }
 })();
@@ -45,7 +44,7 @@ const localePromise = (async () => {
  * @param {object} [options] i18next options.
  * @returns {Promise<string>} The translated string.
  */
-export async function t(key, options) {
+export async function t(key, options = []) {
     await localePromise;
     return ezlocale.fmt_locale(key, ...options);
 }
@@ -57,6 +56,6 @@ export async function t(key, options) {
  * @param {object} [options] i18next options.
  * @returns {string} The translated string or the key if not available.
  */
-export function ts(key, options) {
+export function ts(key, options = []) {
     return ezlocale.fmt_locale(key, ...options);
 }

--- a/src/content/core/locale/i18n.js
+++ b/src/content/core/locale/i18n.js
@@ -1,8 +1,9 @@
-import i18next from 'i18next';
+import * as ezlocale from 'ezlocale';
 
-let i18nInitialized = false;
-const i18nPromise = (async () => {
-    if (i18nInitialized) return;
+let initialized = false;
+
+const localePromise = (async () => {
+    if (initialized) return;
 
     try {
         const settings = await new Promise(
@@ -15,20 +16,24 @@ const i18nPromise = (async () => {
         ); // Verified
         const translations = await response.json();
 
-        await i18next.init({
-            lng: language,
-            debug: false,
-            resources: {
-                [language]: {
-                    translation: translations,
-                },
-            },
+        const response_EN = await fetch(
+            chrome.runtime.getURL(`public/Assets/locales/en.json`),
+        ); // Verified
+        const translations_EN = await response_EN.json();
+
+        await ezlocale.init();
+        await ezlocale.add_locale(language, translations);
+        await ezlocale.add_locale('en', translations_EN);
+        await ezlocale.config({
+            'lang.current': language,
+            'lang.fallback': 'en'
         });
-        i18nInitialized = true;
+
+        initialized = true;
     } catch (error) {
         console.error('RoValra: Failed to initialize i18n', error);
 
-        i18nInitialized = true;
+        initialized = true;
         throw error;
     }
 })();
@@ -41,8 +46,8 @@ const i18nPromise = (async () => {
  * @returns {Promise<string>} The translated string.
  */
 export async function t(key, options) {
-    await i18nPromise;
-    return i18next.t(key, options);
+    await localePromise;
+    return ezlocale.fmt_locale(key, ...options);
 }
 
 /**
@@ -53,5 +58,5 @@ export async function t(key, options) {
  * @returns {string} The translated string or the key if not available.
  */
 export function ts(key, options) {
-    return i18next.t(key, options);
+    return ezlocale.fmt_locale(key, ...options);
 }

--- a/src/content/core/locale/i18n.js
+++ b/src/content/core/locale/i18n.js
@@ -27,7 +27,9 @@ const localePromise = (async () => {
         await ezlocale.add_locale('en', translations_EN);
         await ezlocale.config({
             'lang.current': language,
-            'lang.fallback': 'en'
+            'lang.fallback': 'en',
+            'format.printf': false,
+            'format.named': true
         });
 
     } catch (error) {

--- a/src/content/core/locale/i18n.js
+++ b/src/content/core/locale/i18n.js
@@ -45,8 +45,14 @@ const localePromise = (async () => {
  * @returns {Promise<string>} The translated string.
  */
 export async function t(key, options = []) {
-    await localePromise;
-    return ezlocale.fmt_locale(key, ...options);
+    try {
+        await localePromise;
+        return ezlocale.fmt_locale(key, options);
+    }
+    catch (err) {
+        console.error(`RoValra: An unexpected error occured in t(): ${String(err)}`);
+        return key;
+    }
 }
 
 /**
@@ -57,5 +63,11 @@ export async function t(key, options = []) {
  * @returns {string} The translated string or the key if not available.
  */
 export function ts(key, options = []) {
-    return ezlocale.fmt_locale(key, ...options);
+    try {
+        return ezlocale.fmt_locale(key, options) || key;
+    }
+    catch (err) {
+        console.error(`RoValra: An unexpected error occured in ts(): ${String(err)}`);
+        return key;
+    }
 }

--- a/src/content/features/profile/hiddengames.js
+++ b/src/content/features/profile/hiddengames.js
@@ -8,6 +8,7 @@ import { callRobloxApi } from '../../core/api.js';
 import { safeHtml } from '../../core/packages/dompurify';
 import { createGameCard } from '../../core/ui/games/gameCard.js';
 import { t } from '../../core/locale/i18n.js';
+
 const CONFIG = {
     PAGE_SIZE: 50,
     ACCESS_FILTER: 2,


### PR DESCRIPTION
Replacing i18next with ezlocale will result in more predictable behaviour in specific circumstances, as well as a smaller extension builds.

## Unpacked size
* i18next unpacked size: 577KB
* ezlocale unpacked size: 6KB

## Dependency Count
* i18next dependency count: 1 (242KB unpacked size)
* ezlocale dependency count: 0 (0KB unpacked size)

## Final sizes
* i18next final size: 577KB + 242KB = 819KB
* ezlocale final size: 6KB + 0KB = 6KB

> [!NOTE]
> Please make sure this works before merging.