### PR TITLE
Reduce Roblox Plus ads

### DIFF
--- a/src/content/core/settings/settingConfig.js
+++ b/src/content/core/settings/settingConfig.js
@@ -1438,19 +1438,18 @@ export const SETTINGS_CONFIG = {
             },
             reducePlusAds: {
                 label: 'Less Roblox Plus',
-                description: "Makes Roblox Plus advertising more subtle.",
+                description: 'Makes Roblox Plus advertising more subtle.',
                 type: 'checkbox',
                 default: true,
-                storageKey: 'rovalra_less_robloxplus',
                 childSettings: {
                     removeAllPlusAdds: {
-                        label: "Remove all Roblox Plus advertising.",
+                        label: 'Remove all Roblox Plus advertising.',
                         type: 'checkbox',
-                        default: false
-                    }
+                        default: false,
+                    },
                 },
-                contributors: ["1564574922"]
-            }
+                contributors: ['1564574922'],
+            },
         },
     },
     AntiAccountTracking: {

--- a/src/content/core/settings/settingConfig.js
+++ b/src/content/core/settings/settingConfig.js
@@ -1436,6 +1436,21 @@ export const SETTINGS_CONFIG = {
                     },
                 },
             },
+            reducePlusAds: {
+                label: 'Less Roblox Plus',
+                description: "Makes Roblox Plus advertising more subtle.",
+                type: 'checkbox',
+                default: true,
+                storageKey: 'rovalra_less_robloxplus',
+                childSettings: {
+                    removeAllPlusAdds: {
+                        label: "Remove all Roblox Plus advertising.",
+                        type: 'checkbox',
+                        default: false
+                    }
+                },
+                contributors: ["1564574922"]
+            }
         },
     },
     AntiAccountTracking: {

--- a/src/content/features/sitewide/lessPlus.js
+++ b/src/content/features/sitewide/lessPlus.js
@@ -6,7 +6,7 @@ const plusTypeEnum = Object.freeze({
 
 let plusType = plusTypeEnum.Reduced;
 
-async function actualInitBecauseTheUniverseHatesMe(settings) {
+async function initFromConfig(settings) {
     if (settings.reducePlusAds)
         if (settings.removeAllPlusAdds)
             plusType = plusTypeEnum.None;
@@ -57,5 +57,5 @@ async function actualInitBecauseTheUniverseHatesMe(settings) {
 }
 
 export function init() {
-    chrome.storage.local.get({reducePlusAds: true, removeAllPlusAdds: true}, actualInitBecauseTheUniverseHatesMe);
+    chrome.storage.local.get({reducePlusAds: true, removeAllPlusAdds: true}, initFromConfig);
 }

--- a/src/content/features/sitewide/lessPlus.js
+++ b/src/content/features/sitewide/lessPlus.js
@@ -7,8 +7,8 @@ const plusTypeEnum = Object.freeze({
 let plusType = plusTypeEnum.Reduced;
 
 async function actualInitBecauseTheUniverseHatesMe(settings) {
-    if (settings.rovalra_less_robloxplus)
-        if (settings.rovalra_no_robloxplus)
+    if (settings.reducePlusAds)
+        if (settings.removeAllPlusAdds)
             plusType = plusTypeEnum.None;
         else
             plusType = plusTypeEnum.Reduced;

--- a/src/content/features/sitewide/lessPlus.js
+++ b/src/content/features/sitewide/lessPlus.js
@@ -1,0 +1,61 @@
+const plusTypeEnum = Object.freeze({
+    Full: 0,
+    Reduced: 1,
+    None: 2
+});
+
+let plusType = plusTypeEnum.Reduced;
+
+async function actualInitBecauseTheUniverseHatesMe(settings) {
+    if (settings.rovalra_less_robloxplus)
+        if (settings.rovalra_no_robloxplus)
+            plusType = plusTypeEnum.None;
+        else
+            plusType = plusTypeEnum.Reduced;
+    else
+        plusType = plusTypeEnum.Full;
+
+    window.addEventListener('load', () => {
+        if (plusType >= plusTypeEnum.Reduced) {
+            const _RobloxPlusButtonA = document.querySelectorAll("#left-navigation-container .left-nav div a[href='https://www.roblox.com/plus']");
+            if (_RobloxPlusButtonA.length != 1)
+                console.error(`Query selector \`#left-navigation-container .left-nav div a[href='https://www.roblox.com/plus']\` returned ${_RobloxPlusButtonA.length} elements.`);
+
+            const robloxPlusButton = _RobloxPlusButtonA[0];
+            robloxPlusButton.parentElement.remove();
+
+            const _RobloxPlusNoteA = document.querySelectorAll("#left-navigation-container .left-nav div li.padding-top-xsmall a[href='/plus']");
+            if (_RobloxPlusNoteA.length != 1)
+                console.error(`Query selector \`#left-navigation-container .left-nav div li.padding-top-xsmall a[href='/plus']\` returned ${_RobloxPlusNoteA.length} elements.`);
+
+            const robloxPlusNote = _RobloxPlusNoteA[0];
+            if (plusType >= plusTypeEnum.None)
+                robloxPlusNote.parentElement.remove();
+            else {
+                robloxPlusNote.parentElement.innerHTML = String.raw`
+                    <p class="text-body-medium padding-x-medium padding-y-small" style="white-space: nowrap;">
+                      <span role="presentation" class="grow-0 shrink-0 basis-auto icon icon-regular-roblox-plus size-[var(--icon-size-small)]" style="vertical-align: -1px;"></span>
+                      More fun for less Robux. 
+                      <a href='/plus' class="content-default [text-decoration:underline] [text-decoration-skip-ink:none] [text-underline-offset:3px]">Subscribe</a>
+                    </p>
+                `;  // Verified
+            }
+
+            const _RobloxPlusInBuyRobuxSnippetA = document.querySelectorAll("div.buy-robux-content div div div.flex a[href='/plus']");
+            if (_RobloxPlusInBuyRobuxSnippetA.length != 1)
+                console.error(`Query selector \`div.buy-robux-content div div div.flex a[href='/plus']\` returned ${_RobloxPlusInBuyRobuxSnippetA.length} elements.`);
+
+            const robloxPlusInBuyRobuxSnippet = _RobloxPlusInBuyRobuxSnippetA[0].parentElement.parentElement.parentElement.children[1];
+
+            if (plusType >= plusTypeEnum.None)
+                robloxPlusInBuyRobuxSnippet.parentElement.remove();
+            else
+                robloxPlusInBuyRobuxSnippet.remove();
+        }
+
+    });
+}
+
+export function init() {
+    chrome.storage.local.get({reducePlusAds: true, removeAllPlusAdds: true}, actualInitBecauseTheUniverseHatesMe);
+}

--- a/src/content/features/sitewide/lessPlus.js
+++ b/src/content/features/sitewide/lessPlus.js
@@ -15,7 +15,7 @@ async function actualInitBecauseTheUniverseHatesMe(settings) {
     else
         plusType = plusTypeEnum.Full;
 
-    window.addEventListener('load', () => {
+    window.addEventListener('DOMContentLoaded', () => {
         if (plusType >= plusTypeEnum.Reduced) {
             const _RobloxPlusButtonA = document.querySelectorAll("#left-navigation-container .left-nav div a[href='https://www.roblox.com/plus']");
             if (_RobloxPlusButtonA.length != 1)

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -30,6 +30,7 @@ import { init as initCustomFont } from './features/sitewide/customFont.js';
 import { init as initTransactionsLink } from './features/navigation/transactionslink.js';
 import { initializeModernIcons as initModernIcons } from './features/sitewide/modernIcons.js';
 import { init as initLoginBanner } from './features/scamprevention/loginBanner.js';
+import { init as initLessPlus } from './features/sitewide/lessPlus.js';
 
 // Avatar
 import { init as initAvatarFilters } from './features/avatar/filters.js';
@@ -158,6 +159,7 @@ const featureRoutes = [
             initPurchasePromptItemId,
             initUrlTracker,
             initModernIcons,
+            initLessPlus,
         ],
     },
     // pretty much just the 40% method


### PR DESCRIPTION
Added a setting that lets the user either reduce the number of Roblox Plus ads (some are removed, some are made smaller and more subtle), or remove them entirely.

This only covers the roblox plus ads in the navigation bar and the Buy Robux page.