### PR TITLE
Add limited markdown for untrusted users inside status bubbles

### DIFF
--- a/src/content/core/utils/markdown.js
+++ b/src/content/core/utils/markdown.js
@@ -1,4 +1,5 @@
 import { marked } from 'marked'; // Better markdown!!!
+import { safeHtml } from '../packages/dompurify';
 
 export function parseMarkdown(text, themeColors = {}) {
     if (!text) return '';
@@ -19,4 +20,45 @@ export function parseMarkdown(text, themeColors = {}) {
     });
 
     return `<div class="rovalra-markdown">${marked.parse(processedText)}</div>`;
+}
+
+/**
+ * Format markdown from untrusted sources
+ * @param {string} text 
+ * @returns {string} Safe HTML render
+ */
+export function parseUntrustedMarkdown(text) {
+    if (!text) return '';
+
+    text = safeHtml([text]);
+
+    // Headings
+    text = text.replace(/^# (.*)$/m, (match, heading) => {
+        return `<u><b>${heading}</b></u><br>`;
+    });  // allow ONE heading which is just bold text + newline
+
+    // Bold Text
+    text = text.replaceAll(/\*\*(.*?)\*\*/g, (match, bold) => {
+        return `<b>${bold}</b>`;
+    });
+
+    text = text.replaceAll(/__(.*?)__/g, (match, bold) => {
+        return `<b>${bold}</b>`;
+    });
+
+    // Italic Text
+    text = text.replaceAll(/\*(.*?)\*/g, (match, italic) => {
+        return `<i>${italic}</i>`;
+    });
+
+    text = text.replaceAll(/_(.*?)_/g, (match, italic) => {
+        return `<i>${italic}</i>`;
+    });
+
+    // Inline Codeblocks
+    text = text.replaceAll(/`(.*?)`/g, (match, codeblock) => {
+        return `<code>${codeblock}</code>`;
+    })
+
+    return text.trim();
 }

--- a/src/content/features/profile/header/status.js
+++ b/src/content/features/profile/header/status.js
@@ -13,7 +13,7 @@ import { createStyledInput } from '../../../core/ui/catalog/input.js';
 import { showSystemAlert } from '../../../core/ui/roblox/alert.js';
 import { reportUserContent } from '../../../core/report.js';
 import { showConfirmationPrompt } from '../../../core/ui/confirmationPrompt.js';
-import { parseMarkdown } from '../../../core/utils/markdown.js';
+import { parseMarkdown, parseUntrustedMarkdown } from '../../../core/utils/markdown.js';
 import { migrateLegacyStatus } from '../../../core/profile/descriptionhandler.js';
 import DOMPurify from 'dompurify';
 import {
@@ -228,7 +228,7 @@ async function addStatusBubble(avatarContainer) {
                 video.play().catch(() => {});
             }
         } else {
-            bubble.textContent = statusText;
+            bubble.innerHTML = parseUntrustedMarkdown(statusText);  // Verified
         }
 
         bubbleWrapper.appendChild(bubble);
@@ -267,7 +267,7 @@ async function addStatusBubble(avatarContainer) {
                         video.play().catch(() => {});
                     }
                 } else {
-                    bubble.textContent = textToRender;
+                    bubble.innerHTML = parseUntrustedMarkdown(textToRender);  // Verified
                 }
 
                 const newTooltipText =
@@ -407,7 +407,7 @@ async function addHomeStatusHover(tile) {
                                 },
                             );
                         } else {
-                            bubble.textContent = statusText;
+                            bubble.innerHTML = parseUntrustedMarkdown(statusText).replaceAll("<br>", '');  // Verified
                         }
                         statusLoaded = true;
 


### PR DESCRIPTION
Add limited markdown support for untrusted users.

Supported markdown features:
| Description | Syntax 1 | Syntax 2 | Output | Note |
| - | - | - | - | - |
| Headings | `# {text}` | N/A | `<u><b>{text}</b></u><br>` | The newline (`br`) doesn't display in the friends bar. Also only a maximum of 1 heading is supported. |
| Italic | `*{text}*` | `_{text}_` | `<i>{text}</i>` | N/A |
| Bold | `**{text}**` | `__{text}__` | `<b>{text}</b>` | N/A |
| Italic + Bold | `***{text}***` | `___{text}___` | `<i><b>{text}</b></i>` | N/A |
| Inline Codeblocks | `` `{text}` `` | N/A | `<code>{text}</code>` | N/A |

> [!NOTE]
> This markdown rendered uses simple RegEx, making markdown dos attacks (yes they're a thing) impossible under the 150 character limit.