### PR TITLE
Add exponential backoff to roblox API retries

### DIFF
--- a/src/content/core/api.js
+++ b/src/content/core/api.js
@@ -555,9 +555,9 @@ export async function callRobloxApi(options) {
                         await new Promise(r => setTimeout(r, 50));  // wait for the flag to become false. the polling interval can be changed as needed
                     }
                     callRobloxApi_retrying = true;
-                    const retryDelay = (attempt ** 1.4 + 1) * 1000;
+                    const retryDelay = (attempt ** 1.3 + 1) * 1000;
                     console.debug(
-                        `RoValra API: Request to ${fullUrl} failed with status ${lastResponse.status}. Retrying in ${retryDelay / 1000} seconds`
+                        `RoValra API: Request to ${fullUrl} failed with status ${String(lastResponse?.status ?? "(undefined.status)")}. Retrying in ${retryDelay / 1000} seconds`
                     );
                     await new Promise((res) => setTimeout(res, retryDelay));  // sub-exponential backoff
                     callRobloxApi_retrying = false;

--- a/src/content/core/api.js
+++ b/src/content/core/api.js
@@ -205,6 +205,8 @@ export function resetGameJoinErrorCount() {
     gameJoinErrorCount = 0;
 }
 
+let callRobloxApi_retrying = false;
+
 export async function callRobloxApi(options) {
     captureApiCall(options);
 
@@ -228,13 +230,6 @@ export async function callRobloxApi(options) {
     if (shouldCache && activeRequests.has(requestKey)) {
         const originalResponse = await activeRequests.get(requestKey);
         const clonedResponse = originalResponse.clone();
-
-        if (
-            options.subdomain === 'games' &&
-            options.endpoint.includes('/servers/') &&
-            !options.isRovalraApi
-        ) {
-        }
 
         return clonedResponse;
     }
@@ -436,7 +431,7 @@ export async function callRobloxApi(options) {
         if (isRovalraApi) {
             let lastResponse;
             let authRetried = false;
-            for (let attempt = 0; attempt < 4; attempt++) {
+            for (let attempt = 0; attempt < 6; attempt++) {
                 try {
                     lastResponse = await fetch(fullUrl, fetchOptions);
                     let newAccessToken = null;
@@ -545,7 +540,7 @@ export async function callRobloxApi(options) {
                     if (endpoint && endpoint.includes('/v1/auth')) break;
                 } catch (error) {
                     if (
-                        attempt === 3 ||
+                        attempt === 5 ||
                         (endpoint && endpoint.includes('/v1/auth'))
                     ) {
                         console.error(
@@ -555,8 +550,17 @@ export async function callRobloxApi(options) {
                         throw error;
                     }
                 }
-                if (attempt < 3) {
-                    await new Promise((res) => setTimeout(res, 1000));
+                if (attempt < 5) {
+                    while (callRobloxApi_retrying === true) {
+                        await new Promise(r => setTimeout(r, 50));  // wait for the flag to become false. the polling interval can be changed as needed
+                    }
+                    callRobloxApi_retrying = true;
+                    const retryDelay = (attempt ** 1.4 + 1) * 1000;
+                    console.debug(
+                        `RoValra API: Request to ${fullUrl} failed with status ${lastResponse.status}. Retrying in ${retryDelay / 1000} seconds`
+                    );
+                    await new Promise((res) => setTimeout(res, retryDelay));  // sub-exponential backoff
+                    callRobloxApi_retrying = false;
                 }
             }
             if (!lastResponse.ok) {


### PR DESCRIPTION
## Overview
Add sub-exponential backoff during ratelimits, to survive possibly lowered ratelimits in the future.

## Changes
* Added sub-exponential backoff on retry in callRobloxApi
* Added a debug statement on-retry
* Increased the retry count to 5
* Removed empty if-statement