### PR TITLE
Improved logging

### DIFF
--- a/src/content/core/logging.js
+++ b/src/content/core/logging.js
@@ -1,0 +1,19 @@
+const oldConsole = console;
+
+globalThis.console = {
+    log: (fmt, ...msg) => oldConsole.log(`(RoValra:Log) ${fmt}`, ...msg),
+    debug: (fmt, ...msg) => oldConsole.debug(`(RoValra:Debug) ${fmt}`, ...msg),
+    info: (fmt, ...msg) => oldConsole.info(`(RoValra:Info) ${fmt}`, ...msg),
+    warn: (fmt, ...msg) => oldConsole.warn(`(RoValra:Warn) ${fmt}`, ...msg),
+    error: (fmt, ...msg) => oldConsole.error(`(RoValra:Error) ${fmt}`, ...msg),
+}
+
+window.addEventListener("error", (event) => {
+    event.preventDefault();
+    console.error("Uncaught error:", event.error);
+});
+
+window.addEventListener("unhandledrejection", (event) => {
+    event.preventDefault();
+    console.error("Uncaught async error:", event.reason);
+});

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -1,3 +1,5 @@
+import "./core/logging.js";
+
 import { initializeObserver, startObserving } from './core/observer.js';
 import { detectTheme, dispatchThemeEvent } from './core/theme.js';
 import { getValidAccessToken } from './core/oauth/oauth.js';


### PR DESCRIPTION
## Overview
Appends `(RoValra)` to errors to make it easier to distinguish rovalra errors from other errors.

> [!NOTE]
> Unlike the previous PR, which required using a new module everywhere, this automatically gets applied everywhere by replacing the global `console` with a wrapper and installing handlers for uncaught errors.