### PR TITLE
Add verifiedInnerHtml

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,9 +15,9 @@ const baseRestrictedSyntax = [
     {
         // Block innerHTML assignments that aren't wrapped in sanitize() or safeHtml``
         selector:
-            "AssignmentExpression[left.property.name='innerHTML']:not([right.type='Literal']):not([right.type='TemplateLiteral'][right.expressions.length=0]):not([right.callee.property.name='sanitize']):not([right.callee.name='sanitize']):not([right.tag.name='safeHtml'])",
+            "AssignmentExpression[left.property.name='innerHTML']:not([right.type='Literal']):not([right.type='TemplateLiteral'][right.expressions.length=0]):not([right.callee.property.name='sanitize']):not([right.callee.name='sanitize']):not([right.tag.name='safeHtml']):not(:has(AwaitExpression > Identifier[name='verifiedInnerHtml'])):not(:has(CallExpression[callee.name=='verifiedInnerHtmlSync']))",
         message:
-            '⚠️ Unsafe innerHTML assignment detected. You must wrap the value with DOMPurify.sanitize() or use the safeHtml helper.',
+            '⚠️ Unsafe innerHTML assignment detected. You must wrap the value with DOMPurify.sanitize() or use the safeHtml helper. If you\'re sure of it, add a `// Verified` comment or use verifiedInnerHtml.',
     },
 ];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
             "version": "2.5.1",
             "dependencies": {
                 "dompurify": "^3.4.3",
-                "i18next": "26.2.0",
+                "i18next": "26.0.6",
+                "jsdom": "^29.1.1",
                 "marked": "^18.0.3",
                 "roavatar-renderer": "^1.3.6",
-                "roblox-bat": "0.6.5"
+                "roblox-bat": "0.6.5",
+                "smol-toml": "^1.6.1"
             },
             "devDependencies": {
                 "esbuild": "^0.28.0",
@@ -25,276 +27,206 @@
                 "sass": "^1.99.0"
             }
         },
-        "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-            "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
-            "cpu": [
-                "ppc64"
-            ],
-            "dev": true,
+        "node_modules/@asamuzakjp/css-color": {
+            "version": "5.1.11",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+            "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
             "license": "MIT",
-            "optional": true,
-            "os": [
-                "aix"
-            ],
+            "dependencies": {
+                "@asamuzakjp/generational-cache": "^1.0.1",
+                "@csstools/css-calc": "^3.2.0",
+                "@csstools/css-color-parser": "^4.1.0",
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            },
             "engines": {
-                "node": ">=18"
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
             }
         },
-        "node_modules/@esbuild/android-arm": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-            "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
+        "node_modules/@asamuzakjp/dom-selector": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+            "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
             "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
+            "dependencies": {
+                "@asamuzakjp/generational-cache": "^1.0.1",
+                "@asamuzakjp/nwsapi": "^2.3.9",
+                "bidi-js": "^1.0.3",
+                "css-tree": "^3.2.1",
+                "is-potential-custom-element-name": "^1.0.1"
+            },
             "engines": {
-                "node": ">=18"
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
             }
         },
-        "node_modules/@esbuild/android-arm64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-            "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
+        "node_modules/@asamuzakjp/generational-cache": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+            "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
             "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
             "engines": {
-                "node": ">=18"
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
             }
         },
-        "node_modules/@esbuild/android-x64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-            "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
+        "node_modules/@asamuzakjp/nwsapi": {
+            "version": "2.3.9",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+            "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+            "license": "MIT"
+        },
+        "node_modules/@babel/runtime": {
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+            "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
             "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
             "engines": {
-                "node": ">=18"
+                "node": ">=6.9.0"
             }
         },
-        "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-            "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
+        "node_modules/@bramus/specificity": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+            "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
             "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=18"
+            "dependencies": {
+                "css-tree": "^3.0.0"
+            },
+            "bin": {
+                "specificity": "bin/cli.js"
             }
         },
