### PR TITLE
feat: add age badge customization and add new select theme

### DIFF
--- a/public/Assets/locales/en.json
+++ b/public/Assets/locales/en.json
@@ -377,7 +377,8 @@
         "options": {
             "normal": "Normal Roblox",
             "kids": "Roblox Kids",
-            "select": "Roblox Select"
+            "select": "Roblox Select",
+            "startmode": "Roblox Leaked Select (Start Mode)"
         },
         "badge": {
             "kids": "KIDS",

--- a/public/Assets/locales/en.json
+++ b/public/Assets/locales/en.json
@@ -378,6 +378,10 @@
             "normal": "Normal Roblox",
             "kids": "Roblox Kids",
             "select": "Roblox Select"
+        },
+        "badge": {
+            "kids": "KIDS",
+            "select": "SELECT"
         }
     },
     "betaPrograms": {

--- a/src/content/core/configs/userIds.js
+++ b/src/content/core/configs/userIds.js
@@ -18,6 +18,7 @@ export const CONTRIBUTOR_USER_IDS = [
     '3602693727', //nxvixz
     '422540285', //RRedshift
     '4866259395', //cam
+    '650766686' // auggeeo
 ];
 
 export const TESTER_USER_IDS = [

--- a/src/content/core/settings/settingConfig.js
+++ b/src/content/core/settings/settingConfig.js
@@ -1398,7 +1398,6 @@ export const SETTINGS_CONFIG = {
                         ],
                         type: 'checkbox',
                         default: true,
-                        experimental: 'In development',
                         contributors: ['650766686'],
                     },
                 },
@@ -1430,7 +1429,6 @@ export const SETTINGS_CONFIG = {
                         default: false,
                     },
                 },
-                experimental: 'In development',
             },
             betaProgramsEnabled: {
                 label: 'Adds a beta programs toggle to the navigation bar',

--- a/src/content/core/settings/settingConfig.js
+++ b/src/content/core/settings/settingConfig.js
@@ -1368,6 +1368,7 @@ export const SETTINGS_CONFIG = {
                     'Lets you choose which Roblox age theme is used across the site.',
                 type: 'checkbox',
                 default: false,
+                contributors: ['447170745', '650766686'],
                 childSettings: {
                     ageThemeSelection: {
                         label: 'Theme',

--- a/src/content/core/settings/settingConfig.js
+++ b/src/content/core/settings/settingConfig.js
@@ -1378,6 +1378,7 @@ export const SETTINGS_CONFIG = {
                             { label: 'Normal Roblox', value: 'normal' },
                             { label: 'Roblox Kids', value: 'kids' },
                             { label: 'Roblox Select', value: 'select' },
+                            { label: 'Roblox Leaked Select (Start Mode)', value: 'startmode' },
                         ],
                         default: 'normal',
                     },

--- a/src/content/core/settings/settingConfig.js
+++ b/src/content/core/settings/settingConfig.js
@@ -1388,7 +1388,49 @@ export const SETTINGS_CONFIG = {
                         type: 'checkbox',
                         default: false,
                     },
+                    ageThemeTextMatch: {
+                        label: 'Match Age Badge',
+                        description: [
+                            'Matches the age badge text to the theme you listed.',
+                            '(Note: this is overridden by Custom Age Theme Badge Text.',
+                            'This also means that this will be **automatically turned off** if',
+                            'the Custom Age Theme Badge Text setting is active.)',
+                        ],
+                        type: 'checkbox',
+                        default: true,
+                        experimental: 'In development',
+                        contributors: ['650766686'],
+                    },
                 },
+            },
+            ageKidsTextEnabled: {
+                label: 'Custom Age Theme Badge Text',
+                description: [
+                    'Change the "SELECT" or "KIDS" text in the badge by the Roblox logo.',
+                    'You can even use this if your not in those age groups!',
+                    'If you want you can also choose to hide the badge.',
+                ],
+                type: 'checkbox',
+                default: false,
+                contributors: ['650766686'],
+                childSettings: {
+                    ageKidsTextInput: {
+                        label: 'Custom Badge Text',
+                        description: [
+                            'The text you would like to display in the badge.',
+                            'This will be overridden by the Hide The Badge setting'
+                        ],
+                        type: 'input',
+                        default: null,
+                    },
+                    ageKidsTextHiddenEnabled: {
+                        label: 'Hide The Badge',
+                        description: 'Hide the badge text describing your age group.',
+                        type: 'checkbox',
+                        default: false,
+                    },
+                },
+                experimental: 'In development',
             },
             betaProgramsEnabled: {
                 label: 'Adds a beta programs toggle to the navigation bar',

--- a/src/content/core/settings/settingConfig.js
+++ b/src/content/core/settings/settingConfig.js
@@ -1400,6 +1400,7 @@ export const SETTINGS_CONFIG = {
                         ],
                         type: 'checkbox',
                         default: true,
+                        exclusiveWith: ['ageKidsTextEnabled'],
                         contributors: ['650766686'],
                     },
                 },
