### PR TITLE
Add transactions button to Roblox sidebar

### DIFF
--- a/build.js
+++ b/build.js
@@ -80,15 +80,6 @@ function compileScssFile(inputFile, outputFile) {
 esbuild
     .build({
         ...commonConfig,
-        entryPoints: ['src/content/index.js'],
-        outfile: 'dist/content.js',
-        bundle: true,
-    })
-    .catch(() => process.exit(1));
-
-esbuild
-    .build({
-        ...commonConfig,
         entryPoints: ['src/background/background.js'],
         outfile: 'dist/background.js',
         bundle: true,

--- a/public/Assets/locales/en.json
+++ b/public/Assets/locales/en.json
@@ -302,6 +302,9 @@
         "pending": "Pending:",
         "noPermissions": "No Permission"
     },
+    "navigation": {
+        "transactions": "My Transactions"
+    },
     "betaPrograms": {
         "toggleTooltip": "Toggle Beta Programs",
         "noPrograms": "You are not enrolled into any beta programs.",

--- a/src/content/core/configs/userIds.js
+++ b/src/content/core/configs/userIds.js
@@ -11,6 +11,7 @@ export const CONTRIBUTOR_USER_IDS = [
     '126448532', //steinann
     '1564574922', //cornusandu
     '587159802', //zoinbase
+    '193520242', // contributor
 ];
 
 export const TESTER_USER_IDS = [

--- a/src/content/core/settings/settingConfig.js
+++ b/src/content/core/settings/settingConfig.js
@@ -892,6 +892,13 @@ export const SETTINGS_CONFIG = {
                 type: 'checkbox',
                 default: false,
             },
+            transactionsSidebarLinkEnabled: {
+                label: 'My Transactions sidebar link',
+                description:
+                    'Adds a My Transactions link below Communities in the Roblox sidebar.',
+                type: 'checkbox',
+                default: false,
+            },
             quickSearchEnabled: {
                 label: 'Quick Search',
                 description:

--- a/src/content/features/navigation/transactionslink.js
+++ b/src/content/features/navigation/transactionslink.js
@@ -1,0 +1,314 @@
+import { observeElement } from '../../core/observer.js';
+import { ts } from '../../core/locale/i18n.js';
+
+const COMMUNITY_PATH = '/communities';
+const TRANSACTIONS_PATH = '/transactions';
+const ACTIVE_BACKGROUND_COLOR = 'rgba(255, 255, 255, 0.1)';
+const STATE_SYNC_DELAYS = [0, 50, 150, 350, 750, 1200];
+
+let lastObservedPath = window.location.pathname;
+let sidebarLinkEnabled = false;
+
+function normalizePath(href) {
+    if (!href) return '';
+
+    try {
+        return new URL(href, window.location.origin).pathname;
+    } catch {
+        return '';
+    }
+}
+
+function stripLocalePrefix(path) {
+    return path.replace(/^\/[a-z]{2}(?:-[a-z]{2})?(?=\/)/i, '');
+}
+
+function matchesRoute(pathname, route) {
+    const normalizedPath = stripLocalePrefix(pathname);
+    return normalizedPath === route || normalizedPath.startsWith(`${route}/`);
+}
+
+function createTransactionsIcon() {
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('aria-hidden', 'true');
+    svg.setAttribute('viewBox', '0 0 24 24');
+    svg.setAttribute('fill', 'none');
+    svg.setAttribute('stroke', 'currentColor');
+    svg.setAttribute('stroke-width', '1.7');
+    svg.setAttribute('stroke-linecap', 'round');
+    svg.setAttribute('stroke-linejoin', 'round');
+    svg.style.width = '20px';
+    svg.style.height = '20px';
+    svg.style.display = 'block';
+
+    const receipt = document.createElementNS(
+        'http://www.w3.org/2000/svg',
+        'path',
+    );
+    receipt.setAttribute(
+        'd',
+        'M6 3h12v18l-2-1.25L14 21l-2-1.25L10 21l-2-1.25L6 21z',
+    );
+
+    const lineOne = document.createElementNS(
+        'http://www.w3.org/2000/svg',
+        'path',
+    );
+    lineOne.setAttribute('d', 'M9 8h6');
+
+    const lineTwo = document.createElementNS(
+        'http://www.w3.org/2000/svg',
+        'path',
+    );
+    lineTwo.setAttribute('d', 'M9 12h6');
+
+    const lineThree = document.createElementNS(
+        'http://www.w3.org/2000/svg',
+        'path',
+    );
+    lineThree.setAttribute('d', 'M9 16h4');
+
+    svg.append(receipt, lineOne, lineTwo, lineThree);
+    return svg;
+}
+
+function getSidebarContainer(anchor) {
+    return anchor.closest('ul, ol, nav, [role="navigation"]');
+}
+
+function getSidebarItem(sidebar, link) {
+    let current = link;
+
+    while (current?.parentElement && current.parentElement !== sidebar) {
+        current = current.parentElement;
+    }
+
+    return current?.parentElement === sidebar ? current : link.parentElement;
+}
+
+function stripClonedState(item) {
+    [item, ...item.querySelectorAll('*')].forEach((element) => {
+        element.removeAttribute('id');
+        element.removeAttribute('aria-current');
+        element.removeAttribute('aria-selected');
+
+        [...element.attributes].forEach((attribute) => {
+            if (attribute.name.startsWith('data-')) {
+                element.removeAttribute(attribute.name);
+            }
+        });
+
+        element.classList.remove(
+            'active',
+            'selected',
+            'active-menu-item',
+            'selected-menu-item',
+            'router-link-active',
+            'router-link-exact-active',
+        );
+    });
+}
+
+function findIconHost(link) {
+    const directChildren = [...link.children];
+    return (
+        directChildren.find((child) =>
+            child.querySelector('svg, [class*="icon"], [class*="Icon"]'),
+        ) ||
+        directChildren.find((child) =>
+            child.className?.toString().toLowerCase().includes('icon'),
+        ) ||
+        directChildren.find((child) => !child.textContent.trim())
+    );
+}
+
+function setLinkLabel(link, label) {
+    const labelTarget = [...link.querySelectorAll('*')]
+        .filter(
+            (element) =>
+                element.children.length === 0 && element.textContent.trim(),
+        )
+        .at(-1);
+
+    if (labelTarget) {
+        labelTarget.textContent = label;
+        return;
+    }
+
+    const span = document.createElement('span');
+    span.textContent = label;
+    link.appendChild(span);
+}
+
+function createTransactionsItem(sidebar, communityLink, label) {
+    const templateItem = getSidebarItem(sidebar, communityLink);
+    if (!templateItem) return null;
+
+    const item = templateItem.cloneNode(true);
+    const link = item.querySelector('a[href]');
+    if (!link) return null;
+
+    stripClonedState(item);
+
+    const iconHost = findIconHost(link);
+    if (iconHost) {
+        iconHost.replaceChildren(createTransactionsIcon());
+    } else {
+        link.prepend(createTransactionsIcon());
+    }
+
+    setLinkLabel(link, label);
+    link.setAttribute('href', TRANSACTIONS_PATH);
+    link.dataset.rovalraTransactionsLink = 'true';
+    item.dataset.rovalraTransactionsItem = 'true';
+
+    return item;
+}
+
+function clearInlineActiveStyles(item) {
+    [item, ...item.querySelectorAll('*')].forEach((element) => {
+        element.style.removeProperty('background');
+        element.style.removeProperty('background-color');
+        element.style.removeProperty('border-radius');
+        element.style.removeProperty('color');
+    });
+}
+
+function updateTransactionsActiveState(sidebar) {
+    const item = sidebar.querySelector('[data-rovalra-transactions-item="true"]');
+    const link = sidebar.querySelector(
+        'a[data-rovalra-transactions-link="true"]',
+    );
+    if (!item || !link) return;
+
+    stripClonedState(item);
+    item.dataset.rovalraTransactionsItem = 'true';
+    link.dataset.rovalraTransactionsLink = 'true';
+
+    if (matchesRoute(window.location.pathname, TRANSACTIONS_PATH)) {
+        link.setAttribute('aria-current', 'page');
+        link.style.backgroundColor = ACTIVE_BACKGROUND_COLOR;
+        link.style.borderRadius = '8px';
+        link.style.color = 'inherit';
+    } else {
+        clearInlineActiveStyles(item);
+    }
+}
+
+function attachSidebarStateSync(sidebar) {
+    if (sidebar.dataset.rovalraTransactionsStateSync === 'true') return;
+    sidebar.dataset.rovalraTransactionsStateSync = 'true';
+
+    const syncSoon = () => {
+        STATE_SYNC_DELAYS.forEach((delay) => {
+            if (delay === 0) {
+                requestAnimationFrame(() =>
+                    updateTransactionsActiveState(sidebar),
+                );
+                return;
+            }
+
+            setTimeout(() => updateTransactionsActiveState(sidebar), delay);
+        });
+    };
+
+    sidebar.addEventListener('click', syncSoon, true);
+    window.addEventListener('popstate', syncSoon);
+    window.addEventListener('rovalra:locationchange', syncSoon);
+}
+
+function initLocationChangeWatcher() {
+    if (initLocationChangeWatcher._run) return;
+    initLocationChangeWatcher._run = true;
+
+    setInterval(() => {
+        if (window.location.pathname === lastObservedPath) return;
+
+        lastObservedPath = window.location.pathname;
+        window.dispatchEvent(new Event('rovalra:locationchange'));
+    }, 1000);
+}
+
+function insertTransactionsLink(communityLink, label) {
+    if (!sidebarLinkEnabled) return;
+
+    if (!matchesRoute(normalizePath(communityLink.href), COMMUNITY_PATH)) {
+        return;
+    }
+
+    const sidebar = getSidebarContainer(communityLink);
+    if (!sidebar) return;
+
+    const existing = sidebar.querySelector(
+        'a[data-rovalra-transactions-link="true"], a[href="/transactions"]',
+    );
+    if (existing) {
+        updateTransactionsActiveState(sidebar);
+        attachSidebarStateSync(sidebar);
+        return;
+    }
+
+    const communityItem = getSidebarItem(sidebar, communityLink);
+    const transactionsItem = createTransactionsItem(
+        sidebar,
+        communityLink,
+        label,
+    );
+    if (!communityItem || !transactionsItem) return;
+
+    communityItem.insertAdjacentElement('afterend', transactionsItem);
+    updateTransactionsActiveState(sidebar);
+    attachSidebarStateSync(sidebar);
+}
+
+function removeTransactionsLinks() {
+    document
+        .querySelectorAll('[data-rovalra-transactions-item="true"]')
+        .forEach((item) => item.remove());
+}
+
+function addTransactionsLinks(label) {
+    document
+        .querySelectorAll('a[href*="/communities"]')
+        .forEach((communityLink) => insertTransactionsLink(communityLink, label));
+}
+
+export function init() {
+    if (init._run) return;
+    init._run = true;
+
+    chrome.storage.local.get(
+        { transactionsSidebarLinkEnabled: false },
+        (settings) => {
+            const label = ts('navigation.transactions');
+            initLocationChangeWatcher();
+            sidebarLinkEnabled = settings.transactionsSidebarLinkEnabled;
+
+            observeElement(
+                'a[href*="/communities"]',
+                (communityLink) => {
+                    insertTransactionsLink(communityLink, label);
+                },
+                { multiple: true },
+            );
+
+            chrome.storage.onChanged.addListener((changes, areaName) => {
+                if (
+                    areaName !== 'local' ||
+                    !changes.transactionsSidebarLinkEnabled
+                ) {
+                    return;
+                }
+
+                sidebarLinkEnabled =
+                    changes.transactionsSidebarLinkEnabled.newValue;
+
+                if (sidebarLinkEnabled) {
+                    addTransactionsLinks(label);
+                } else {
+                    removeTransactionsLinks();
+                }
+            });
+        },
+    );
+}

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -23,6 +23,7 @@ import { init as initQuickSearch } from './features/navigation/search/quicksearc
 import { init as initRenderTest } from './features/developer/rendertest.js';
 import { init as initGroupFunds } from './features/navigation/groupfunds.js';
 import { init as initCustomFont } from './features/sitewide/customFont.js';
+import { init as initTransactionsLink } from './features/navigation/transactionslink.js';
 
 // Avatar
 import { init as initAvatarFilters } from './features/avatar/filters.js';
@@ -127,6 +128,7 @@ const featureRoutes = [
             initPrivateGames,
             initBannedUsers,
             initGroupFunds,
+            initTransactionsLink,
             initStatus,
             initCustomFont,
             initRobuxIcons,


### PR DESCRIPTION
## Summary
- Adds a new optional `My Transactions` link to the Roblox left sidebar.
- Places the link directly below `Communities`.
- Routes the link to `/transactions`.
- Adds a `My Transactions sidebar link` toggle under the `Navigation` settings category.
- Keeps the feature disabled by default.
- Makes the sidebar link appear/disappear immediately when the setting is toggled, without needing a page refresh.
- Anchors the sidebar insertion from the existing `Communities` link only, instead of scanning multiple navigation links.
- Adds the `My Transactions` label to the locale file.
- Adds my Roblox user ID to the contributor badge list.
- Fixes a build race where `dist/content.js` could be generated without the Draco decoder, causing `DracoDecoderModule is not defined`.

## Testing
- Ran `npm run build`.
- Ran `npx eslint build.js src/content/features/navigation/transactionslink.js src/content/core/settings/settingConfig.js`.
- Loaded the unpacked extension in Edge.
- Verified the feature is off by default.
- Verified enabling `My Transactions sidebar link` under Navigation adds the sidebar link without refreshing.
- Verified disabling `My Transactions sidebar link` removes the sidebar link without refreshing.
- Verified `My Transactions` appears below `Communities` when enabled.
- Verified clicking `My Transactions` opens `https://www.roblox.com/transactions`.
- Verified the sidebar insertion anchors from the `Communities` link.
- Verified the `DracoDecoderModule is not defined` error no longer appears after rebuilding.