-        "node_modules/@esbuild/darwin-x64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-            "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
-            "cpu": [
-                "x64"
+        "node_modules/@csstools/color-helpers": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+            "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
             ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
+            "license": "MIT-0",
             "engines": {
-                "node": ">=18"
+                "node": ">=20.19.0"
             }
         },
-        "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-            "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
-            "cpu": [
-                "arm64"
+        "node_modules/@csstools/css-calc": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+            "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
             ],
-            "dev": true,
             "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
             "engines": {
-                "node": ">=18"
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
             }
         },
-        "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-            "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
-            "cpu": [
-                "x64"
+        "node_modules/@csstools/css-color-parser": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+            "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
             ],
-            "dev": true,
             "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
+            "dependencies": {
+                "@csstools/color-helpers": "^6.0.2",
+                "@csstools/css-calc": "^3.2.1"
+            },
             "engines": {
-                "node": ">=18"
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
             }
         },
-        "node_modules/@esbuild/linux-arm": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-            "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
-            "cpu": [
-                "arm"
+        "node_modules/@csstools/css-parser-algorithms": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+            "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
             ],
-            "dev": true,
             "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
             "engines": {
-                "node": ">=18"
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-tokenizer": "^4.0.0"
             }
         },
-        "node_modules/@esbuild/linux-arm64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-            "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
-            "cpu": [
-                "arm64"
+        "node_modules/@csstools/css-syntax-patches-for-csstree": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
+            "integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
             ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
+            "license": "MIT-0",
+            "peerDependencies": {
+                "css-tree": "^3.2.1"
+            },
+            "peerDependenciesMeta": {
+                "css-tree": {
+                    "optional": true
+                }
             }
         },
-        "node_modules/@esbuild/linux-ia32": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-            "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
-            "cpu": [
-                "ia32"
+        "node_modules/@csstools/css-tokenizer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+            "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
             ],
-            "dev": true,
             "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
             "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-loong64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-            "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
-            "cpu": [
-                "loong64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-            "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
-            "cpu": [
-                "mips64el"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-            "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
-            "cpu": [
-                "ppc64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-            "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
-            "cpu": [
-                "riscv64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-s390x": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-            "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
-            "cpu": [
-                "s390x"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
+                "node": ">=20.19.0"
             }
         },
         "node_modules/@esbuild/linux-x64": {
@@ -309,159 +241,6 @@
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-            "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-            "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-            "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-            "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/openharmony-arm64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-            "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openharmony"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/sunos-x64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-            "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "sunos"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/win32-arm64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-            "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/win32-ia32": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-            "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/win32-x64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-            "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
             ],
             "engines": {
                 "node": ">=18"
@@ -509,22 +288,6 @@
             },
             "engines": {
                 "node": "^20.19.0 || ^22.13.0 || >=24"
-            }
-        },
-        "node_modules/@eslint/config-array/node_modules/minimatch": {
-            "version": "9.0.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.2"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/@eslint/config-helpers": {
@@ -577,6 +340,23 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
+        "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
         "node_modules/@eslint/eslintrc/node_modules/globals": {
             "version": "13.24.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
@@ -594,19 +374,16 @@
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-            "version": "9.0.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.2"
+                "brace-expansion": "^1.1.7"
             },
             "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
+                "node": "*"
             }
         },
         "node_modules/@eslint/js": {
@@ -641,6 +418,23 @@
             },
             "engines": {
                 "node": "^20.19.0 || ^22.13.0 || >=24"
+            }
+        },
+        "node_modules/@exodus/bytes": {
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+            "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+            "license": "MIT",
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "@noble/hashes": "^1.8.0 || ^2.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@noble/hashes": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@humanfs/core": {
@@ -683,20 +477,34 @@
                 "node": ">=10.10.0"
             }
         },
+        "node_modules/@humanwhocodes/config-array/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
         "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
