### PR TITLE
Add a setting to hide the Add Friends button on Home page

### DIFF
--- a/src/content/core/configs/userIds.js
+++ b/src/content/core/configs/userIds.js
@@ -21,6 +21,7 @@ export const CONTRIBUTOR_USER_IDS = [
     '650766686', // auggeeoF
     '146089324', // WoozyNate
     '2974594300', // AGENT700PRODS (im not spending 1k robux to change it, ok?)
+    '476449201', //IYoLsa
 ];
 
 export const TESTER_USER_IDS = [

--- a/src/content/core/settings/settingConfig.js
+++ b/src/content/core/settings/settingConfig.js
@@ -1131,6 +1131,15 @@ export const SETTINGS_CONFIG = {
                 type: 'checkbox',
                 default: true,
             },
+            HideAddFriendsButton: {
+                label: 'Hide Add Friends Button',
+                description: [
+                    'Hides the Add Friends button from the Home page and allows friend cards to use the freed space.',
+                ],
+                type: 'checkbox',
+                default: false,
+                contributors: ['476449201'],
+            },
             homeLayoutEnabled: {
                 label: 'Home Layout',
                 description: [

--- a/src/content/features/home/hideAddFriendsButton.js
+++ b/src/content/features/home/hideAddFriendsButton.js
@@ -1,0 +1,112 @@
+import { observeElement } from '../../core/observer.js';
+import { settings } from '../../core/settings/getSettings.js';
+
+const SETTING_NAME = 'HideAddFriendsButton';
+const HIDDEN_CLASS = 'rovalra-hide-add-friends-button';
+const ADD_FRIENDS_ICON_SELECTOR = '.add-friends-icon-container';
+const FRIEND_ITEM_SELECTOR = '.friends-carousel-tile';
+const HOME_FRIENDS_CONTAINER_SELECTOR = [
+    '#HomeContainer .friend-carousel-container',
+    '#HomeContainer .react-friends-carousel-container',
+    '#HomeContainer .friends-carousel-container',
+].join(', ');
+const USER_PROFILE_LINK_SELECTOR =
+    'a.avatar-card-link[href*="/users/"], a[href*="/users/"][href*="/profile"]';
+
+let observerRegistered = false;
+let storageListenerRegistered = false;
+let enabled = false;
+
+function isHomePage() {
+    const path = window.location.pathname
+        .toLowerCase()
+        .replace(/^\/[a-z]{2}(?:-[a-z]{2})?\//, '/');
+    return path.startsWith('/home');
+}
+
+function isFirstCarouselItem(item) {
+    const parent = item?.parentElement;
+    if (!parent) return false;
+
+    const items = [...parent.children].filter((element) =>
+        element.classList?.contains('friends-carousel-tile'),
+    );
+    return items[0] === item;
+}
+
+function isAddFriendsButtonItem(item) {
+    if (!(item instanceof HTMLElement)) return false;
+    if (!isHomePage()) return false;
+    if (!item.closest(HOME_FRIENDS_CONTAINER_SELECTOR)) return false;
+    if (!isFirstCarouselItem(item)) return false;
+    if (!item.querySelector(ADD_FRIENDS_ICON_SELECTOR)) return false;
+    if (item.querySelector(USER_PROFILE_LINK_SELECTOR)) return false;
+
+    return true;
+}
+
+function hideAddFriendsButtonFromIcon(iconContainer) {
+    if (!enabled) return;
+
+    const item = iconContainer.closest(FRIEND_ITEM_SELECTOR);
+    if (isAddFriendsButtonItem(item)) {
+        item.classList.add(HIDDEN_CLASS);
+    }
+}
+
+function applyExistingAddFriendsButtons() {
+    if (!enabled || !isHomePage()) return;
+
+    document
+        .querySelectorAll(
+            `#HomeContainer ${FRIEND_ITEM_SELECTOR} ${ADD_FRIENDS_ICON_SELECTOR}`,
+        )
+        .forEach(hideAddFriendsButtonFromIcon);
+}
+
+function removeHiddenButtonClasses() {
+    document
+        .querySelectorAll(`.${HIDDEN_CLASS}`)
+        .forEach((item) => item.classList.remove(HIDDEN_CLASS));
+}
+
+function registerObserver() {
+    if (observerRegistered) return;
+
+    observerRegistered = true;
+    observeElement(
+        `#HomeContainer ${FRIEND_ITEM_SELECTOR} ${ADD_FRIENDS_ICON_SELECTOR}`,
+        hideAddFriendsButtonFromIcon,
+        { multiple: true },
+    );
+}
+
+function registerStorageListener() {
+    if (storageListenerRegistered) return;
+
+    storageListenerRegistered = true;
+    chrome.storage.onChanged.addListener((changes, namespace) => {
+        if (namespace !== 'local' || !changes[SETTING_NAME]) return;
+
+        enabled = changes[SETTING_NAME].newValue === true;
+        if (enabled) {
+            registerObserver();
+            applyExistingAddFriendsButtons();
+        } else {
+            removeHiddenButtonClasses();
+        }
+    });
+}
+
+export async function init() {
+    registerStorageListener();
+
+    enabled = (await settings.HideAddFriendsButton) === true;
+    if (!enabled) {
+        removeHiddenButtonClasses();
+        return;
+    }
+
+    registerObserver();
+    applyExistingAddFriendsButtons();
+}

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -161,6 +161,7 @@ import { init as initAccurateContinue } from './features/home/accurateContinue.j
 import { init as initHomeLayout } from './features/home/homeLayout.js';
 import { init as initCustomThemeEditor } from './features/home/customThemeEditor.js';
 import { init as initUnderratedGamesHome } from './features/home/underratedGames.js';
+import { init as initHideAddFriendsButton } from './features/home/hideAddFriendsButton.js';
 import { init as initThemeCatalogPage } from './features/themes/themeCatalogPage.js';
 // create
 import { init as initCreateDownload } from './features/create.roblox.com/download.js';
@@ -417,6 +418,7 @@ const featureRoutes = [
             initHomeLayout,
             initUnderratedGamesHome,
             initAccurateContinue,
+            initHideAddFriendsButton,
         ],
     },
     {

--- a/src/css/features/home/hideAddFriendsButton.scss
+++ b/src/css/features/home/hideAddFriendsButton.scss
@@ -1,0 +1,3 @@
+.rovalra-hide-add-friends-button {
+    display: none !important;
+}

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -28,6 +28,7 @@
 @use 'features/groups/antibots.scss';
 @use 'features/home/homeLayout.scss';
 @use 'features/home/customThemeEditor.scss';
+@use 'features/home/hideAddFriendsButton.scss';
 @use 'features/sitewide/friendGameLink.scss';
 @use 'features/themes/themeCatalogPage.scss';
 @use 'components/region_filters.scss';


### PR DESCRIPTION
Hi!! This adds a new Home setting called HideAddFriendsButton.

I wanted to hide the Add Friends item at the start of the Friends section. I saw this feature on another extension and wanted RoValra to have it aswell since i personally find the button useless & it's better to have more friends there. When the setting is enabled, the entire item is hidden and the actual friend cards move into the freed space. The setting is disabled by default.

## How it works
It uses RoValra's existing observer system and only runs on the Roblox Home page. The Add Friends item is detected through its DOM structure. It also continues working when the Friends section loads late or gets rendered again.
## Testing
I tested it manually on the Roblox Home page and confirmed it works with literally no issues, heh.