### PR TITLE
Dim unowned game badges

### DIFF
--- a/src/content/core/settings/settingConfig.js
+++ b/src/content/core/settings/settingConfig.js
@@ -360,6 +360,15 @@ export const SETTINGS_CONFIG = {
                 type: 'checkbox',
                 default: true,
             },
+            badgeOwnershipEnabled: {
+                label: 'Dim Unowned Badges',
+                description: [
+                    "Makes experience badges you don't own darker on badge pages. (Similar to how BTRoblox does it)",
+                ],
+                type: 'checkbox',
+                default: true,
+                contributors: [546872490],
+            },
             updateHistoryEnabled: {
                 label: 'Update History',
                 description: [

--- a/src/content/features/games/badgeOwnership.js
+++ b/src/content/features/games/badgeOwnership.js
@@ -1,0 +1,194 @@
+import { callRobloxApi } from '../../core/api.js';
+import { getPlaceIdFromUrl } from '../../core/idExtractor.js';
+import { observeChildren, observeElement } from '../../core/observer.js';
+import { settings } from '../../core/settings/getSettings.js';
+import {
+    get as getCache,
+    set as setCache,
+} from '../../core/storage/cacheHandler.js';
+import { getAuthenticatedUserId } from '../../core/user.js';
+
+const ROW_SELECTOR =
+    ':scope > .stack-list:not(.rovalra-hidden-badges-list) > .stack-row.badge-row';
+const NOT_OWNED_CLASS = 'rovalra-badge-not-owned';
+const CACHE_SECTION = 'badge_ownership';
+const OWNERSHIP_BATCH_SIZE = 100;
+const UPDATE_DELAY_MS = 500;
+const OWNERSHIP_CACHE_MS = 5 * 60 * 1000;
+
+let initialized = false;
+const ownershipCache = new Map();
+const observedLists = new WeakSet();
+const updateTimers = new WeakMap();
+
+function getBadgeId(row) {
+    const href = row.querySelector('a[href*="/badges/"]')?.href;
+    return href?.match(/\/badges\/(\d+)/)?.[1] || null;
+}
+
+function getBadgeRows(container) {
+    return [...container.querySelectorAll(ROW_SELECTOR)];
+}
+
+function observeBadgeLists(container) {
+    container
+        .querySelectorAll(
+            ':scope > .stack-list:not(.rovalra-hidden-badges-list)',
+        )
+        .forEach((list) => {
+            if (observedLists.has(list)) return;
+            observedLists.add(list);
+            observeChildren(list, () =>
+                scheduleBadgeOwnershipUpdate(container),
+            );
+        });
+}
+
+function getCacheKey(userId, badgeId) {
+    return `${userId}:${badgeId}`;
+}
+
+function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function getRateLimitDelay(response) {
+    const retryAfterSeconds = Number(response.headers.get('retry-after'));
+    if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0) {
+        return retryAfterSeconds * 1000 + 1000;
+    }
+
+    const resetValue = Number(response.headers.get('x-ratelimit-reset'));
+    if (Number.isFinite(resetValue) && resetValue > 0) {
+        return (
+            (resetValue > 1e9
+                ? Math.max(0, resetValue * 1000 - Date.now())
+                : resetValue * 1000) + 1000
+        );
+    }
+
+    return 3000;
+}
+
+async function fetchAwardedDates(userId, badgeIds) {
+    const params = new URLSearchParams();
+    badgeIds.forEach((badgeId) => params.append('badgeIds', badgeId));
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+        const response = await callRobloxApi({
+            subdomain: 'badges',
+            endpoint: `/v1/users/${userId}/badges/awarded-dates?${params.toString()}`,
+        });
+
+        if (response.status === 429 && attempt < 2) {
+            await sleep(getRateLimitDelay(response));
+            continue;
+        }
+
+        if (!response.ok) return null;
+        return response.json();
+    }
+
+    return null;
+}
+
+async function fetchOwnedBadgeIds(userId, badgeIds) {
+    const uniqueBadgeIds = [...new Set(badgeIds.map(String))];
+
+    await Promise.all(
+        uniqueBadgeIds.map(async (badgeId) => {
+            const cacheKey = getCacheKey(userId, badgeId);
+            if (ownershipCache.has(cacheKey)) return;
+
+            const cached = await getCache(CACHE_SECTION, cacheKey, 'session');
+            if (!cached || cached.expiresAt <= Date.now()) return;
+
+            ownershipCache.set(cacheKey, cached.owned === true);
+        }),
+    );
+
+    const missingIds = uniqueBadgeIds.filter(
+        (badgeId) => !ownershipCache.has(getCacheKey(userId, badgeId)),
+    );
+
+    for (let i = 0; i < missingIds.length; i += OWNERSHIP_BATCH_SIZE) {
+        const batch = missingIds.slice(i, i + OWNERSHIP_BATCH_SIZE);
+        const data = await fetchAwardedDates(userId, batch);
+        if (!data) continue;
+
+        const ownedIds = new Set(
+            (data?.data || []).map((badge) => String(badge.badgeId)),
+        );
+
+        batch.forEach((badgeId) => {
+            const cacheKey = getCacheKey(userId, badgeId);
+            const owned = ownedIds.has(badgeId);
+            ownershipCache.set(cacheKey, owned);
+            void setCache(
+                CACHE_SECTION,
+                cacheKey,
+                { owned, expiresAt: Date.now() + OWNERSHIP_CACHE_MS },
+                'session',
+            );
+        });
+    }
+}
+
+async function updateBadgeOwnership(container) {
+    if (!getPlaceIdFromUrl()) return;
+
+    const userId = await getAuthenticatedUserId();
+    if (!userId) return;
+
+    const rows = getBadgeRows(container);
+    const badgeIds = rows.map(getBadgeId).filter(Boolean);
+    if (badgeIds.length === 0) return;
+
+    await fetchOwnedBadgeIds(userId, badgeIds);
+
+    getBadgeRows(container).forEach((row) => {
+        const badgeId = getBadgeId(row);
+        const ownsBadge = badgeId
+            ? ownershipCache.get(getCacheKey(userId, badgeId))
+            : undefined;
+
+        row.classList.toggle(NOT_OWNED_CLASS, ownsBadge === false);
+    });
+}
+
+function scheduleBadgeOwnershipUpdate(container) {
+    clearTimeout(updateTimers.get(container));
+    updateTimers.set(
+        container,
+        setTimeout(() => {
+            updateTimers.delete(container);
+            updateBadgeOwnership(container).catch((error) => {
+                console.warn('RoValra: Failed to check badge ownership', error);
+            });
+        }, UPDATE_DELAY_MS),
+    );
+}
+
+function setupBadgeOwnership(container) {
+    if (container.dataset.rovalraBadgeOwnershipAdded) return;
+    container.dataset.rovalraBadgeOwnershipAdded = 'true';
+
+    observeBadgeLists(container);
+    scheduleBadgeOwnershipUpdate(container);
+    observeChildren(container, () => {
+        observeBadgeLists(container);
+        scheduleBadgeOwnershipUpdate(container);
+    });
+}
+
+export async function init() {
+    if (initialized) return;
+    if ((await settings.badgeOwnershipEnabled) === false) return;
+    initialized = true;
+
+    observeElement('.game-badges-list', setupBadgeOwnership, {
+        multiple: true,
+    });
+}
+
+export default init;

