### PR TITLE
fix: when sidebar collapsed communities list doesnt change position

### DIFF
--- a/src/css/features/sitewide/sidebar_collapse.scss
+++ b/src/css/features/sitewide/sidebar_collapse.scss
@@ -140,3 +140,19 @@ $roblox-left-nav-breakpoint: 768px;
     height: 24px;
     fill: currentColor;
 }
+
+.left-nav[data-rovalra-sidebar-collapsed='true'][data-rovalra-sidebar-layout-active='true'] {
+    ~ #container-main,
+    ~ main.container-main,
+    body & {
+        #group-container > div > div > div.groups-list-sidebar.ng-scope {
+            left: $collapsed-sidebar-width !important;
+        }
+    }
+}
+
+body:has(.left-nav[data-rovalra-sidebar-collapsed='true'][data-rovalra-sidebar-layout-active='true']) {
+    #group-container > div > div > div.groups-list-sidebar.ng-scope {
+        left: $collapsed-sidebar-width !important;
+    }
+}


### PR DESCRIPTION
before:\
<img width="308" height="638" alt="image" src="https://github.com/user-attachments/assets/aacf219a-bb44-4ed4-b9b3-ce6237b2a6b2" />
after:\
<img width="194" height="633" alt="image" src="https://github.com/user-attachments/assets/fe071559-ead7-4aae-9f32-455e5d4a3703" />