-            "version": "9.0.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.2"
+                "brace-expansion": "^1.1.7"
             },
             "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
+                "node": "*"
             }
         },
         "node_modules/@humanwhocodes/module-importer": {
@@ -823,174 +631,6 @@
                 "@parcel/watcher-win32-x64": "2.5.1"
             }
         },
-        "node_modules/@parcel/watcher-android-arm64": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz",
-            "integrity": "sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">= 10.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/@parcel/watcher-darwin-arm64": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz",
-            "integrity": "sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">= 10.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/@parcel/watcher-darwin-x64": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz",
-            "integrity": "sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">= 10.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/@parcel/watcher-freebsd-x64": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz",
-            "integrity": "sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">= 10.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/@parcel/watcher-linux-arm-glibc": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz",
-            "integrity": "sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/@parcel/watcher-linux-arm-musl": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz",
-            "integrity": "sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/@parcel/watcher-linux-arm64-glibc": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz",
-            "integrity": "sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/@parcel/watcher-linux-arm64-musl": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz",
-            "integrity": "sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
         "node_modules/@parcel/watcher-linux-x64-glibc": {
             "version": "2.5.1",
             "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz",
@@ -1024,69 +664,6 @@
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "engines": {
-                "node": ">= 10.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/@parcel/watcher-win32-arm64": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz",
-            "integrity": "sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">= 10.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/@parcel/watcher-win32-ia32": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz",
-            "integrity": "sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">= 10.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/@parcel/watcher-win32-x64": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz",
-            "integrity": "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
             ],
             "engines": {
                 "node": ">= 10.0.0"
@@ -1191,14 +768,31 @@
                 }
             }
         },
+        "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-            "version": "9.0.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+            "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.2"
+                "brace-expansion": "^2.0.1"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -1315,21 +909,13 @@
                 "node": ">=8"
             }
         },
-        "node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/brace-expansion": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-            "dev": true,
+        "node_modules/bidi-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+            "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
             "license": "MIT",
             "dependencies": {
-                "balanced-match": "^1.0.0"
+                "require-from-string": "^2.0.2"
             }
         },
         "node_modules/braces": {
@@ -1432,6 +1018,32 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/css-tree": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+            "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+            "license": "MIT",
+            "dependencies": {
+                "mdn-data": "2.27.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+            }
+        },
+        "node_modules/data-urls": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+            "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-mimetype": "^5.0.0",
+                "whatwg-url": "^16.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
         "node_modules/debug": {
             "version": "4.4.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1448,6 +1060,12 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/decimal.js": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+            "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+            "license": "MIT"
         },
         "node_modules/deep-is": {
             "version": "0.1.4",
@@ -1504,12 +1122,24 @@
             }
         },
         "node_modules/dompurify": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.3.tgz",
-            "integrity": "sha512-VVwJidIJcp1hpg2OMXML3ZVRPYSZiq4aX7qBh83BSIpOaRDqI+qxhXjjIWnpzkOXhmp0L81lnoME1mnCc9H48A==",
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.4.tgz",
+            "integrity": "sha512-r8K7KGKEcztXfA/nfabSYB2hg9tDphORJTdf8xprN/luSLGmNhOBN8dm1/SYjqLLet6YUFEXOcrdTuwryp/Bew==",
             "license": "(MPL-2.0 OR Apache-2.0)",
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"
+            }
+        },
+        "node_modules/entities": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+            "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "node_modules/esbuild": {
@@ -1719,22 +1349,6 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
-        "node_modules/eslint/node_modules/minimatch": {
-            "version": "9.0.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.2"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/espree": {
             "version": "9.6.1",
             "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
@@ -1918,9 +1532,9 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-            "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.4.tgz",
+            "integrity": "sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==",
             "dev": true,
             "license": "ISC"
         },