--- a/src/content/features/games/badgeOwnership.js
+++ b/src/content/features/games/badgeOwnership.js
@@ -19,6 +19,7 @@ const OWNERSHIP_BATCH_SIZE = 100;
 const MAX_RETRIES = 3;
 const UPDATE_DELAY_MS = 500;
 const OWNERSHIP_CACHE_MS = 5 * 60 * 1000;
+const REQUEST_SPACING_MS = 1000;
 const COOLDOWN_MIN_MS = 30 * 1000;
 const COOLDOWN_MAX_MS = 60 * 1000;
 
@@ -58,19 +59,19 @@ function sleep(ms) {
     return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function clampCooldown(ms) {
-    return Math.min(Math.max(ms, 1000), COOLDOWN_MAX_MS);
+function normalizeDelay(ms) {
+    return Math.max(ms, 1000);
 }
 
 function getRateLimitDelay(response) {
     const retryAfterSeconds = Number(response.headers.get('retry-after'));
     if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0) {
-        return clampCooldown(retryAfterSeconds * 1000 + 1000);
+        return normalizeDelay(retryAfterSeconds * 1000 + 1000);
     }
 
     const resetValue = Number(response.headers.get('x-ratelimit-reset'));
     if (Number.isFinite(resetValue) && resetValue > 0) {
-        return clampCooldown(
+        return normalizeDelay(
             (resetValue > 1e9
                 ? Math.max(0, resetValue * 1000 - Date.now())
                 : resetValue * 1000) + 1000
@@ -95,23 +96,38 @@ async function getSharedCooldownDelay() {
     return Math.max(0, cooldownUntil - Date.now());
 }
 
-async function setSharedCooldown() {
+async function waitForSharedCooldown() {
+    const delay = await getSharedCooldownDelay();
+    if (delay > 0) {
+        await sleep(delay + Math.floor(Math.random() * 1000));
+    }
+}
+
+async function setSharedCooldown(delayMs) {
+    const cooldownUntil = Number(
+        await getCache(COOLDOWN_SECTION, COOLDOWN_KEY, CACHE_AREA),
+    );
+    const nextCooldownUntil = Date.now() + normalizeDelay(delayMs);
     await setCache(
         COOLDOWN_SECTION,
         COOLDOWN_KEY,
-        Date.now() + getFallbackCooldownDelay(),
+        Math.max(
+            Number.isFinite(cooldownUntil) ? cooldownUntil : 0,
+            nextCooldownUntil,
+        ),
         CACHE_AREA,
     );
 }
 
 async function fetchAwardedDates(userId, badgeIds) {
-    if ((await getSharedCooldownDelay()) > 0) return null;
-
     const params = new URLSearchParams();
     badgeIds.forEach((badgeId) => params.append('badgeIds', badgeId));
     let shouldCooldown = false;
 
     for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+        await waitForSharedCooldown();
+        await setSharedCooldown(REQUEST_SPACING_MS);
+
         let response;
         try {
             response = await callRobloxApi({
@@ -128,9 +144,11 @@ async function fetchAwardedDates(userId, badgeIds) {
         }
 
         if (response.status === 429) {
+            const retryDelay = getRateLimitDelay(response);
             shouldCooldown = true;
+            await setSharedCooldown(retryDelay);
             if (attempt < MAX_RETRIES - 1) {
-                await sleep(getRateLimitDelay(response));
+                await sleep(retryDelay);
                 continue;
             }
             break;
@@ -150,7 +168,7 @@ async function fetchAwardedDates(userId, badgeIds) {
     }
 
     if (shouldCooldown) {
-        await setSharedCooldown();
+        await setSharedCooldown(getFallbackCooldownDelay());
     }
 
     return null;

--- a/src/content/features/games/badgeOwnership.js
+++ b/src/content/features/games/badgeOwnership.js
@@ -12,9 +12,15 @@ const ROW_SELECTOR =
     ':scope > .stack-list:not(.rovalra-hidden-badges-list) > .stack-row.badge-row';
 const NOT_OWNED_CLASS = 'rovalra-badge-not-owned';
 const CACHE_SECTION = 'badge_ownership';
+const COOLDOWN_SECTION = 'badge_ownership_cooldown';
+const COOLDOWN_KEY = 'awarded_dates';
+const CACHE_AREA = 'local';
 const OWNERSHIP_BATCH_SIZE = 100;
+const MAX_RETRIES = 3;
 const UPDATE_DELAY_MS = 500;
 const OWNERSHIP_CACHE_MS = 5 * 60 * 1000;
+const COOLDOWN_MIN_MS = 30 * 1000;
+const COOLDOWN_MAX_MS = 60 * 1000;
 
 let initialized = false;
 const ownershipCache = new Map();
@@ -52,15 +58,19 @@ function sleep(ms) {
     return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function clampCooldown(ms) {
+    return Math.min(Math.max(ms, 1000), COOLDOWN_MAX_MS);
+}
+
 function getRateLimitDelay(response) {
     const retryAfterSeconds = Number(response.headers.get('retry-after'));
     if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0) {
-        return retryAfterSeconds * 1000 + 1000;
+        return clampCooldown(retryAfterSeconds * 1000 + 1000);
     }
 
     const resetValue = Number(response.headers.get('x-ratelimit-reset'));
     if (Number.isFinite(resetValue) && resetValue > 0) {
-        return (
+        return clampCooldown(
             (resetValue > 1e9
                 ? Math.max(0, resetValue * 1000 - Date.now())
                 : resetValue * 1000) + 1000
@@ -70,42 +80,117 @@ function getRateLimitDelay(response) {
     return 3000;
 }
 
+function getFallbackCooldownDelay() {
+    return (
+        COOLDOWN_MIN_MS +
+        Math.floor(Math.random() * (COOLDOWN_MAX_MS - COOLDOWN_MIN_MS))
+    );
+}
+
+async function getSharedCooldownDelay() {
+    const cooldownUntil = Number(
+        await getCache(COOLDOWN_SECTION, COOLDOWN_KEY, CACHE_AREA),
+    );
+    if (!Number.isFinite(cooldownUntil)) return 0;
+    return Math.max(0, cooldownUntil - Date.now());
+}
+
+async function setSharedCooldown() {
+    await setCache(
+        COOLDOWN_SECTION,
+        COOLDOWN_KEY,
+        Date.now() + getFallbackCooldownDelay(),
+        CACHE_AREA,
+    );
+}
+
 async function fetchAwardedDates(userId, badgeIds) {
+    if ((await getSharedCooldownDelay()) > 0) return null;
+
     const params = new URLSearchParams();
     badgeIds.forEach((badgeId) => params.append('badgeIds', badgeId));
+    let shouldCooldown = false;
 
-    for (let attempt = 0; attempt < 3; attempt++) {
-        const response = await callRobloxApi({
-            subdomain: 'badges',
-            endpoint: `/v1/users/${userId}/badges/awarded-dates?${params.toString()}`,
-        });
+    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+        let response;
+        try {
+            response = await callRobloxApi({
+                subdomain: 'badges',
+                endpoint: `/v1/users/${userId}/badges/awarded-dates?${params.toString()}`,
+            });
+        } catch {
+            shouldCooldown = true;
+            if (attempt < MAX_RETRIES - 1) {
+                await sleep(1000);
+                continue;
+            }
+            break;
+        }
 
-        if (response.status === 429 && attempt < 2) {
-            await sleep(getRateLimitDelay(response));
-            continue;
+        if (response.status === 429) {
+            shouldCooldown = true;
+            if (attempt < MAX_RETRIES - 1) {
+                await sleep(getRateLimitDelay(response));
+                continue;
+            }
+            break;
+        }
+
+        if (response.status >= 500) {
+            shouldCooldown = true;
+            if (attempt < MAX_RETRIES - 1) {
+                await sleep(1000);
+                continue;
+            }
+            break;
         }
 
         if (!response.ok) return null;
-        return response.json();
+        return response.json().catch(() => null);
+    }
+
+    if (shouldCooldown) {
+        await setSharedCooldown();
     }
 
     return null;
 }
 
+async function loadCachedBadgeOwnership(userId, badgeIds) {
+    const cached =
+        (await getCache(CACHE_SECTION, String(userId), CACHE_AREA)) || {};
+    const now = Date.now();
+
+    badgeIds.forEach((badgeId) => {
+        const cacheKey = getCacheKey(userId, badgeId);
+        if (ownershipCache.has(cacheKey)) return;
+
+        const entry = cached[badgeId];
+        if (!entry || entry.expiresAt <= now) return;
+
+        ownershipCache.set(cacheKey, entry.owned === true);
+    });
+}
+
+async function cacheBadgeOwnershipBatch(userId, badgeIds, ownedIds) {
+    const cached =
+        (await getCache(CACHE_SECTION, String(userId), CACHE_AREA)) || {};
+    const expiresAt = Date.now() + OWNERSHIP_CACHE_MS;
+
+    badgeIds.forEach((badgeId) => {
+        const cacheKey = getCacheKey(userId, badgeId);
+        const owned = ownedIds.has(badgeId);
+        ownershipCache.set(cacheKey, owned);
+        cached[badgeId] = { owned, expiresAt };
+    });
+
+    await setCache(CACHE_SECTION, String(userId), cached, CACHE_AREA);
+}
+
 async function fetchOwnedBadgeIds(userId, badgeIds) {
     const uniqueBadgeIds = [...new Set(badgeIds.map(String))];
 
-    await Promise.all(
-        uniqueBadgeIds.map(async (badgeId) => {
-            const cacheKey = getCacheKey(userId, badgeId);
-            if (ownershipCache.has(cacheKey)) return;
-
-            const cached = await getCache(CACHE_SECTION, cacheKey, 'session');
-            if (!cached || cached.expiresAt <= Date.now()) return;
-
-            ownershipCache.set(cacheKey, cached.owned === true);
-        }),
-    );
+    await loadCachedBadgeOwnership(userId, uniqueBadgeIds);
 
     const missingIds = uniqueBadgeIds.filter(
         (badgeId) => !ownershipCache.has(getCacheKey(userId, badgeId)),
@@ -120,17 +205,7 @@ async function fetchOwnedBadgeIds(userId, badgeIds) {
             (data?.data || []).map((badge) => String(badge.badgeId)),
         );
 
-        batch.forEach((badgeId) => {
-            const cacheKey = getCacheKey(userId, badgeId);
-            const owned = ownedIds.has(badgeId);
-            ownershipCache.set(cacheKey, owned);
-            void setCache(
-                CACHE_SECTION,
-                cacheKey,
-                { owned, expiresAt: Date.now() + OWNERSHIP_CACHE_MS },
-                'session',
-            );
-        });
+        await cacheBadgeOwnershipBatch(userId, batch, ownedIds);
     }
 }
 

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -67,6 +67,7 @@ import { init as initBotDetector } from './features/games/about/botDetector.js';
 import { init as initQuickPlay } from './features/games/quickplay.js';
 import { init as initHiddenBadges } from './features/games/hiddenBadges.js';
 import { init as initBadgeLayoutToggle } from './features/games/badgeLayoutToggle.js';
+import { init as initBadgeOwnership } from './features/games/badgeOwnership.js';
 import { init as initServerList } from './features/games/serverlist/serverlist.js';
 import { initRecentServers } from './features/games/serverlist/recentservers.js';
 import { init as initRegionPlayButton } from './features/games/RegionPlayButton.js';
@@ -287,6 +288,7 @@ const featureRoutes = [
             initEvents,
             initHiddenBadges,
             initBadgeLayoutToggle,
+            initBadgeOwnership,
         ],
     },
     // Private games page

--- a/src/css/features/games/badgeLayoutToggle.scss
+++ b/src/css/features/games/badgeLayoutToggle.scss
@@ -202,4 +202,9 @@
     &:not(.rovalra-badge-grid-view) .rovalra-badge-grid-stats {
         display: none !important;
     }
+
+    .rovalra-badge-not-owned {
+        opacity: 0.45;
+        filter: grayscale(0.85) brightness(0.72);
+    }
 }


### PR DESCRIPTION
> This Pull Request came from this suggestion from the RoValra's server - suggestion thread id: 1522674127675195482

## This makes badges that you don't own dim/darker just like in BTRoblox, and makes it a toggle'able setting inside the experiences tab

It can be improved, because it might **NOT** work if you open a __few tabs__ with games and then check the badges, as the **API Ratelimit**s you and then the feature cannot compare the badges making them **NOT** Dimmed.

But when __normally__ *using* the website, and going on game pages, it never happened to me.