### PR TITLE
fix: roblox plus sidebar thingy was not centered when sidebar was collapsed

### DIFF
--- a/src/content/core/configs/userIds.js
+++ b/src/content/core/configs/userIds.js
@@ -20,6 +20,7 @@ export const CONTRIBUTOR_USER_IDS = [
     '4866259395', //cam
     '650766686', // auggeeoF
     '146089324', // WoozyNate
+    '2974594300', // AGENT700PRODS (im not spending 1k robux to change it, ok?)
 ];
 
 export const TESTER_USER_IDS = [

--- a/src/css/features/sitewide/sidebar_collapse.scss
+++ b/src/css/features/sitewide/sidebar_collapse.scss
@@ -63,7 +63,8 @@ $roblox-left-nav-breakpoint: 768px;
         padding-right: 0 !important;
     }
 
-    li[data-rovalra-sidebar-layout-key*="href:/plus"] > a {
+    /* target SPECIFICALLY le roblox plus promo card widget */
+    li[data-rovalra-sidebar-layout-key="href:/plus:occurrence-2"] > a {
         width: 48px !important;
         min-width: 48px !important;
         height: 48px !important;
@@ -78,12 +79,13 @@ $roblox-left-nav-breakpoint: 768px;
         box-sizing: border-box !important;
     }
 
-    li[data-rovalra-sidebar-layout-key*="href:/plus"] > a > span:nth-child(2),
-    li[data-rovalra-sidebar-layout-key*="href:/plus"] > a > span:nth-child(3) {
+    /* hide only the promo text and subscribe link inside the roblox plus promo card */
+    li[data-rovalra-sidebar-layout-key="href:/plus:occurrence-2"] > a > span:nth-child(2),
+    li[data-rovalra-sidebar-layout-key="href:/plus:occurrence-2"] > a > span:nth-child(3) {
         display: none !important;
     }
 
-    li[data-rovalra-sidebar-layout-key*="href:/plus"] > a > span:first-child {
+    li[data-rovalra-sidebar-layout-key="href:/plus:occurrence-2"] > a > span:first-child {
         margin: 0 !important;
         flex: 0 0 auto !important;
     }

--- a/src/css/features/sitewide/sidebar_collapse.scss
+++ b/src/css/features/sitewide/sidebar_collapse.scss
@@ -62,9 +62,34 @@ $roblox-left-nav-breakpoint: 768px;
         padding-left: 0 !important;
         padding-right: 0 !important;
     }
+
+    li[data-rovalra-sidebar-layout-key*="href:/plus"] > a {
+        width: 48px !important;
+        min-width: 48px !important;
+        height: 48px !important;
+        min-height: 48px !important;
+        padding: 0 !important;
+        margin-left: auto !important;
+        margin-right: auto !important;
+        display: flex !important;
+        align-items: center !important;
+        justify-content: center !important;
+        flex-direction: row !important;
+        box-sizing: border-box !important;
+    }
+
+    li[data-rovalra-sidebar-layout-key*="href:/plus"] > a > span:nth-child(2),
+    li[data-rovalra-sidebar-layout-key*="href:/plus"] > a > span:nth-child(3) {
+        display: none !important;
+    }
+
+    li[data-rovalra-sidebar-layout-key*="href:/plus"] > a > span:first-child {
+        margin: 0 !important;
+        flex: 0 0 auto !important;
+    }
 }
 
-// Removes roqols side bar collabse thingy
+// Removes roqols side bar collapse thingy
 .left-nav[data-rovalra-sidebar-collapse-ready='true']
     nav
     > li.nav-minimise-button {


### PR DESCRIPTION
<img width="61" height="66" alt="image" src="https://github.com/user-attachments/assets/b62380c1-3ad5-4e41-8150-4243505a7d88" />
look it is in the CENTER now. there is two roblox plus thingies and one is an icon and the other one is like a card panel thingy. i wasnt sure to keep them both or not but i decided to keep them since idk. ok dats all