@@ -1965,22 +1579,6 @@
             },
             "engines": {
                 "node": ">=10.13.0"
-            }
-        },
-        "node_modules/glob/node_modules/minimatch": {
-            "version": "9.0.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.2"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/globals": {
@@ -2062,10 +1660,22 @@
                 "node": ">=8"
             }
         },
+        "node_modules/html-encoding-sniffer": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+            "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+            "license": "MIT",
+            "dependencies": {
+                "@exodus/bytes": "^1.6.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
         "node_modules/i18next": {
-            "version": "26.2.0",
-            "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.2.0.tgz",
-            "integrity": "sha512-zwBHldHdTmwN7r6UNc7lC6GWNN+YYg3DrRSeHR5PRRBf5QnJZcYHrQc0uaU26qZeYxR7iFZD+Y315dPnKP47wA==",
+            "version": "26.0.6",
+            "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.6.tgz",
+            "integrity": "sha512-A4U6eCXodIbrhf8EarRurB9/4ebyaurH4+fu4gig9bqxmpSt+fCAFm/GpRQDcN1Xzu/LdFCx4nYHsnM1edIIbg==",
             "funding": [
                 {
                     "type": "individual",
@@ -2081,6 +1691,9 @@
                 }
             ],
             "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.29.2"
+            },
             "peerDependencies": {
                 "typescript": "^5 || ^6"
             },
@@ -2206,6 +1819,12 @@
                 "node": ">=8"
             }
         },
+        "node_modules/is-potential-custom-element-name": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+            "license": "MIT"
+        },
         "node_modules/isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2223,6 +1842,46 @@
             },
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/jsdom": {
+            "version": "29.1.1",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+            "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/css-color": "^5.1.11",
+                "@asamuzakjp/dom-selector": "^7.1.1",
+                "@bramus/specificity": "^2.4.2",
+                "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+                "@exodus/bytes": "^1.15.0",
+                "css-tree": "^3.2.1",
+                "data-urls": "^7.0.0",
+                "decimal.js": "^10.6.0",
+                "html-encoding-sniffer": "^6.0.0",
+                "is-potential-custom-element-name": "^1.0.1",
+                "lru-cache": "^11.3.5",
+                "parse5": "^8.0.1",
+                "saxes": "^6.0.0",
+                "symbol-tree": "^3.2.4",
+                "tough-cookie": "^6.0.1",
+                "undici": "^7.25.0",
+                "w3c-xmlserializer": "^5.0.0",
+                "webidl-conversions": "^8.0.1",
+                "whatwg-mimetype": "^5.0.0",
+                "whatwg-url": "^16.0.1",
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "canvas": "^3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "canvas": {
+                    "optional": true
+                }
             }
         },
         "node_modules/json-buffer": {
@@ -2287,9 +1946,9 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.18.1",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+            "version": "4.17.23",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
             "dev": true,
             "license": "MIT"
         },
@@ -2396,10 +2055,9 @@
             }
         },
         "node_modules/lru-cache": {
-            "version": "11.2.6",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-            "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
-            "dev": true,
+            "version": "11.3.6",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+            "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": "20 || >=22"
@@ -2416,6 +2074,12 @@
             "engines": {
                 "node": ">= 20"
             }
+        },
+        "node_modules/mdn-data": {
+            "version": "2.27.1",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+            "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+            "license": "CC0-1.0"
         },
         "node_modules/merge2": {
             "version": "1.4.1",
@@ -2439,6 +2103,39 @@
             },
             "engines": {
                 "node": ">=8.6"
+            }
+        },
+        "node_modules/minimatch": {
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.2"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/minimatch/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/minimatch/node_modules/brace-expansion": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
             }
         },
         "node_modules/minipass": {
@@ -2550,6 +2247,18 @@
             },
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/parse5": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+            "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+            "license": "MIT",
+            "dependencies": {
+                "entities": "^8.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
             }
         },
         "node_modules/path-exists": {
@@ -2715,6 +2424,23 @@
                 }
             }
         },
