### PR TITLE
Combine community funds with navbar balance

### DIFF
--- a/src/content/core/settings/settingConfig.js
+++ b/src/content/core/settings/settingConfig.js
@@ -1663,6 +1663,13 @@ export const SETTINGS_CONFIG = {
                 default: false,
                 storageKey: 'rovalra-group-funds-data',
                 childSettings: {
+                    GroupFundsNavbarTotalEnabled: {
+                        label: 'Combine Community Funds with Robux Balance',
+                        description:
+                            'Combines your Robux balance with your configured community funds in the navbar. Click the balance to see your Robux and each community separately.',
+                        type: 'checkbox',
+                        default: false,
+                    },
                     GroupFundsIds: {
                         label: 'Community IDs',
                         description:

--- a/src/content/core/settings/settingConfig.js
+++ b/src/content/core/settings/settingConfig.js
@@ -1669,6 +1669,7 @@ export const SETTINGS_CONFIG = {
                             'Combines your Robux balance with your configured community funds in the navbar. Click the balance to see your Robux and each community separately.',
                         type: 'checkbox',
                         default: false,
+                        contributors: ['278039610'],
                     },
                     GroupFundsIds: {
                         label: 'Community IDs',

--- a/src/content/core/ui/robuxIcon.js
+++ b/src/content/core/ui/robuxIcon.js
@@ -37,6 +37,7 @@ const IGNORE_USD_SELECTOR =
 
 const INLINE_FIAT_LOCATIONS = '#navbar-robux, #buy-robux-popover';
 const TOOLTIP_FIAT_LOCATIONS = '#rovalra-stat-robux';
+const NAVBAR_BALANCE_UPDATED_EVENT = 'rovalra:navbar-balance-updated';
 
 let robuxPricingPromise = null;
 let robuxIconInitialized = false;
@@ -223,6 +224,13 @@ function shouldUseTrackedNavbarCurrency(element) {
 
 async function resolveEstimateRobuxAmount(element, amount) {
     if (shouldUseTrackedNavbarCurrency(element)) {
+        const explicitNavbarAmount = Number(
+            element.dataset.rovalraNavbarRobuxAmount,
+        );
+        if (Number.isFinite(explicitNavbarAmount) && explicitNavbarAmount > 0) {
+            return explicitNavbarAmount;
+        }
+
         const currencyData = await getCachedUserCurrency();
         const trackedRobux = Number(currencyData?.robux);
         if (Number.isFinite(trackedRobux) && trackedRobux > 0) {
@@ -906,6 +914,11 @@ export function init() {
 
     document.addEventListener(USER_CURRENCY_CHANGED_EVENT, () => {
         scheduleUsdRefresh(0);
+    });
+
+    document.addEventListener(NAVBAR_BALANCE_UPDATED_EVENT, () => {
+        scheduleUsdRefresh(0);
+        scheduleUsdRefresh(50);
     });
 
     observeElement(

--- a/src/content/features/navigation/groupfunds.js
+++ b/src/content/features/navigation/groupfunds.js
@@ -30,6 +30,8 @@ const state = {
 
 const activeGroupRequests = new Map();
 let currentUserMenuDataPromise = null;
+let personalRowData = null;
+let personalRowDataPromise = null;
 
 function sanitizeGroupIds(groupIds) {
     if (!Array.isArray(groupIds)) return [];
@@ -234,6 +236,109 @@ async function getPersonalRobuxBalance() {
     return Number.isFinite(freshBalance) ? freshBalance : null;
 }
 
+function shouldWarmPersonalRowData() {
+    return (
+        state.groupFundsEnabled &&
+        state.navbarTotalEnabled &&
+        !state.hideRobux
+    );
+}
+
+async function warmPersonalRowData() {
+    if (!shouldWarmPersonalRowData()) return null;
+    if (personalRowDataPromise) return personalRowDataPromise;
+
+    personalRowDataPromise = (async () => {
+        const [userResult, balanceResult] = await Promise.allSettled([
+            getCurrentUserMenuData(),
+            getPersonalRobuxBalance(),
+        ]);
+
+        if (!shouldWarmPersonalRowData()) return null;
+
+        const userData =
+            userResult.status === 'fulfilled' ? userResult.value : null;
+        const personalBalance =
+            balanceResult.status === 'fulfilled'
+                ? Number(balanceResult.value)
+                : NaN;
+
+        personalRowData = {
+            userId: userData?.userId || personalRowData?.userId || null,
+            username: userData?.username || personalRowData?.username || 'User',
+            thumbnailData:
+                userData?.thumbnailData || personalRowData?.thumbnailData || null,
+            personalBalance: Number.isFinite(personalBalance)
+                ? personalBalance
+                : personalRowData?.personalBalance,
+        };
+
+        return personalRowData;
+    })().finally(() => {
+        personalRowDataPromise = null;
+    });
+
+    return personalRowDataPromise;
+}
+
+function upsertPersonalRow(section, divider, data) {
+    if (state.hideRobux || !data) return;
+
+    const personalBalance = Number(data.personalBalance);
+    if (!Number.isFinite(personalBalance)) return;
+
+    let userLi = section.querySelector('.rovalra-personal-robux-row');
+    if (!(userLi instanceof HTMLElement)) {
+        userLi = document.createElement('li');
+        userLi.className = 'rovalra-personal-robux-row';
+        section.insertBefore(userLi, divider.nextSibling);
+    }
+
+    userLi.textContent = '';
+
+    const userLink = document.createElement('a');
+    userLink.className = 'rbx-menu-item';
+    if (data.userId) {
+        userLink.href = `https://www.roblox.com/users/${data.userId}/profile`;
+    }
+    userLink.style.display = 'flex';
+    userLink.style.alignItems = 'center';
+    userLink.style.justifyContent = 'space-between';
+
+    const leftContainer = document.createElement('div');
+    leftContainer.style.display = 'flex';
+    leftContainer.style.alignItems = 'center';
+
+    const iconContainer = document.createElement('span');
+    iconContainer.style.width = '28px';
+    iconContainer.style.height = '28px';
+    iconContainer.style.marginRight = '8px';
+    iconContainer.style.display = 'inline-block';
+
+    if (data.thumbnailData) {
+        const img = createThumbnailElement(data.thumbnailData, 'User', '', {
+            borderRadius: '999px',
+            width: '28px',
+            height: '28px',
+        });
+        iconContainer.appendChild(img);
+    }
+
+    const nameSpan = document.createElement('span');
+    nameSpan.textContent = data.username || 'User';
+
+    const amountSpan = document.createElement('span');
+    const rbxIcon = document.createElement('span');
+    rbxIcon.className = 'icon-robux-16x16';
+    rbxIcon.style.verticalAlign = 'text-bottom';
+    rbxIcon.style.marginRight = '3px';
+    amountSpan.append(rbxIcon, personalBalance.toLocaleString());
+
+    leftContainer.append(iconContainer, nameSpan);
+    userLink.append(leftContainer, amountSpan);
+    userLi.appendChild(userLink);
+}
+
 async function restorePersonalNavbarBalance() {
     const robux = await getPersonalRobuxBalance();
     let restoredAny = false;
@@ -316,6 +421,10 @@ async function syncSettingsAndRender() {
         await ensureFreshDataForConfiguredGroups();
     }
 
+    if (shouldWarmPersonalRowData()) {
+        warmPersonalRowData().catch(() => {});
+    }
+
     await renderNavbarTotal();
 }
 
@@ -323,7 +432,7 @@ export function init() {
     if (state.initialized) return;
     state.initialized = true;
 
-    const renderSection = async (popover) => {
+    const renderSection = (popover) => {
         const menu = popover.querySelector('.dropdown-menu');
         if (!menu) return;
 
@@ -336,7 +445,7 @@ export function init() {
 
         if (!state.groupFundsEnabled || state.groupIds.length === 0) return;
 
-        const allCachedData = await getCache();
+        const allCachedDataPromise = getCache();
 
         const section = document.createElement('div');
         section.className = 'rovalra-group-funds-section';
@@ -346,64 +455,15 @@ export function init() {
         section.appendChild(divider);
 
         if (state.navbarTotalEnabled && !state.hideRobux) {
-            const userData = await getCurrentUserMenuData().catch(() => null);
-            const personalBalance = await getPersonalRobuxBalance();
+            upsertPersonalRow(section, divider, personalRowData);
 
-            if (
-                state.renderVersion === myVersion &&
-                userData &&
-                Number.isFinite(personalBalance)
-            ) {
-                const userLi = document.createElement('li');
-                const userLink = document.createElement('a');
-                userLink.className = 'rbx-menu-item';
-                userLink.href = `https://www.roblox.com/users/${userData.userId}/profile`;
-                userLink.style.display = 'flex';
-                userLink.style.alignItems = 'center';
-                userLink.style.justifyContent = 'space-between';
-
-                const leftContainer = document.createElement('div');
-                leftContainer.style.display = 'flex';
-                leftContainer.style.alignItems = 'center';
-
-                const iconContainer = document.createElement('span');
-                iconContainer.style.width = '28px';
-                iconContainer.style.height = '28px';
-                iconContainer.style.marginRight = '8px';
-                iconContainer.style.display = 'inline-block';
-
-                if (userData.thumbnailData) {
-                    const img = createThumbnailElement(
-                        userData.thumbnailData,
-                        'User',
-                        '',
-                        {
-                            borderRadius: '999px',
-                            width: '28px',
-                            height: '28px',
-                        },
-                    );
-                    iconContainer.appendChild(img);
-                }
-
-                const nameSpan = document.createElement('span');
-                nameSpan.textContent = userData.username;
-
-                const amountSpan = document.createElement('span');
-                const rbxIcon = document.createElement('span');
-                rbxIcon.className = 'icon-robux-16x16';
-                rbxIcon.style.verticalAlign = 'text-bottom';
-                rbxIcon.style.marginRight = '3px';
-                amountSpan.append(rbxIcon, personalBalance.toLocaleString());
-
-                leftContainer.append(iconContainer, nameSpan);
-                userLink.append(leftContainer, amountSpan);
-                userLi.appendChild(userLink);
-                section.appendChild(userLi);
-            }
+            warmPersonalRowData().then((data) => {
+                if (state.renderVersion !== myVersion) return;
+                upsertPersonalRow(section, divider, data);
+            });
         }
 
-        const renderGroup = async (groupId) => {
+        const renderGroup = (groupId) => {
             const fundsLi = document.createElement('li');
             const fundsLink = document.createElement('a');
             fundsLink.className = 'rbx-menu-item';
@@ -495,38 +555,41 @@ export function init() {
                 if (data.pending !== undefined) renderPending(data.pending);
             };
 
-            const cachedData = allCachedData[groupId];
+            amountSpan.textContent = ts('groupFunds.loading');
 
-            if (cachedData) {
-                updateFromData(cachedData);
-            } else {
-                amountSpan.textContent = ts('groupFunds.loading');
-            }
+            allCachedDataPromise.then(async (allCachedData) => {
+                if (state.renderVersion !== myVersion) return;
 
-            if (cachedData && isCacheFresh(cachedData)) {
-                return;
-            }
+                const cachedData = allCachedData[groupId];
 
-            const freshData = await fetchAndCacheGroupData(groupId);
+                if (cachedData) {
+                    updateFromData(cachedData);
+                }
 
-            if (state.renderVersion !== myVersion) return;
+                if (cachedData && isCacheFresh(cachedData)) {
+                    return;
+                }
 
-            if (freshData) {
-                updateFromData(freshData);
-                return;
-            }
+                const freshData = await fetchAndCacheGroupData(groupId);
 
-            if (!cachedData) {
-                amountSpan.textContent = ts('groupFunds.noPermissions');
-                pendingLink.textContent = '';
-            }
+                if (state.renderVersion !== myVersion) return;
+
+                if (freshData) {
+                    updateFromData(freshData);
+                    return;
+                }
+
+                if (!cachedData) {
+                    amountSpan.textContent = ts('groupFunds.noPermissions');
+                    pendingLink.textContent = '';
+                }
+            });
         };
 
         state.groupIds.forEach((groupId) => {
             renderGroup(groupId);
         });
 
-        if (state.renderVersion !== myVersion) return;
         menu.appendChild(section);
     };
 
@@ -580,12 +643,15 @@ export function init() {
         ) {
             syncSettingsAndRender().catch(() => {});
             if (openPopover) {
-                renderSection(openPopover).catch(() => {});
+                renderSection(openPopover);
             }
         }
     });
 
     document.addEventListener(USER_CURRENCY_CHANGED_EVENT, () => {
+        if (shouldWarmPersonalRowData()) {
+            warmPersonalRowData().catch(() => {});
+        }
         renderNavbarTotal().catch(() => {});
     });
 

--- a/src/content/features/navigation/groupfunds.js
+++ b/src/content/features/navigation/groupfunds.js
@@ -271,8 +271,13 @@ async function renderNavbarTotal() {
         return;
     }
 
-    if (state.groupIds.length === 0 || state.hideRobux) {
+    if (state.groupIds.length === 0) {
         await restorePersonalNavbarBalance();
+        return;
+    }
+
+    if (state.hideRobux) {
+        clearNavbarOverride();
         return;
     }
 
@@ -340,7 +345,7 @@ export function init() {
         divider.className = 'rbx-divider';
         section.appendChild(divider);
 
-        if (state.navbarTotalEnabled) {
+        if (state.navbarTotalEnabled && !state.hideRobux) {
             const userData = await getCurrentUserMenuData().catch(() => null);
             const personalBalance = await getPersonalRobuxBalance();
 

--- a/src/content/features/navigation/groupfunds.js
+++ b/src/content/features/navigation/groupfunds.js
@@ -272,14 +272,14 @@ async function renderNavbarTotal() {
     }
 
     if (state.groupIds.length === 0 || state.hideRobux) {
-        clearNavbarOverride();
+        await restorePersonalNavbarBalance();
         return;
     }
 
     const personalRobux = await getPersonalRobuxBalance();
 
     if (!Number.isFinite(personalRobux)) {
-        clearNavbarOverride();
+        await restorePersonalNavbarBalance();
         return;
     }
 

--- a/src/content/features/navigation/groupfunds.js
+++ b/src/content/features/navigation/groupfunds.js
@@ -4,252 +4,589 @@ import { ts } from '../../core/locale/i18n.js';
 import {
     fetchThumbnails,
     createThumbnailElement,
+    getBatchThumbnails,
 } from '../../core/thumbnail/thumbnails.js';
+import {
+    getCachedUserCurrency,
+    getUserCurrency,
+} from '../../core/user/userCurrency.js';
+import { USER_CURRENCY_CHANGED_EVENT } from '../../core/utils/trackers/currency.js';
+import { getAuthenticatedUserId } from '../../core/user.js';
+import { getUserName } from '../../core/apis/users.js';
 
-export function init() {
-    if (init._run) return;
-    init._run = true;
+const CACHE_KEY = 'rovalra-group-funds-data';
+const CACHE_DURATION = 5 * 60 * 1000;
+const NAVBAR_SELECTORS = '#nav-robux-amount, #nav-robux-balance';
+const NAVBAR_BALANCE_UPDATED_EVENT = 'rovalra:navbar-balance-updated';
 
-    chrome.storage.local.get(
-        { GroupFundsEnabled: false, GroupFundsIds: [] },
-        (settings) => {
-            let groupIds = settings.GroupFundsIds;
+const state = {
+    initialized: false,
+    groupFundsEnabled: false,
+    navbarTotalEnabled: false,
+    groupIds: [],
+    hideRobux: false,
+    renderVersion: 0,
+};
 
-            if (Array.isArray(groupIds)) {
-                groupIds = groupIds.filter((id) => id && id.trim() !== '');
-            }
+const activeGroupRequests = new Map();
+let currentUserMenuDataPromise = null;
 
-            if (
-                !settings.GroupFundsEnabled ||
-                !groupIds ||
-                groupIds.length === 0
-            )
-                return;
+function sanitizeGroupIds(groupIds) {
+    if (!Array.isArray(groupIds)) return [];
 
-            const cacheKey = 'rovalra-group-funds-data';
-            let version = 0;
+    return groupIds.filter((id) => id && String(id).trim() !== '');
+}
 
-            const renderSection = async (popover) => {
-                const menu = popover.querySelector('.dropdown-menu');
-                if (!menu) return;
+function getSettings() {
+    return new Promise((resolve) => {
+        chrome.storage.local.get(
+            {
+                GroupFundsEnabled: false,
+                GroupFundsNavbarTotalEnabled: false,
+                GroupFundsIds: [],
+                streamermode: false,
+                hideRobux: false,
+            },
+            resolve,
+        );
+    });
+}
 
-                version++;
-                const myVersion = version;
+function getCache() {
+    return new Promise((resolve) => {
+        chrome.storage.local.get(CACHE_KEY, (data) => {
+            resolve(data[CACHE_KEY] || {});
+        });
+    });
+}
 
-                menu.querySelectorAll('.rovalra-group-funds-section').forEach(
-                    (el) => el.remove(),
-                );
+function setCache(cache) {
+    chrome.storage.local.set({ [CACHE_KEY]: cache });
+}
 
-                const storageData = await new Promise((resolve) =>
-                    chrome.storage.local.get(cacheKey, resolve),
-                );
-                const allCachedData = storageData[cacheKey] || {};
+function isCacheFresh(entry) {
+    return (
+        entry &&
+        Number.isFinite(Number(entry.timestamp)) &&
+        Date.now() - entry.timestamp < CACHE_DURATION
+    );
+}
 
-                const section = document.createElement('div');
-                section.className = 'rovalra-group-funds-section';
+async function fetchAndCacheGroupData(groupId) {
+    if (activeGroupRequests.has(groupId)) {
+        return activeGroupRequests.get(groupId);
+    }
 
-                const divider = document.createElement('li');
-                divider.className = 'rbx-divider';
-                section.appendChild(divider);
+    const request = (async () => {
+        const cache = await getCache();
+        const cachedData = cache[groupId] || null;
 
-                const renderGroup = async (groupId) => {
-                    const fundsLi = document.createElement('li');
-                    const fundsLink = document.createElement('a');
-                    fundsLink.className = 'rbx-menu-item';
-                    fundsLink.href = `https://www.roblox.com/groups/configure?id=${groupId}#!/revenue/summary`;
-                    fundsLink.style.display = 'flex';
-                    fundsLink.style.alignItems = 'center';
-
-                    const leftContainer = document.createElement('div');
-                    leftContainer.style.display = 'flex';
-                    leftContainer.style.alignItems = 'center';
-
-                    const iconContainer = document.createElement('span');
-                    iconContainer.style.width = '28px';
-                    iconContainer.style.height = '28px';
-                    iconContainer.style.marginRight = '8px';
-                    iconContainer.style.display = 'inline-block';
-
-                    leftContainer.appendChild(iconContainer);
-
-                    fundsLink.appendChild(leftContainer);
-
-                    const amountSpan = document.createElement('span');
-                    fundsLink.appendChild(amountSpan);
-
-                    fundsLi.appendChild(fundsLink);
-                    section.appendChild(fundsLi);
-
-                    const pendingLi = document.createElement('li');
-                    const pendingLink = document.createElement('a');
-                    pendingLink.className = 'rbx-menu-item';
-                    pendingLink.style.paddingTop = '0';
-                    pendingLink.style.paddingBottom = '5px';
-                    pendingLink.style.fontSize = '12px';
-                    pendingLink.style.color = 'gray';
-                    pendingLink.style.textAlign = 'right';
-                    pendingLink.style.pointerEvents = 'none';
-                    pendingLink.textContent = '';
-                    pendingLi.appendChild(pendingLink);
-                    section.appendChild(pendingLi);
-
-                    const renderIcon = (data) => {
-                        if (data) {
-                            const img = createThumbnailElement(
-                                data,
-                                'Group',
-                                '',
-                                {
-                                    borderRadius: '8px',
-                                    width: '28px',
-                                    height: '28px',
-                                },
-                            );
-                            iconContainer.innerHTML = '';
-                            iconContainer.appendChild(img);
-                        }
-                    };
-
-                    const renderFunds = (amount) => {
-                        amountSpan.innerHTML = '';
-                        const rbxIcon = document.createElement('span');
-                        rbxIcon.className = 'icon-robux-16x16';
-                        rbxIcon.style.verticalAlign = 'text-bottom';
-                        rbxIcon.style.marginRight = '3px';
-
-                        const text = document.createTextNode(
-                            amount.toLocaleString(),
-                        );
-
-                        amountSpan.appendChild(rbxIcon);
-                        amountSpan.appendChild(text);
-                    };
-
-                    const renderPending = (amount) => {
-                        pendingLink.innerHTML = '';
-                        const label = document.createTextNode(
-                            ts('groupFunds.pending') + ' ',
-                        );
-                        const icon = document.createElement('span');
-                        icon.className = 'icon-robux-16x16';
-                        icon.style.verticalAlign = 'text-bottom';
-                        icon.style.marginLeft = '3px';
-                        icon.style.marginRight = '2px';
-                        icon.style.filter = 'grayscale(100%) opacity(0.6)';
-                        const value = document.createTextNode(
-                            amount.toLocaleString(),
-                        );
-
-                        pendingLink.append(label, icon, value);
-                    };
-
-                    const updateFromData = (data) => {
-                        if (data.icon) renderIcon(data.icon);
-                        if (data.funds !== undefined) renderFunds(data.funds);
-                        if (data.pending !== undefined)
-                            renderPending(data.pending);
-                    };
-
-                    const cachedData = allCachedData[groupId];
-
-                    if (cachedData) {
-                        updateFromData(cachedData);
-                    } else {
-                        amountSpan.textContent = ts('groupFunds.loading');
+        try {
+            const [iconData, fundsData, pendingData] = await Promise.all([
+                fetchThumbnails(
+                    [{ id: groupId }],
+                    'GroupIcon',
+                    '150x150',
+                    false,
+                ).then((map) => map.get(parseInt(groupId, 10))),
+                callRobloxApiJson({
+                    subdomain: 'economy',
+                    endpoint: `/v1/groups/${groupId}/currency`,
+                }).then((data) => {
+                    if (data.robux === undefined) {
+                        throw new Error('Unauthorized');
                     }
+                    return data.robux;
+                }),
+                callRobloxApiJson({
+                    subdomain: 'apis',
+                    endpoint: `/transaction-records/v1/groups/${groupId}/revenue/summary/day`,
+                }).then((data) => data.pendingRobux || 0),
+            ]);
 
-                    const CACHE_DURATION = 5 * 60 * 1000;
-
-                    if (
-                        cachedData &&
-                        Date.now() - cachedData.timestamp < CACHE_DURATION
-                    ) {
-                        return;
-                    }
-
-                    try {
-                        const [iconData, fundsData, pendingData] =
-                            await Promise.all([
-                                fetchThumbnails(
-                                    [{ id: groupId }],
-                                    'GroupIcon',
-                                    '150x150',
-                                    false,
-                                ).then((map) => map.get(parseInt(groupId))),
-                                callRobloxApiJson({
-                                    subdomain: 'economy',
-                                    endpoint: `/v1/groups/${groupId}/currency`,
-                                }).then((data) => {
-                                    if (data.robux === undefined) {
-                                        throw new Error('Unauthorized');
-                                    }
-                                    return data.robux;
-                                }),
-                                callRobloxApiJson({
-                                    subdomain: 'apis',
-                                    endpoint: `/transaction-records/v1/groups/${groupId}/revenue/summary/day`,
-                                }).then((data) => data.pendingRobux || 0),
-                            ]);
-
-                        if (version !== myVersion) return;
-
-                        const newEntry = {
-                            icon: iconData,
-                            funds: fundsData,
-                            pending: pendingData,
-                            timestamp: Date.now(),
-                        };
-
-                        updateFromData(newEntry);
-
-                        const freshStorage = await new Promise((resolve) =>
-                            chrome.storage.local.get(cacheKey, resolve),
-                        );
-                        const freshCache = freshStorage[cacheKey] || {};
-                        freshCache[groupId] = newEntry;
-                        chrome.storage.local.set({ [cacheKey]: freshCache });
-                    } catch (e) {
-                        if (version !== myVersion) return;
-                        console.warn(
-                            'RoValra: Failed to update group funds data',
-                            e,
-                        );
-                        if (!cachedData) {
-                            amountSpan.textContent = ts(
-                                'groupFunds.noPermissions',
-                            );
-                            pendingLink.textContent = '';
-                        }
-                    }
-                };
-
-                if (version !== myVersion) return;
-
-                groupIds.forEach((id) => renderGroup(id));
-
-                menu.appendChild(section);
+            const newEntry = {
+                icon: iconData,
+                funds: fundsData,
+                pending: pendingData,
+                timestamp: Date.now(),
             };
 
-            observeElement(
-                '#buy-robux-popover',
-                (popover) => {
-                    const menu = popover.querySelector('.dropdown-menu');
-                    if (
-                        menu &&
-                        menu.querySelector('.rovalra-group-funds-section')
-                    )
-                        return;
-                    renderSection(popover);
-                },
-                {
-                    onRemove: () => {
-                        version++;
-                        document
-                            .querySelectorAll('.rovalra-group-funds-section')
-                            .forEach((el) => el.remove());
-                    },
-                },
-            );
+            const freshCache = await getCache();
+            freshCache[groupId] = newEntry;
+            setCache(freshCache);
+
+            return newEntry;
+        } catch (error) {
+            console.warn('RoValra: Failed to update group funds data', error);
+            return cachedData;
+        } finally {
+            activeGroupRequests.delete(groupId);
+        }
+    })();
+
+    activeGroupRequests.set(groupId, request);
+    return request;
+}
+
+async function ensureFreshDataForConfiguredGroups() {
+    if (!state.groupFundsEnabled || state.groupIds.length === 0) return;
+
+    const cache = await getCache();
+
+    state.groupIds.forEach((groupId) => {
+        if (!isCacheFresh(cache[groupId])) {
+            fetchAndCacheGroupData(groupId).catch(() => {});
+        }
+    });
+}
+
+function clearNavbarOverride() {
+    document.querySelectorAll(NAVBAR_SELECTORS).forEach((element) => {
+        delete element.dataset.rovalraNavbarRobuxAmount;
+        delete element.dataset.rovalraGroupFundsOverride;
+    });
+}
+
+function notifyNavbarBalanceUpdated() {
+    document.dispatchEvent(new CustomEvent(NAVBAR_BALANCE_UPDATED_EVENT));
+}
+
+function setNavbarAmountText(element, amountText) {
+    if (!(element instanceof HTMLElement)) return false;
+
+    const existingTextNodes = Array.from(element.childNodes).filter(
+        (node) => node.nodeType === Node.TEXT_NODE,
+    );
+    const primaryTextNode = existingTextNodes[0] || document.createTextNode('');
+    const normalizedText = String(amountText);
+
+    if (!primaryTextNode.parentNode) {
+        element.insertBefore(primaryTextNode, element.firstChild);
+    }
+
+    if (primaryTextNode.textContent !== normalizedText) {
+        primaryTextNode.textContent = normalizedText;
+    }
+
+    existingTextNodes.slice(1).forEach((node) => node.remove());
+    return true;
+}
+
+function captureOriginalNavbarAmount(element) {
+    if (!(element instanceof HTMLElement)) return;
+    if (element.dataset.rovalraOriginalNavbarAmount !== undefined) return;
+
+    const originalText = Array.from(element.childNodes)
+        .filter((node) => node.nodeType === Node.TEXT_NODE)
+        .map((node) => node.textContent || '')
+        .join('')
+        .trim();
+
+    if (originalText) {
+        element.dataset.rovalraOriginalNavbarAmount = originalText;
+    }
+}
+
+function restoreOriginalNavbarAmount(element) {
+    if (!(element instanceof HTMLElement)) return false;
+
+    const originalText = element.dataset.rovalraOriginalNavbarAmount;
+    if (!originalText) return false;
+
+    setNavbarAmountText(element, originalText);
+    delete element.dataset.rovalraOriginalNavbarAmount;
+    return true;
+}
+
+async function getCurrentUserMenuData() {
+    if (currentUserMenuDataPromise) {
+        return currentUserMenuDataPromise;
+    }
+
+    currentUserMenuDataPromise = (async () => {
+        const userId = await getAuthenticatedUserId();
+        if (!userId) return null;
+
+        const [username, thumbnails] = await Promise.all([
+            getUserName(userId),
+            getBatchThumbnails([userId], 'AvatarHeadshot', '48x48'),
+        ]);
+
+        return {
+            userId,
+            username: username || 'User',
+            thumbnailData: thumbnails?.[0] || null,
+        };
+    })().finally(() => {
+        currentUserMenuDataPromise = null;
+    });
+
+    return currentUserMenuDataPromise;
+}
+
+async function getPersonalRobuxBalance() {
+    const cachedBalance = Number((await getCachedUserCurrency())?.robux);
+    if (Number.isFinite(cachedBalance)) {
+        return cachedBalance;
+    }
+
+    const freshBalance = Number((await getUserCurrency())?.robux);
+    return Number.isFinite(freshBalance) ? freshBalance : null;
+}
+
+async function restorePersonalNavbarBalance() {
+    const robux = await getPersonalRobuxBalance();
+    let restoredAny = false;
+
+    document.querySelectorAll(NAVBAR_SELECTORS).forEach((element) => {
+        delete element.dataset.rovalraNavbarRobuxAmount;
+
+        if (element.dataset.rovalraGroupFundsOverride === 'true') {
+            if (Number.isFinite(robux)) {
+                setNavbarAmountText(element, robux.toLocaleString());
+                restoredAny = true;
+            } else if (restoreOriginalNavbarAmount(element)) {
+                restoredAny = true;
+            }
+        }
+
+        delete element.dataset.rovalraGroupFundsOverride;
+    });
+
+    if (restoredAny) {
+        notifyNavbarBalanceUpdated();
+    }
+}
+
+function sumConfiguredGroupFunds(cache) {
+    return state.groupIds.reduce((sum, groupId) => {
+        const funds = Number(cache[groupId]?.funds);
+        return Number.isFinite(funds) ? sum + funds : sum;
+    }, 0);
+}
+
+async function renderNavbarTotal() {
+    if (!state.groupFundsEnabled || !state.navbarTotalEnabled) {
+        await restorePersonalNavbarBalance();
+        return;
+    }
+
+    if (state.groupIds.length === 0 || state.hideRobux) {
+        clearNavbarOverride();
+        return;
+    }
+
+    const personalRobux = await getPersonalRobuxBalance();
+
+    if (!Number.isFinite(personalRobux)) {
+        clearNavbarOverride();
+        return;
+    }
+
+    const cache = await getCache();
+    const mergedTotal = personalRobux + sumConfiguredGroupFunds(cache);
+    const formattedTotal = mergedTotal.toLocaleString();
+
+    document.querySelectorAll(NAVBAR_SELECTORS).forEach((element) => {
+        captureOriginalNavbarAmount(element);
+        element.dataset.rovalraNavbarRobuxAmount = String(mergedTotal);
+        if (element.dataset.rovalraGroupFundsOverride !== 'true') {
+            element.dataset.rovalraGroupFundsOverride = 'true';
+        }
+        setNavbarAmountText(element, formattedTotal);
+    });
+
+    notifyNavbarBalanceUpdated();
+}
+
+async function syncSettingsAndRender() {
+    const settings = await getSettings();
+
+    state.groupFundsEnabled = settings.GroupFundsEnabled === true;
+    state.navbarTotalEnabled = settings.GroupFundsNavbarTotalEnabled === true;
+    state.groupIds = sanitizeGroupIds(settings.GroupFundsIds);
+    state.hideRobux = settings.streamermode && settings.hideRobux === true;
+
+    if (state.groupFundsEnabled && state.groupIds.length > 0) {
+        await ensureFreshDataForConfiguredGroups();
+    }
+
+    await renderNavbarTotal();
+}
+
+export function init() {
+    if (state.initialized) return;
+    state.initialized = true;
+
+    const renderSection = async (popover) => {
+        const menu = popover.querySelector('.dropdown-menu');
+        if (!menu) return;
+
+        state.renderVersion++;
+        const myVersion = state.renderVersion;
+
+        menu.querySelectorAll('.rovalra-group-funds-section').forEach((el) =>
+            el.remove(),
+        );
+
+        if (!state.groupFundsEnabled || state.groupIds.length === 0) return;
+
+        const allCachedData = await getCache();
+
+        const section = document.createElement('div');
+        section.className = 'rovalra-group-funds-section';
+
+        const divider = document.createElement('li');
+        divider.className = 'rbx-divider';
+        section.appendChild(divider);
+
+        if (state.navbarTotalEnabled) {
+            const userData = await getCurrentUserMenuData().catch(() => null);
+            const personalBalance = await getPersonalRobuxBalance();
+
+            if (
+                state.renderVersion === myVersion &&
+                userData &&
+                Number.isFinite(personalBalance)
+            ) {
+                const userLi = document.createElement('li');
+                const userLink = document.createElement('a');
+                userLink.className = 'rbx-menu-item';
+                userLink.href = `https://www.roblox.com/users/${userData.userId}/profile`;
+                userLink.style.display = 'flex';
+                userLink.style.alignItems = 'center';
+                userLink.style.justifyContent = 'space-between';
+
+                const leftContainer = document.createElement('div');
+                leftContainer.style.display = 'flex';
+                leftContainer.style.alignItems = 'center';
+
+                const iconContainer = document.createElement('span');
+                iconContainer.style.width = '28px';
+                iconContainer.style.height = '28px';
+                iconContainer.style.marginRight = '8px';
+                iconContainer.style.display = 'inline-block';
+
+                if (userData.thumbnailData) {
+                    const img = createThumbnailElement(
+                        userData.thumbnailData,
+                        'User',
+                        '',
+                        {
+                            borderRadius: '999px',
+                            width: '28px',
+                            height: '28px',
+                        },
+                    );
+                    iconContainer.appendChild(img);
+                }
+
+                const nameSpan = document.createElement('span');
+                nameSpan.textContent = userData.username;
+
+                const amountSpan = document.createElement('span');
+                const rbxIcon = document.createElement('span');
+                rbxIcon.className = 'icon-robux-16x16';
+                rbxIcon.style.verticalAlign = 'text-bottom';
+                rbxIcon.style.marginRight = '3px';
+                amountSpan.append(rbxIcon, personalBalance.toLocaleString());
+
+                leftContainer.append(iconContainer, nameSpan);
+                userLink.append(leftContainer, amountSpan);
+                userLi.appendChild(userLink);
+                section.appendChild(userLi);
+            }
+        }
+
+        const renderGroup = async (groupId) => {
+            const fundsLi = document.createElement('li');
+            const fundsLink = document.createElement('a');
+            fundsLink.className = 'rbx-menu-item';
+            fundsLink.href = `https://www.roblox.com/groups/configure?id=${groupId}#!/revenue/summary`;
+            fundsLink.style.display = 'flex';
+            fundsLink.style.alignItems = 'center';
+
+            const leftContainer = document.createElement('div');
+            leftContainer.style.display = 'flex';
+            leftContainer.style.alignItems = 'center';
+
+            const iconContainer = document.createElement('span');
+            iconContainer.style.width = '28px';
+            iconContainer.style.height = '28px';
+            iconContainer.style.marginRight = '8px';
+            iconContainer.style.display = 'inline-block';
+
+            leftContainer.appendChild(iconContainer);
+
+            fundsLink.appendChild(leftContainer);
+
+            const amountSpan = document.createElement('span');
+            fundsLink.appendChild(amountSpan);
+
+            fundsLi.appendChild(fundsLink);
+            section.appendChild(fundsLi);
+
+            const pendingLi = document.createElement('li');
+            const pendingLink = document.createElement('a');
+            pendingLink.className = 'rbx-menu-item';
+            pendingLink.style.paddingTop = '0';
+            pendingLink.style.paddingBottom = '5px';
+            pendingLink.style.fontSize = '12px';
+            pendingLink.style.color = 'gray';
+            pendingLink.style.textAlign = 'right';
+            pendingLink.style.pointerEvents = 'none';
+            pendingLink.textContent = '';
+            pendingLi.appendChild(pendingLink);
+            section.appendChild(pendingLi);
+
+            const renderIcon = (data) => {
+                if (data) {
+                    const img = createThumbnailElement(data, 'Group', '', {
+                        borderRadius: '8px',
+                        width: '28px',
+                        height: '28px',
+                    });
+                    iconContainer.innerHTML = '';
+                    iconContainer.appendChild(img);
+                }
+            };
+
+            const renderFunds = (amount) => {
+                amountSpan.innerHTML = '';
+                const rbxIcon = document.createElement('span');
+                rbxIcon.className = 'icon-robux-16x16';
+                rbxIcon.style.verticalAlign = 'text-bottom';
+                rbxIcon.style.marginRight = '3px';
+
+                const text = document.createTextNode(
+                    amount.toLocaleString(),
+                );
+
+                amountSpan.appendChild(rbxIcon);
+                amountSpan.appendChild(text);
+            };
+
+            const renderPending = (amount) => {
+                pendingLink.innerHTML = '';
+                const label = document.createTextNode(
+                    ts('groupFunds.pending') + ' ',
+                );
+                const icon = document.createElement('span');
+                icon.className = 'icon-robux-16x16';
+                icon.style.verticalAlign = 'text-bottom';
+                icon.style.marginLeft = '3px';
+                icon.style.marginRight = '2px';
+                icon.style.filter = 'grayscale(100%) opacity(0.6)';
+                const value = document.createTextNode(
+                    amount.toLocaleString(),
+                );
+
+                pendingLink.append(label, icon, value);
+            };
+
+            const updateFromData = (data) => {
+                if (data.icon) renderIcon(data.icon);
+                if (data.funds !== undefined) renderFunds(data.funds);
+                if (data.pending !== undefined) renderPending(data.pending);
+            };
+
+            const cachedData = allCachedData[groupId];
+
+            if (cachedData) {
+                updateFromData(cachedData);
+            } else {
+                amountSpan.textContent = ts('groupFunds.loading');
+            }
+
+            if (cachedData && isCacheFresh(cachedData)) {
+                return;
+            }
+
+            const freshData = await fetchAndCacheGroupData(groupId);
+
+            if (state.renderVersion !== myVersion) return;
+
+            if (freshData) {
+                updateFromData(freshData);
+                return;
+            }
+
+            if (!cachedData) {
+                amountSpan.textContent = ts('groupFunds.noPermissions');
+                pendingLink.textContent = '';
+            }
+        };
+
+        state.groupIds.forEach((groupId) => {
+            renderGroup(groupId);
+        });
+
+        if (state.renderVersion !== myVersion) return;
+        menu.appendChild(section);
+    };
+
+    syncSettingsAndRender().catch((error) => {
+        console.error('RoValra: Failed to initialize group funds', error);
+    });
+
+    observeElement(
+        '#buy-robux-popover',
+        (popover) => {
+            const menu = popover.querySelector('.dropdown-menu');
+            if (menu && menu.querySelector('.rovalra-group-funds-section')) {
+                return;
+            }
+            renderSection(popover);
+        },
+        {
+            onRemove: () => {
+                state.renderVersion++;
+                document
+                    .querySelectorAll('.rovalra-group-funds-section')
+                    .forEach((el) => el.remove());
+            },
         },
     );
+
+    observeElement(
+        NAVBAR_SELECTORS,
+        () => {
+            renderNavbarTotal().catch(() => {});
+        },
+        { multiple: true },
+    );
+
+    chrome.storage.onChanged.addListener((changes, namespace) => {
+        if (namespace !== 'local') return;
+
+        const openPopover = document.querySelector('#buy-robux-popover');
+
+        if (changes[CACHE_KEY]) {
+            renderNavbarTotal().catch(() => {});
+            return;
+        }
+
+        if (
+            changes.GroupFundsEnabled ||
+            changes.GroupFundsNavbarTotalEnabled ||
+            changes.GroupFundsIds ||
+            changes.streamermode ||
+            changes.hideRobux
+        ) {
+            syncSettingsAndRender().catch(() => {});
+            if (openPopover) {
+                renderSection(openPopover).catch(() => {});
+            }
+        }
+    });
+
+    document.addEventListener(USER_CURRENCY_CHANGED_EVENT, () => {
+        renderNavbarTotal().catch(() => {});
+    });
+
+    document.addEventListener('rovalra-streamer-mode', (event) => {
+        const detail = event.detail || {};
+        state.hideRobux = detail.enabled && detail.hideRobux === true;
+        renderNavbarTotal().catch(() => {});
+    });
 }


### PR DESCRIPTION
‎ 
## Adds an optional child toggle under **Show Community Funds** that combines personal Robux + configured community funds in the navbar balance.

### Behavior

- Disabled by default
- When enabled, the navbar shows `personal Robux + configured community funds`
- The dropdown still separates personal Robux and community funds
- Pending community funds stay separate and are not included in the combined total

### Old behavior

Community funds were shown in the dropdown, but the navbar balance stayed as personal Robux only.

<table>
  <tr>
    <td><strong>Setting</strong></td>
    <td><strong>Navbar / dropdown</strong></td>
  </tr>
  <tr>
    <td>
      <img width="420" alt="Current Show Community Funds setting" src="https://github.com/user-attachments/assets/e295859d-1618-4670-8676-c947e8d91196" />
    </td>
    <td>
      <img width="420" alt="Current community funds dropdown behavior" src="https://github.com/user-attachments/assets/5f2058e8-9281-457f-9443-6f838f537b9d" />
    </td>
  </tr>
</table>

### New behavior

With the new toggle enabled, the navbar balance combines the Robux on your account with the Robux from all added groups.

<table>
  <tr>
    <td><strong>Setting</strong></td>
    <td><strong>Navbar / dropdown</strong></td>
  </tr>
  <tr>
    <td>
      <img width="420" alt="Combine Community Funds setting" src="https://github.com/user-attachments/assets/8417f1c3-0b6b-4f49-ac7d-c4646e058212" />
    </td>
    <td>
      <img width="420" alt="Combined Robux navbar balance with dropdown breakdown" src="https://github.com/user-attachments/assets/8cf408b6-beae-4a20-b8c0-69ef2afdaf02" />
    </td>
  </tr>
</table>