@@ -1413,6 +1414,7 @@ export const SETTINGS_CONFIG = {
                 ],
                 type: 'checkbox',
                 default: false,
+                exclusiveWith: ['ageThemeTextMatch'],
                 contributors: ['650766686', '1564574922'],
                 childSettings: {
                     ageKidsTextInput: {

--- a/src/content/core/settings/settingConfig.js
+++ b/src/content/core/settings/settingConfig.js
@@ -1413,7 +1413,7 @@ export const SETTINGS_CONFIG = {
                 ],
                 type: 'checkbox',
                 default: false,
-                contributors: ['650766686'],
+                contributors: ['650766686', '1564574922'],
                 childSettings: {
                     ageKidsTextInput: {
                         label: 'Custom Badge Text',

--- a/src/content/features/sitewide/kidsTheme.js
+++ b/src/content/features/sitewide/kidsTheme.js
@@ -2,6 +2,7 @@ import { createDropdownMenu } from '../../core/ui/dropdown.js';
 import { createNavbarButton } from '../../core/ui/navbarButton.js';
 import { getAssets } from '../../core/assets.js';
 import { t } from '../../core/locale/i18n.js';
+import { makeBadgeChanges } from './kidsThemeText.js';
 
 const AGE_THEME_OPTIONS = [
     {
@@ -80,6 +81,7 @@ async function addAgeThemeNavbarButton(currentTheme) {
             chrome.storage.local.set({ ageThemeSelection: themeSelection });
             applyAgeTheme(themeSelection);
             updateSelectedMenuItem(menu, themeSelection);
+            makeBadgeChanges(); // Makes badge changes because observing body doesn't work
         },
         position: 'center',
     });

--- a/src/content/features/sitewide/kidsTheme.js
+++ b/src/content/features/sitewide/kidsTheme.js
@@ -20,11 +20,17 @@ const AGE_THEME_OPTIONS = [
         fallbackLabel: 'Roblox Select',
         value: 'select',
     },
+    {
+        labelKey: 'ageTheme.options.startmode',
+        fallbackLabel: 'Roblox Leaked Select (Start Mode)',
+        value: 'startmode',
+    },
 ];
 
 const AGE_THEME_CLASSES = [
     'age-roblox-theme',
     'age-kids-theme',
+    'age-select-theme',
     'age-startmode-theme',
 ];
 
@@ -32,7 +38,8 @@ let navbarInitialized = false;
 
 function getThemeClass(themeSelection) {
     if (themeSelection === 'kids') return 'age-kids-theme';
-    if (themeSelection === 'select') return 'age-startmode-theme';
+    if (themeSelection === 'startmode') return 'age-startmode-theme';
+    if (themeSelection === 'select') return 'age-select-theme'
     return 'age-roblox-theme';
 }
 

--- a/src/content/features/sitewide/kidsThemeText.js
+++ b/src/content/features/sitewide/kidsThemeText.js
@@ -15,6 +15,11 @@ const AGE_BADGE_TEXT_OPTIONS = [
         value: 'select',
     },
     {
+        labelKey: 'ageTheme.badge.select',
+        fallbackLabel: 'SELECT',
+        value: 'startmode',
+    },
+    {
         labelKey: 'ageTheme.badge.kids',
         fallbackLabel: 'KIDS',
         value: 'kids',

--- a/src/content/features/sitewide/kidsThemeText.js
+++ b/src/content/features/sitewide/kidsThemeText.js
@@ -7,6 +7,8 @@ const badgeClassToSelect = 'rbx-age-badge';
 const badgeClasses = badgeClassToSelect + ' items-center justify-center select-none height-400 padding-x-xsmall radius-small text-label-small margin-left-[6px] bg-[var(--color-content-emphasis)] content-[var(--color-surface-0)]';
 
 let currentBadgeContainerObserver = null
+let observerCalled = 0
+
 
 const AGE_BADGE_TEXT_OPTIONS = [
     {
@@ -113,7 +115,8 @@ export function makeBadgeChanges() {
             } else if (settings.ageKidsThemeEnabled && settings.ageThemeTextMatch) {
                 matchBadgeToTheme(settings.ageThemeSelection);
             }
-            if (currentBadgeContainerObserver) currentBadgeContainerObserver.disconnect();
+            if (currentBadgeContainerObserver && observerCalled >= 2) currentBadgeContainerObserver.disconnect();
+            else if (currentBadgeContainerObserver) observerCalled++;
         },
     );
 }
@@ -121,7 +124,7 @@ export function makeBadgeChanges() {
 export function init() {
     if (!document.body && !document.getElementById(ageBadgeContainerId)) return;
     if (currentBadgeContainerObserver) currentBadgeContainerObserver.disconnect();
+    makeBadgeChanges();
     currentBadgeContainerObserver = observeChildren(document.getElementById(ageBadgeContainerId), makeBadgeChanges);
     startObserving();
-    makeBadgeChanges();
 }

--- a/src/content/features/sitewide/kidsThemeText.js
+++ b/src/content/features/sitewide/kidsThemeText.js
@@ -108,7 +108,6 @@ export function makeBadgeChanges() {
             } else if (settings.ageKidsThemeEnabled && settings.ageThemeTextMatch) {
                 matchBadgeToTheme(settings.ageThemeSelection);
             }
-            console.log("meow :3")
             if (currentBadgeContainerObserver) currentBadgeContainerObserver.disconnect();
         },
     );

--- a/src/content/features/sitewide/kidsThemeText.js
+++ b/src/content/features/sitewide/kidsThemeText.js
@@ -1,0 +1,122 @@
+import DOMPurify from 'dompurify';
+import { observeChildren, startObserving } from '../../core/observer.js';
+import { t } from '../../core/locale/i18n.js';
+
+const ageBadgeContainerId = 'age-badge-container';
+const badgeClassToSelect = 'rbx-age-badge';
+const badgeClasses = badgeClassToSelect + ' items-center justify-center select-none height-400 padding-x-xsmall radius-small text-label-small margin-left-[6px] bg-[var(--color-content-emphasis)] content-[var(--color-surface-0)]';
+
+let currentBadgeContainerObserver = null
+
+const AGE_BADGE_TEXT_OPTIONS = [
+    {
+        labelKey: 'ageTheme.badge.select',
+        fallbackLabel: 'SELECT',
+        value: 'select',
+    },
+    {
+        labelKey: 'ageTheme.badge.kids',
+        fallbackLabel: 'KIDS',
+        value: 'kids',
+    },
+];
+
+async function getLocalizedThemeOptionsText() {
+    return Promise.all(
+        AGE_BADGE_TEXT_OPTIONS.map(async (option) => [
+            option.value,
+            (await t(option.labelKey).catch(() => option.fallbackLabel)).toLocaleUpperCase(),
+        ]),
+    ).then(entries => Object.fromEntries(entries));
+}
+
+async function hideBadge() {
+    const badgeContainer = document.getElementById(ageBadgeContainerId)
+    badgeContainer.style.display = 'none';
+    badgeContainer.style.visibility = 'hidden';
+}
+
+async function showBadge() {
+    const badgeContainer = document.getElementById(ageBadgeContainerId)
+    badgeContainer.style.display = null;
+    badgeContainer.style.visibility = null;
+}
+
+async function addBadge() {
+    const badgeContainer = document.getElementById(ageBadgeContainerId);
+    const newBadge = document.createElement('span');
+
+    if (!badgeContainer) return undefined;
+
+    newBadge.className = badgeClasses;
+    badgeContainer.appendChild(newBadge);
+
+    return newBadge;
+}
+
+async function editBadge(text) {
+    const cleanText = DOMPurify.sanitize(text)
+    const elementsWithBadgeClass =
+        document.getElementsByClassName(badgeClassToSelect);
+    const badgeElement = elementsWithBadgeClass.length >= 1
+        ? elementsWithBadgeClass[0]
+        : addBadge();
+
+    if (!badgeElement) return;
+
+    if (cleanText == '')
+        hideBadge();
+    else
+        showBadge();
+
+    badgeElement.textContent = cleanText
+}
+
+async function matchBadgeToTheme(theme) {
+    const badgeNames = await getLocalizedThemeOptionsText();
+    editBadge(badgeNames[theme])
+}
+
+export function makeBadgeChanges() {
+    chrome.storage.local.get(
+        {
+            // Age Theme Settings
+            ageKidsThemeEnabled: false,
+            ageThemeSelection: 'normal',
+            ageThemeTextMatch: true,
+
+            // Age Text Settings
+            ageKidsTextEnabled: false,
+            ageKidsTextInput: null,
+            ageKidsTextHiddenEnabled: false,
+        },
+        (settings) => {
+            if (
+                (
+                    !(settings.ageKidsThemeEnabled && settings.ageThemeTextMatch)
+                    && (!settings.ageKidsTextEnabled)
+                )
+                || !document.body
+            ) return;
+
+            if (settings.ageKidsTextEnabled && settings.ageKidsTextHiddenEnabled) {
+                chrome.storage.local.set({ ageThemeTextMatch: false });
+                hideBadge();
+            } else if (settings.ageKidsTextEnabled && !settings.ageKidsTextHiddenEnabled) {
+                chrome.storage.local.set({ ageThemeTextMatch: false });
+                editBadge(settings.ageKidsTextInput);
+            } else if (settings.ageKidsThemeEnabled && settings.ageThemeTextMatch) {
+                matchBadgeToTheme(settings.ageThemeSelection);
+            }
+            console.log("meow :3")
+            if (currentBadgeContainerObserver) currentBadgeContainerObserver.disconnect();
+        },
+    );
+}
+
+export function init() {
+    if (!document.body && !document.getElementById(ageBadgeContainerId)) return;
+    if (currentBadgeContainerObserver) currentBadgeContainerObserver.disconnect();
+    currentBadgeContainerObserver = observeChildren(document.getElementById(ageBadgeContainerId), makeBadgeChanges);
+    startObserving();
+}

--- a/src/content/features/sitewide/kidsThemeText.js
+++ b/src/content/features/sitewide/kidsThemeText.js
@@ -65,7 +65,7 @@ async function editBadge(text) {
         document.getElementsByClassName(badgeClassToSelect);
     const badgeElement = elementsWithBadgeClass.length >= 1
         ? elementsWithBadgeClass[0]
-        : addBadge();
+        : await addBadge();
 
     if (!badgeElement) return;
 
@@ -123,4 +123,5 @@ export function init() {
     if (currentBadgeContainerObserver) currentBadgeContainerObserver.disconnect();
     currentBadgeContainerObserver = observeChildren(document.getElementById(ageBadgeContainerId), makeBadgeChanges);
     startObserving();
+    makeBadgeChanges();
 }

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -38,6 +38,7 @@ import { initializeModernIcons as initModernIcons } from './features/sitewide/mo
 import { init as initLoginBanner } from './features/scamprevention/loginBanner.js';
 import { init as initLessPlus } from './features/sitewide/lessPlus.js';
 import { init as initKidsTheme } from './features/sitewide/kidsTheme.js';
+import { init as initKidsThemeText } from './features/sitewide/kidsThemeText.js'
 import { init as initSidebarCollapse } from './features/sitewide/sidebarCollapse.js';
 import { init as initRemoveDownloadButton } from './features/sitewide/removeDownloadButton.js';
 import { init as initPaymentMethodBonusItems } from './features/paymentmethods/bonusItems.js';
@@ -190,6 +191,7 @@ const featureRoutes = [
             initModernIcons,
             initLessPlus,
             initKidsTheme,
+            initKidsThemeText,
             initSidebarCollapse,
             initRemoveDownloadButton,
         ],
@@ -421,7 +423,7 @@ async function initializePage() {
     const startFeatures = async () => {
         const featureStartTime = performance.now();
 
-        await t('__i18n_ready__').catch(() => {});
+        await t('__i18n_ready__').catch(() => { });
         await refreshRemoteSettingLocks().catch((error) =>
             console.error(
                 'RoValra: Failed to refresh remote settings config.',
@@ -438,8 +440,8 @@ async function initializePage() {
             `%cRoValra Initialized`,
             'font-size: 1.5em; color: #FF4500;',
             `\n(Observer: ${observerStatus})` +
-                `\nFeature Load Time: ${(endTime - featureStartTime).toFixed(2)}ms` +
-                `\nTotal Load Time: ${(endTime - startTime).toFixed(2)}ms`,
+            `\nFeature Load Time: ${(endTime - featureStartTime).toFixed(2)}ms` +
+            `\nTotal Load Time: ${(endTime - startTime).toFixed(2)}ms`,
         );
     };
 
@@ -483,12 +485,12 @@ function setupUrlChangeListeners() {
     const originalPushState = history.pushState;
     const originalReplaceState = history.replaceState;
 
-    history.pushState = function (...args) {
+    history.pushState = function(...args) {
         originalPushState.apply(this, args);
         handleUrlChange();
     };
 
-    history.replaceState = function (...args) {
+    history.replaceState = function(...args) {
         originalReplaceState.apply(this, args);
         handleUrlChange();
     };

--- a/src/css/features/sitewide/kids_theme_text.scss
+++ b/src/css/features/sitewide/kids_theme_text.scss
@@ -1,0 +1,3 @@
+#age-badge-container {
+    width: max-content;
+}

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -28,3 +28,4 @@
 @use 'features/catalog/explorer.scss';
 @use 'components/robuxIcon.scss';
 @use 'features/sitewide/sidebar_collapse.scss';
+@use 'features/sitewide/kids_theme_text.scss';


### PR DESCRIPTION
add new age badge customization
- make it match with the custom age theme you have
- hide it entirely
- even put your own text in there yourself!
- adds new select theme
- puts old select theme behind a different option

Also adds me to contributers
and adds me as a contributer to the features I made

now presenting the worst code you have probably seen in your life!