+        "node_modules/prettier-eslint/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/prettier-eslint/node_modules/brace-expansion": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
         "node_modules/prettier-eslint/node_modules/eslint": {
             "version": "8.57.1",
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
@@ -2839,19 +2565,16 @@
             }
         },
         "node_modules/prettier-eslint/node_modules/minimatch": {
-            "version": "9.0.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.2"
+                "brace-expansion": "^1.1.7"
             },
             "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
+                "node": "*"
             }
         },
         "node_modules/prettier-eslint/node_modules/rimraf": {
@@ -2903,7 +2626,6 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -2968,6 +2690,15 @@
             "funding": {
                 "type": "individual",
                 "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/require-relative": {
@@ -3082,6 +2813,18 @@
                 "@parcel/watcher": "^2.4.1"
             }
         },
+        "node_modules/saxes": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+            "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+            "license": "ISC",
+            "dependencies": {
+                "xmlchars": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=v12.22.7"
+            }
+        },
         "node_modules/scheduler": {
             "version": "0.27.0",
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -3131,11 +2874,22 @@
                 "node": ">=8"
             }
         },
+        "node_modules/smol-toml": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+            "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/cyyynthia"
+            }
+        },
         "node_modules/source-map-js": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
             "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-            "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
@@ -3180,6 +2934,12 @@
                 "node": ">=8"
             }
         },
+        "node_modules/symbol-tree": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+            "license": "MIT"
+        },
         "node_modules/text-table": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -3192,6 +2952,24 @@
             "resolved": "https://registry.npmjs.org/three/-/three-0.180.0.tgz",
             "integrity": "sha512-o+qycAMZrh+TsE01GqWUxUIKR1AL0S8pq7zDkYOQw8GqfX8b8VoCKYUoHbhiX5j+7hr8XsuHDVU6+gkQJQKg9w=="
         },
+        "node_modules/tldts": {
+            "version": "7.0.30",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
+            "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+            "license": "MIT",
+            "dependencies": {
+                "tldts-core": "^7.0.30"
+            },
+            "bin": {
+                "tldts": "bin/cli.js"
+            }
+        },
+        "node_modules/tldts-core": {
+            "version": "7.0.30",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+            "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
+            "license": "MIT"
+        },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3203,6 +2981,30 @@
             },
             "engines": {
                 "node": ">=8.0"
+            }
+        },
+        "node_modules/tough-cookie": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+            "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "tldts": "^7.0.5"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/tr46": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+            "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+            "license": "MIT",
+            "dependencies": {
+                "punycode": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/ts-api-utils": {
@@ -3285,6 +3087,15 @@
                 "node": ">=14.17"
             }
         },
+        "node_modules/undici": {
+            "version": "7.25.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+            "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.18.1"
+            }
+        },
         "node_modules/uri-js": {
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -3338,6 +3149,50 @@
                 "eslint": ">=6.0.0"
             }
         },
