### PR TITLE
Make verboseDebug not log anything unless enabled

### DIFF
--- a/src/background/settingsCompat.ts
+++ b/src/background/settingsCompat.ts
@@ -8,7 +8,7 @@ const settingDeprecations: Record<string, ((value: any, gets: (key: string) => P
 
 
 import { SETTINGS_CONFIG } from "../content/core/settings/settingConfig.js";
-import { debugVerbose, flush } from "../content/core/debug.js";
+import { debugVerbose } from "../content/core/debug.js";
 
 let compatResults: { replaced: string[]; deleted: string[] } | null = null;
 
@@ -121,7 +121,6 @@ const init = (async () => {
     });
 
     await cleanup();
-    flush();
 
     console.debug("Setting compat checks finished.");
 });

--- a/src/content/core/debug.ts
+++ b/src/content/core/debug.ts
@@ -8,22 +8,7 @@ async function init() {
 
 init();
 
-let toFlush: string = "";
-
 export function debugVerbose(fmt: string, ...args: any[]) {
-    if (toFlush.length >= 500) {
-        flush();
-    }
-    if (verbose) {
+    if (verbose)
         console.debug(fmt, ...args);
-    } else {
-        toFlush += fmt;
-        toFlush += (args?.length || 0) >= 1 ? ` (${args.length} suppressed Objects)` : ``;
-        toFlush += "\n";
-    }
-}
-
-export function flush() {
-    console.debug(toFlush);
-    toFlush = "";
 }

--- a/src/content/core/settings/settingsCompat.ts
+++ b/src/content/core/settings/settingsCompat.ts
@@ -1,4 +1,4 @@
-import { debugVerbose, flush } from "../debug";
+import { debugVerbose } from "../debug";
 import { settings } from "./getSettings";
 
 chrome.runtime.sendMessage({ type: "settingsCompatGetRes" }, (message) => {
@@ -24,8 +24,6 @@ chrome.runtime.sendMessage({ type: "settingsCompatGetRes" }, (message) => {
     *  ${deleted.join("\n    *  ")}`);
             debugVerbose(`Deleted/locked/deprecated ${deleted.length} settings.`, deleted);
         }
-
-        flush();
     })();
 
     return true; 


### PR DESCRIPTION
No point in logging things in the console if it isn't enabled by the user.