### PR TITLE
Make tooltips round

### DIFF
--- a/src/css/sitewide.css
+++ b/src/css/sitewide.css
@@ -63,3 +63,7 @@
     );
     --rovalra-icon-blocked-color: #ffffff;
 }
+
+div.tooltip-inner {
+    border-radius: 8px;
+}


### PR DESCRIPTION
Very simple change -- makes tooltips round.

This also affects Roblox tooltips.