+        "node_modules/w3c-xmlserializer": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+            "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+            "license": "MIT",
+            "dependencies": {
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/webidl-conversions": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+            "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/whatwg-mimetype": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+            "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/whatwg-url": {
+            "version": "16.0.1",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+            "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+            "license": "MIT",
+            "dependencies": {
+                "@exodus/bytes": "^1.11.0",
+                "tr46": "^6.0.0",
+                "webidl-conversions": "^8.0.1"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
         "node_modules/which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3369,6 +3224,21 @@
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/xml-name-validator": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+            "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/xmlchars": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+            "license": "MIT"
         },
         "node_modules/yocto-queue": {
             "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -20,9 +20,11 @@
     },
     "dependencies": {
         "dompurify": "^3.4.3",
-        "i18next": "26.2.0",
         "marked": "^18.0.3",
         "roavatar-renderer": "^1.3.6",
+        "i18next": "26.0.6",
+        "jsdom": "^29.1.1",
+        "smol-toml": "^1.6.1",
         "roblox-bat": "0.6.5"
     },
     "overrides": {

--- a/public/Assets/data/innerHtmlList.toml
+++ b/public/Assets/data/innerHtmlList.toml
@@ -1,6 +1,6 @@
 [status.trusted]
-disclaimer = """\
+disclaimer = """
 [[locale status.trusted.helpText]]
 <br>
-[[locale status.trusted.warning]]\
+[[locale status.trusted.warning]]
 """

--- a/public/Assets/data/innerHtmlList.toml
+++ b/public/Assets/data/innerHtmlList.toml
@@ -1,0 +1,6 @@
+[status.trusted]
+disclaimer = """\
+[[locale status.trusted.helpText]]
+<br>
+[[locale status.trusted.warning]]\
+"""

--- a/public/Assets/locales/en.json
+++ b/public/Assets/locales/en.json
@@ -765,6 +765,7 @@
     "plusPrivateServerTooltip": {
         "tooltipText": "Original Price: <b>{{originalPrice}} Robux</b><br>Currently shows as <b>Free</b> due to Roblox Plus."
     },
+<<<<<<< HEAD
     "animations": {
         "idle": "Idle",
         "walk": "Walk",
@@ -783,5 +784,12 @@
             "oldest": "Oldest"
         },
         "tooltip": "Sort by when the user joined the community"
+=======
+    "status": {
+        "trusted": {
+            "helpText": "You are a trusted RoValra user, you can add any text, embed videos, and images.",
+            "warning": "<strong>Note:</strong> If you are found to add inappropriate content against the Roblox ToS, your donator and custom badges will be revoked with no chance to get it back."
+        }
+>>>>>>> 2922bde (innerhtml: added verifiedInnerHtml)
     }
 }

--- a/public/Assets/locales/en.json
+++ b/public/Assets/locales/en.json
@@ -765,7 +765,6 @@
     "plusPrivateServerTooltip": {
         "tooltipText": "Original Price: <b>{{originalPrice}} Robux</b><br>Currently shows as <b>Free</b> due to Roblox Plus."
     },
-<<<<<<< HEAD
     "animations": {
         "idle": "Idle",
         "walk": "Walk",
@@ -784,12 +783,11 @@
             "oldest": "Oldest"
         },
         "tooltip": "Sort by when the user joined the community"
-=======
+    },
     "status": {
         "trusted": {
             "helpText": "You are a trusted RoValra user, you can add any text, embed videos, and images.",
             "warning": "<strong>Note:</strong> If you are found to add inappropriate content against the Roblox ToS, your donator and custom badges will be revoked with no chance to get it back."
         }
->>>>>>> 2922bde (innerhtml: added verifiedInnerHtml)
     }
 }

--- a/src/content/core/html/innerhtml.js
+++ b/src/content/core/html/innerhtml.js
@@ -1,0 +1,131 @@
+import * as TOML from "smol-toml";
+import { t } from "../locale/i18n.js";
+import { asyncReplaceAll } from "../utils/string.js";
+import { safeHtml } from "../packages/dompurify.js";
+
+const modify = async (obj) => {
+    for (const key in obj) {
+        if (obj[key] !== null && typeof obj[key] === "object")
+            await modify(obj[key]);
+        else {
+            obj[key] = String(obj[key]);
+
+            // Locales
+            obj[key] = await asyncReplaceAll(obj[key], /\[\[locale (.*?)\]\]/g, async (substring, locale) => {
+                return await t(locale);
+            });
+
+            // Nested Innerhtml
+            obj[key] = await asyncReplaceAll(obj[key], /\[\[innerhtml (.*?)\]\]/g, async (substring, key) => {
+                let newObj = structuredClone(obj);
+                
+                // some overly complex logic here
+                const parts = key.split(".");
+                let target = newObj;
+
+                for (let i = 0; i < parts.length - 1; i++) {
+                    target = target?.[parts[i]];
+
+                    if (target === undefined)
+                        target = null;
+                                
+                    if (target == null) {
+                        break;
+                    }
+                }
+
+                if (target != null) {
+                    target[parts.at(-1)] = '';
+                }
+
+
+                await modify(newObj);
+                
+                let value = newObj;
+                for (const subkey of key.split(".")) {
+                    if (value === undefined) {
+                        break;
+                    }
+                    value = value[subkey];
+                }
+
+                if (value === undefined)
+                    value = "(Object undefined)";
+
+                if (typeof value === "string")
+                    return value;
+                else
+                    return `(Object ${typeof value})`;
+            });
+        }
+    }
+};
+
+let verifiedInnerHtmlSyncVal = undefined;
+export const verifiedInnerHtmlSync = () => {
+    if (verifiedInnerHtmlSyncVal === undefined)
+        console.error(`(RoValra) verifiedInnerHtmlSync returning undefined.`, new Error("Referencing an uninitialised variable."));
+    return verifiedInnerHtmlSyncVal;
+};
+
+/**
+ * @type {Promise<Record<string, string | Record>>}
+ */
+export const verifiedInnerHtml = (async () => {
+    const response = await fetch(
+        chrome.runtime.getURL(`public/Assets/data/innerHtmlList.toml`),
+    );  // Verified
+
+    const text = await response.text();
+
+    const toml = TOML.parse(text);
+
+    await modify(toml);
+
+    const rawVerifiedInnerHtml = toml;
+
+    const proxify = (obj) => new Proxy(obj, {
+        get(target, prop, receiver) {
+            if (prop === "fmt")
+                return this.fmt;
+            if (typeof target[prop] === "object")
+                return proxify(target[prop]);
+            else if (typeof target[prop] === "string")
+                return (...args) => this.fmt(target, prop, ...args);
+        },
+
+        set(t, p, newValue, receiver) {
+            console.error(`Attempted to modify innerHtml data.`, new TypeError("Assignment to constant variable."));
+        },
+
+        /**
+         * Format an innerHTML block with variables
+         * @param {{string: any}?} options
+         */
+        fmt(target, subKey, options) {
+            if (options === undefined)
+                options = {};
+
+            /** @type {string} */
+            let raw = target[subKey];
+
+            if (raw === undefined) {
+                console.error(`Undefined subkey: '${raw}'`, new Error());
+                return;
+            }
+
+            for (const key of Object.keys(options)) {
+                const value = options[key];
+
+                raw = raw.replaceAll(`{{{${key}}}}`, safeHtml([value]));
+                raw = raw.replaceAll(`{{${key}}}`, value);
+            }
+
+            return raw;
+        }
+    })
+
+    verifiedInnerHtmlSyncVal = proxify(rawVerifiedInnerHtml)
+
+    return verifiedInnerHtmlSyncVal;
+})();

--- a/src/content/core/utils/string.js
+++ b/src/content/core/utils/string.js
@@ -1,0 +1,11 @@
+export const asyncReplaceAll = async (string, regexp, callback) => {
+    const matches = string.matchAll(regexp);
+    
+    for (const match of matches) {
+        const full = match[0];
+        const captureGroups = match.slice(1, match.length);
+        string = string.replace(full, await callback(full, ...captureGroups));
+    }
+
+    return string;
+}

--- a/src/content/features/profile/header/status.js
+++ b/src/content/features/profile/header/status.js
@@ -33,14 +33,11 @@ import {
     syncDonatorTier,
     getCurrentUserTier,
 } from '../../../core/settings/handlesettings.js';
-<<<<<<< HEAD
 import {
     onUserCardElement,
     observeUserCardElements,
 } from '../../../core/profile/userCardElements.js';
-=======
 import { verifiedInnerHtml, verifiedInnerHtmlSync } from '../../../core/html/innerhtml.js';
->>>>>>> 2922bde (innerhtml: added verifiedInnerHtml)
 const MAX_STATUS_LENGTH = 128;
 const REPORTING_ENABLED = false;
 let activeHomeStatusBubble = null;

--- a/src/content/features/profile/header/status.js
+++ b/src/content/features/profile/header/status.js
@@ -33,10 +33,14 @@ import {
     syncDonatorTier,
     getCurrentUserTier,
 } from '../../../core/settings/handlesettings.js';
+<<<<<<< HEAD
 import {
     onUserCardElement,
     observeUserCardElements,
 } from '../../../core/profile/userCardElements.js';
+=======
+import { verifiedInnerHtml, verifiedInnerHtmlSync } from '../../../core/html/innerhtml.js';
+>>>>>>> 2922bde (innerhtml: added verifiedInnerHtml)
 const MAX_STATUS_LENGTH = 128;
 const REPORTING_ENABLED = false;
 let activeHomeStatusBubble = null;
@@ -99,7 +103,7 @@ DOMPurify.addHook('afterSanitizeAttributes', (currentNode) => {
     }
 });
 
-function openEditStatusOverlay(currentStatus, onSave, isTrusted) {
+async function openEditStatusOverlay(currentStatus, onSave, isTrusted) {
     const container = document.createElement('div');
     Object.assign(container.style, {
         display: 'flex',
@@ -123,11 +127,7 @@ function openEditStatusOverlay(currentStatus, onSave, isTrusted) {
     if (isTrusted) {
         const trustedHelpText = document.createElement('p');
         trustedHelpText.className = 'text-description';
-        trustedHelpText.innerHTML = DOMPurify.sanitize(`
-            You are a trusted RoValra user, you can add any text, embed videos, and images.
-            <br>
-            <strong>Note:</strong> If you are found to add inappropriate content against the Roblox ToS, your donator and custom badges will be revoked with no chance to get it back.
-        `);
+        trustedHelpText.innerHTML = verifiedInnerHtmlSync().status.trusted.disclaimer();
         Object.assign(trustedHelpText.style, {
             fontSize: '12px',
         });


### PR DESCRIPTION
## Overview
Added `verifiedInnerHtml`, a safer way of using hardcoded innerHtml.

Simply add innerHTML values to public/Assets/data/innerHtmlList.toml, and you can then use them!

<img width="344" height="231" alt="image" src="https://github.com/user-attachments/assets/8f22fc8e-40d5-4653-9bdb-9b3ba352a50e" />


## Writing innerHTML
There are four syntax features worth noting:

### 1. Referencing locales
Simply reference a locale by doing `[[locale <localeKey>]]`.

Example: `[[locale status.trusted.warning]]`

### 2. Referencing other innerHTML keys
Reference another innerHTML key by doing `[[innerhtml <key>]]`.

Example: `[[innerhtml some.other.key]]`

> [!NOTE]
> If two innerHTML keys reference eachother, the parser will resolve this by replacing one with `(unbounded reference loop)`.

### 3. Named Variables
Simple enough: `{{namedVariable}}`

> [!CAUTION]
> Using a variable this way will not automatically sanitise it.

### 4. Untrusted Named Variables
Syntax: `{{{namedVariable}}}`

These variables get passed through `safeHTML()` before being used.

## Using verifiedInnerHtml
For demonstration, I will be showing how to use `verifiedInnerHtmlSync`.

Assuming you have a key `status.trusted.disclaimer` that requires a variable with the user's description (completely hypothetical scenario), you would do:

```js
verifiedInnerHtmlSync().status.trusted.disclaimer({description: someValue});
```

The innerhtml key can itself choose to sanitise description by using it as `{{{description}}}` instead of `{{description}}`.

If there are no variables, you can just do:
```js
verifiedInnerHtmlSync().status.trusted.disclaimer();
```

For async, do:
```js
(await verifiedInnerHtml).status.trusted.disclaimer();
```

## About linter errors
The verifiedInnerHtml feature is ignored by the linter.