### PR TITLE
Favorite Friends

### DIFF
--- a/public/Assets/locales/en.json
+++ b/public/Assets/locales/en.json
@@ -679,6 +679,12 @@
         "exitBulkMode": "Exit Bulk Mode",
         "successMessage": "Successfully unfriended {{successCount}}/{{totalCount}} friends!"
     },
+	"favoriteFriends": {
+		"favoriteFriend": "Favorite Friend",
+		"favoriteFriendDisplayName": "Favorite {{displayName}}",
+		"unFavoriteFriend": "Unfavorite Friend",
+		"unFavoriteFriendDisplayName": "Unfavorite {{displayName}}"
+	},
     "purchasePrompt": {
         "balanceAfter": "Your balance after this transaction will be"
     },

--- a/src/content/core/settings/settingConfig.js
+++ b/src/content/core/settings/settingConfig.js
@@ -648,17 +648,17 @@ export const SETTINGS_CONFIG = {
                 locked: 'Roblox released their own version of this.',
                 isPermanent: true,
             },
-			favoriteFriendsEnabled: {
-				label: "Favorite Friends",
-				description: [
-					"Allows friends that are selected to be shown first, regardless of their status.",
-					"Friends that are favorited show up in: Home, Profile, and the Friends tab."
-				],
-				type: "checkbox",
-				default: false,
-				storageKey: ["Stores userIds of favorited friends"], 
-				contributors: ["341871092"]
-			},
+            favoriteFriendsEnabled: {
+                label: 'Favorite Friends',
+                description: [
+                    'Allows friends that are selected to be shown first, regardless of their status.',
+                    'Friends that are favorited show up in: Home, Profile, and the Friends tab.',
+                ],
+                type: 'checkbox',
+                default: false,
+                storageKey: 'rovalra_favorited_friends',
+                contributors: ['341871092'],
+            },
             currencyTransferEnabled: {
                 label: 'Send Robux',
                 description: [

--- a/src/content/core/settings/settingConfig.js
+++ b/src/content/core/settings/settingConfig.js
@@ -648,6 +648,17 @@ export const SETTINGS_CONFIG = {
                 locked: 'Roblox released their own version of this.',
                 isPermanent: true,
             },
+			favoriteFriendsEnabled: {
+				label: "Favorite Friends",
+				description: [
+					"Allows friends that are selected to be shown first, regardless of their status.",
+					"Friends that are favorited show up in: Home, Profile, and the Friends tab."
+				],
+				type: "checkbox",
+				default: false,
+				storageKey: ["Stores userIds of favorited friends"], 
+				contributors: ["341871092"]
+			},
             currencyTransferEnabled: {
                 label: 'Send Robux',
                 description: [

--- a/src/content/features/sitewide/favoriteFriends.js
+++ b/src/content/features/sitewide/favoriteFriends.js
@@ -1,0 +1,44 @@
+import { settings } from '../../core/settings/getSettings';
+import { observeElement } from '../../core/observer';
+import { createButton } from '../../core/ui/buttons';
+import { t } from '../../core/locale/i18n';
+import { getUserCardContext } from '../../core/profile/userCardElements';
+import { getUserDisplayName } from '../../core/apis/users';
+
+async function addUserCardToggle() {
+    observeElement('.friend-tile-dropdown', async (userCard) => {
+        const userTile = userCard.closest('.friends-carousel-tile');
+
+        const toggleIdentifier = 'rovalra-favorite-friend-userCard-toggle';
+        if (userCard.querySelector(`.${toggleIdentifier}`)) return;
+
+        const userId = getUserCardContext(userTile).userId;
+        const userDisplayName = await getUserDisplayName(userId);
+
+        const container = userCard.querySelector('ul');
+        let item = document.createElement('li');
+
+        const toggle = createButton(
+            await t('favoriteFriends.favoriteFriendDisplayName', {
+                displayName: userDisplayName,
+            }),
+            'secondary',
+        );
+        toggle.classList.add(toggleIdentifier);
+        toggle.classList.add('friend-tile-dropdown-button');
+
+        let favoriteIcon = document.createElement('span');
+        favoriteIcon.classList.add('icon-favorite');
+        toggle.prepend(favoriteIcon);
+
+        item.append(toggle);
+        container.append(item);
+    });
+}
+// .friends-carousel-tile
+// .friend-tile-dropdown
+
+export async function init() {
+    if (!(await settings.favoriteFriendsEnabled)) return;
+    observeElement('.friends-carousel-tile', addUserCardToggle);
+}

--- a/src/content/features/sitewide/favoriteFriends.js
+++ b/src/content/features/sitewide/favoriteFriends.js
@@ -5,40 +5,157 @@ import { t } from '../../core/locale/i18n';
 import { getUserCardContext } from '../../core/profile/userCardElements';
 import { getUserDisplayName } from '../../core/apis/users';
 
+const DEVELOPMENT_MODE = true;
+
+const STORAGE_KEY = 'rovalra_favorited_friends';
+const TOGGLE_IDENTIFIER = 'rovalra-favorite-friend-userCard-toggle';
+const FAVORITED_IDENTIFER = 'rovalra-friend-favorited';
+
+// ─── Chrome Storage ──────────────────────────────────────────────────────────
+
+async function fetchFavoritedFriends() {
+    try {
+        const storage = await chrome.storage.local.get(STORAGE_KEY);
+        return Array.isArray(storage[STORAGE_KEY]) ? storage[STORAGE_KEY] : [];
+    } catch (error) {
+        console.log(
+            'Rovalra: Failed to fetch favorited friends cache, ',
+            error,
+        );
+        return [];
+    }
+}
+
+async function writeFavoritedFriends(favorite_friends) {
+    try {
+        await chrome.storage.local.set({
+            [STORAGE_KEY]: favorite_friends,
+        });
+    } catch (error) {
+        console.warn(
+            'RoValra: Failed to write favorited friends into cache, ',
+            error,
+        );
+    }
+}
+
+// ─── Helper Functions ────────────────────────────────────────────────────────
+
+async function isFavorited(userId) {
+    let favorited_friends = await fetchFavoritedFriends();
+
+    return favorited_friends.includes(userId);
+}
+
+async function determineLabel(userFavorited, userDisplayName) {
+    return userFavorited
+        ? await t('favoriteFriends.unFavoriteFriendDisplayName', {
+              displayName: userDisplayName,
+          })
+        : await t('favoriteFriends.favoriteFriendDisplayName', {
+              displayName: userDisplayName,
+          });
+}
+
+// ─── Favoriting Logic ────────────────────────────────────────────────────────
+
+async function toggleFavorite(userId) {
+    let favorited_friends = await fetchFavoritedFriends();
+    const userFavorited = await isFavorited(userId);
+
+    userFavorited
+        ? favorited_friends.pop(userId)
+        : favorited_friends.push(userId);
+
+    if (DEVELOPMENT_MODE) console.table('Favorited Friends', favorited_friends);
+    await writeFavoritedFriends(favorited_friends);
+}
+
+// ─── Component Injection ─────────────────────────────────────────────────────
+
+async function createUserCardToggle(userTile, userId, userDisplayName) {
+    const favoriteToggle = createButton(
+        await determineLabel(await isFavorited(userId), userDisplayName),
+        'secondary',
+        {
+            onClick: async () => {
+                await toggleFavorite(userId);
+                updateToggle();
+                await updateTileDecoration();
+            },
+        },
+    );
+
+    const updateToggle = async () => {
+        const textNode = favoriteToggle.childNodes[1];
+        textNode.textContent = await determineLabel(
+            await isFavorited(userId),
+            userDisplayName,
+        );
+    };
+
+    const updateTileDecoration = async () => {
+        (await isFavorited(userId))
+            ? userTile.classList.add(FAVORITED_IDENTIFER)
+            : userTile.classList.remove(FAVORITED_IDENTIFER);
+    };
+
+    if (DEVELOPMENT_MODE)
+        console.log(
+            `RoValra - Favorited Friends: Is ${userDisplayName} (${userId}) favorited? ${await isFavorited(userId)}.`,
+            await determineLabel(await isFavorited(userId), userDisplayName),
+        );
+
+    favoriteToggle.classList.add(TOGGLE_IDENTIFIER);
+    favoriteToggle.classList.add('friend-tile-dropdown-button');
+
+    let favoriteIcon = document.createElement('span');
+    favoriteIcon.classList.add('icon-favorite');
+    favoriteToggle.prepend(favoriteIcon);
+
+    return favoriteToggle;
+}
+
 async function addUserCardToggle() {
     observeElement('.friend-tile-dropdown', async (userCard) => {
         const userTile = userCard.closest('.friends-carousel-tile');
-
-        const toggleIdentifier = 'rovalra-favorite-friend-userCard-toggle';
-        if (userCard.querySelector(`.${toggleIdentifier}`)) return;
-
-        const userId = getUserCardContext(userTile).userId;
-        const userDisplayName = await getUserDisplayName(userId);
+        if (userCard.querySelector(`.${TOGGLE_IDENTIFIER}`)) return;
 
         const container = userCard.querySelector('ul');
         let item = document.createElement('li');
 
-        const toggle = createButton(
-            await t('favoriteFriends.favoriteFriendDisplayName', {
-                displayName: userDisplayName,
-            }),
-            'secondary',
+        const userId = getUserCardContext(userTile).userId;
+        const userDisplayName = await getUserDisplayName(userId);
+
+        const favoriteToggle = await createUserCardToggle(
+            userTile,
+            userId,
+            userDisplayName,
         );
-        toggle.classList.add(toggleIdentifier);
-        toggle.classList.add('friend-tile-dropdown-button');
 
-        let favoriteIcon = document.createElement('span');
-        favoriteIcon.classList.add('icon-favorite');
-        toggle.prepend(favoriteIcon);
-
-        item.append(toggle);
+        item.append(favoriteToggle);
         container.append(item);
     });
 }
+
+async function addUserTileDecoration(userTile) {
+    if (userTile.querySelector(`.${FAVORITED_IDENTIFER}`)) return;
+    const userId = getUserCardContext(userTile).userId;
+    const userFavorited = await isFavorited(userId);
+
+    if (userFavorited) userTile.classList.add(FAVORITED_IDENTIFER);
+}
+
 // .friends-carousel-tile
 // .friend-tile-dropdown
 
 export async function init() {
     if (!(await settings.favoriteFriendsEnabled)) return;
     observeElement('.friends-carousel-tile', addUserCardToggle);
+    observeElement('.friends-carousel-tile', addUserTileDecoration, {
+        multiple: true,
+    });
+
+    let favorite_friends = await fetchFavoritedFriends();
+    console.table(favorite_friends);
 }

--- a/src/content/features/sitewide/favoriteFriends.js
+++ b/src/content/features/sitewide/favoriteFriends.js
@@ -4,12 +4,18 @@ import { createButton } from '../../core/ui/buttons';
 import { t } from '../../core/locale/i18n';
 import { getUserCardContext } from '../../core/profile/userCardElements';
 import { getUserDisplayName } from '../../core/apis/users';
+import { fetchThumbnails } from '../../core/thumbnail/thumbnails';
 
 const DEVELOPMENT_MODE = true;
+const CAROUSEL_OFFSET = 2;
 
 const STORAGE_KEY = 'rovalra_favorited_friends';
+
 const TOGGLE_IDENTIFIER = 'rovalra-favorite-friend-userCard-toggle';
+const TOGGLE_FAVORITED_IDENTIFIER = 'rovalra-favorite-friend-userCard-toggled';
+
 const FAVORITED_IDENTIFER = 'rovalra-friend-favorited';
+const AVATAR_IDENTIFIER = 'rovalra-forcefully-loaded-avatar';
 
 // ─── Chrome Storage ──────────────────────────────────────────────────────────
 
@@ -57,48 +63,106 @@ async function determineLabel(userFavorited, userDisplayName) {
           });
 }
 
+async function updateToggle(favoriteToggle, userDisplayName, userFavorited) {
+    const textNode = favoriteToggle.childNodes[1];
+    textNode.textContent = await determineLabel(userFavorited, userDisplayName);
+}
+
+async function updateTileDecoration(userTile, userFavorited) {
+    userFavorited
+        ? userTile.classList.add(FAVORITED_IDENTIFER)
+        : userTile.classList.remove(FAVORITED_IDENTIFER);
+}
+
+async function attachAvatar(userTile, userId) {
+    const container = userTile.querySelector('.thumbnail-2d-container.shimmer');
+    if (container.querySelector(`.${AVATAR_IDENTIFIER}`)) return;
+
+    const avatarImage = document.createElement('img');
+    avatarImage.classList.add(AVATAR_IDENTIFIER);
+    container.append(avatarImage);
+
+    const thumbMap = await fetchThumbnails(
+        [{ id: userId }],
+        'AvatarHeadshot',
+        '150x150',
+        true,
+    );
+
+    avatarImage.src = thumbMap.entries().next().value[1].imageUrl;
+    container.classList.remove('shimmer');
+}
+
 // ─── Favoriting Logic ────────────────────────────────────────────────────────
 
 async function toggleFavorite(userId) {
     let favorited_friends = await fetchFavoritedFriends();
-    const userFavorited = await isFavorited(userId);
 
-    userFavorited
-        ? favorited_friends.pop(userId)
-        : favorited_friends.push(userId);
+    favorited_friends = favorited_friends.includes(userId)
+        ? favorited_friends.filter((id) => id !== userId)
+        : [...favorited_friends, userId];
 
     if (DEVELOPMENT_MODE) console.table('Favorited Friends', favorited_friends);
     await writeFavoritedFriends(favorited_friends);
+
+    return favorited_friends.includes(userId);
+}
+
+async function reorderCarousel(userTile, userId) {
+    const userFavorited = await isFavorited(userId);
+    const userFavoritedFriends = await fetchFavoritedFriends(userId);
+
+    const tileContainer = document.querySelector(
+        '.friends-carousel-list-container',
+    );
+
+    const alreadyFavoritedLocation = () => {
+        if (tileContainer.querySelector('.add-friends-icon-container')) {
+            return tileContainer.children[1];
+        } else {
+            return tileContainer.children[0];
+        }
+    };
+
+    userFavorited
+        ? tileContainer.insertBefore(
+              userTile.parentElement,
+              alreadyFavoritedLocation(),
+          )
+        : tileContainer.insertBefore(
+              userTile.parentElement,
+              tileContainer.children[
+                  userFavoritedFriends.length + CAROUSEL_OFFSET
+              ],
+          );
 }
 
 // ─── Component Injection ─────────────────────────────────────────────────────
 
 async function createUserCardToggle(userTile, userId, userDisplayName) {
+    let userFavorited = await isFavorited(userId);
+
     const favoriteToggle = createButton(
-        await determineLabel(await isFavorited(userId), userDisplayName),
+        await determineLabel(userFavorited, userDisplayName),
         'secondary',
         {
             onClick: async () => {
-                await toggleFavorite(userId);
-                updateToggle();
-                await updateTileDecoration();
+                const userFavorited = await toggleFavorite(userId);
+                await updateToggle(
+                    favoriteToggle,
+                    userDisplayName,
+                    userFavorited,
+                );
+                await updateTileDecoration(userTile, userFavorited);
+                await reorderCarousel(userTile, userId);
             },
         },
     );
 
-    const updateToggle = async () => {
-        const textNode = favoriteToggle.childNodes[1];
-        textNode.textContent = await determineLabel(
-            await isFavorited(userId),
-            userDisplayName,
-        );
-    };
-
-    const updateTileDecoration = async () => {
-        (await isFavorited(userId))
-            ? userTile.classList.add(FAVORITED_IDENTIFER)
-            : userTile.classList.remove(FAVORITED_IDENTIFER);
-    };
+    userFavorited = await isFavorited(userId);
+    userFavorited
+        ? favoriteToggle.classList.add(TOGGLE_FAVORITED_IDENTIFIER)
+        : favoriteToggle.classList.remove(TOGGLE_FAVORITED_IDENTIFIER);
 
     if (DEVELOPMENT_MODE)
         console.log(
@@ -138,21 +202,25 @@ async function addUserCardToggle() {
     });
 }
 
-async function addUserTileDecoration(userTile) {
+async function userTileModification(userTile) {
     if (userTile.querySelector(`.${FAVORITED_IDENTIFER}`)) return;
+
     const userId = getUserCardContext(userTile).userId;
     const userFavorited = await isFavorited(userId);
 
-    if (userFavorited) userTile.classList.add(FAVORITED_IDENTIFER);
-}
+    if (userFavorited) {
+        userTile.classList.add(FAVORITED_IDENTIFER);
+        await reorderCarousel(userTile, userId);
 
-// .friends-carousel-tile
-// .friend-tile-dropdown
+        if (userTile.querySelector('.thumbnail-2d-container.shimmer'))
+            attachAvatar(userTile, userId);
+    }
+}
 
 export async function init() {
     if (!(await settings.favoriteFriendsEnabled)) return;
     observeElement('.friends-carousel-tile', addUserCardToggle);
-    observeElement('.friends-carousel-tile', addUserTileDecoration, {
+    observeElement('.friends-carousel-tile', userTileModification, {
         multiple: true,
     });
 

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -159,7 +159,7 @@ const featureRoutes = [
             initBirthdayTracker,
             initServerTracker,
             initFriendsListTracking,
-			initFavoriteFriends,
+            initFavoriteFriends,
             initTransactionsTracking,
             initBadgesTracking,
             initUserCurrencyTracking,

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -20,6 +20,7 @@ import { init as initApiKey } from './core/utils/trackers/apiKey.js';
 import { init as initBirthdayTracker } from './core/utils/trackers/birthday.js';
 import { init as initServerTracker } from './core/utils/trackers/servers.js';
 import { initFriendsListTracking } from './core/utils/trackers/friendslist.js';
+import { init as initFavoriteFriends } from './features/sitewide/favoriteFriends.js';
 import { initTransactionsTracking } from './core/utils/trackers/transactions.js';
 import { initBadgesTracking } from './core/utils/trackers/badges.js';
 import { initUserCurrencyTracking } from './core/utils/trackers/currency.js';
@@ -158,6 +159,7 @@ const featureRoutes = [
             initBirthdayTracker,
             initServerTracker,
             initFriendsListTracking,
+			initFavoriteFriends,
             initTransactionsTracking,
             initBadgesTracking,
             initUserCurrencyTracking,

--- a/src/css/features/sitewide/favorite_friends.scss
+++ b/src/css/features/sitewide/favorite_friends.scss
@@ -1,0 +1,12 @@
+.friends-carousel-tile:has(
+	.friend-tile-dropdown
+) .rovalra-favorite-friend-userCard-toggle {
+	display: flex;
+	display: -ms-flexbox;
+
+	flex-direction: row;
+	align-items: center;
+	gap: 5px;
+
+	border-radius: 0px 0px 5px 5px;
+}

--- a/src/css/features/sitewide/favorite_friends.scss
+++ b/src/css/features/sitewide/favorite_friends.scss
@@ -16,3 +16,9 @@
         outline-offset: 2px;
     }
 }
+
+.friends-carousel-tile:has(.friend-tile-dropdown)
+    .rovalra-favorite-friend-userCard-toggled
+    > .icon-favorite {
+    background-position: -28px -84px;
+}

--- a/src/css/features/sitewide/favorite_friends.scss
+++ b/src/css/features/sitewide/favorite_friends.scss
@@ -1,12 +1,18 @@
-.friends-carousel-tile:has(
-	.friend-tile-dropdown
-) .rovalra-favorite-friend-userCard-toggle {
-	display: flex;
-	display: -ms-flexbox;
+.friends-carousel-tile:has(.friend-tile-dropdown)
+    .rovalra-favorite-friend-userCard-toggle {
+    display: flex;
+    display: -ms-flexbox;
 
-	flex-direction: row;
-	align-items: center;
-	gap: 5px;
+    flex-direction: row;
+    align-items: center;
+    gap: 5px;
 
-	border-radius: 0px 0px 5px 5px;
+    border-radius: 0px 0px 5px 5px;
+}
+
+.rovalra-friend-favorited {
+    .avatar-card-fullbody {
+        outline: green 2px solid;
+        outline-offset: 2px;
+    }
 }

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -27,3 +27,4 @@
 @use 'features/catalog/depenencies.scss';
 @use 'components/robuxIcon.scss';
 @use 'features/sitewide/sidebar_collapse.scss';
+@use 'features/sitewide/favorite_friends.scss';


### PR DESCRIPTION
# Overview
Allows users to "favorite" a friend, meaning they'll be "pinned" (an earlier name of my PR) and will always appear first among their friends on Home, Friends, and Profile. This saves time by letting them see updates and activities from the people that they care about most, regardless of their status (offline, online, playing, or in development/studio).

> [!NOTE]
> **"Favorite Friends" ≠ Trusted Friends**. "Favoriting" a friend is purely cosmetic and empowers users to organize and keep tabs on friends they care about most. 

# Main Changes

- Appends a toggle button to a friend tile's (`.friends-carousel-tile`) dropdown (`.friend-tile-dropdown`) to allow that friend to be "favorited."
- Storage for an array of "favorited" friends in `chrome.local.storage`.
- Simple SASS for showcasing a "favorited" friend tile. 

# Milestones

- [x] i18n (so far)
- [x] Toggle injection in user card (`.friends-carousel-tile` > `.friend-tile-dropdown`)
- [x] Reorganization of `.friends-carousel-list-container` to put "favorited" friends first.
- [ ] Toggle injection in `.avatar-card-container` in Friends page.
- [ ] Reorganization of `.avatar-cards` to put "favorited" friends first (Friends page).

**More to come soon! Please suggest features, suggestions, fixes, or anything else in the PR comments or in [my thread](https://discord.com/channels/1143867106765570088/1515962027187765349)!**