### PR TITLE
Add customizable Topbar Layout editor

### DIFF
--- a/public/Assets/locales/en.json
+++ b/public/Assets/locales/en.json
@@ -29,6 +29,30 @@
         "show": "Show",
         "hide": "Hide"
     },
+    "topbarLayout": {
+        "empty": "RoValra was unable to find any supported topbar items.",
+        "reset": "Reset",
+        "save": "Save",
+        "overlayTitle": "Topbar Layout",
+        "button": "Topbar Layout",
+        "disabled": "Required",
+        "show": "Show",
+        "hide": "Hide",
+        "labels": {
+            "logo": "Roblox Logo",
+            "charts": "Charts",
+            "marketplace": "Marketplace",
+            "create": "Create",
+            "robux": "Robux",
+            "search": "Search",
+            "profile": "Profile",
+            "qol": "Status",
+            "topbarLayout": "Topbar Layout",
+            "notifications": "Notifications",
+            "robuxBalance": "Robux Balance",
+            "settings": "Settings"
+        }
+    },
     "underratedGames": {
         "topic": "Underrated Games",
         "subtitle": "Underrated games hand picked by the RoValra community.",

--- a/src/content/core/settings/settingConfig.js
+++ b/src/content/core/settings/settingConfig.js
@@ -1646,7 +1646,7 @@ export const SETTINGS_CONFIG = {
                     'Lets you reorder and hide buttons in the Roblox topbar.',
                 ],
                 type: 'checkbox',
-                default: true,
+                default: false,
                 contributors: ['476449201'],
                 storageKey: [
                     'rovalra_topbar_layout_order',

--- a/src/content/core/settings/settingConfig.js
+++ b/src/content/core/settings/settingConfig.js
@@ -1640,6 +1640,19 @@ export const SETTINGS_CONFIG = {
                     'rovalra_sidebar_layout_hidden',
                 ],
             },
+            topbarLayoutEnabled: {
+                label: 'Topbar Layout',
+                description: [
+                    'Lets you reorder and hide buttons in the Roblox topbar.',
+                ],
+                type: 'checkbox',
+                default: true,
+                contributors: ['476449201'],
+                storageKey: [
+                    'rovalra_topbar_layout_order',
+                    'rovalra_topbar_layout_hidden',
+                ],
+            },
             ageKidsThemeEnabled: {
                 label: 'Age Theme',
                 description: [

--- a/src/content/core/ui/layoutEditor.js
+++ b/src/content/core/ui/layoutEditor.js
@@ -1,0 +1,441 @@
+import DOMPurify from 'dompurify';
+import { getAssets } from '../assets.js';
+
+const HOLD_THRESHOLD = 200;
+const MOVE_THRESHOLD = 5;
+
+function decodeSvgAsset(assetName) {
+    const svgData = getAssets()[assetName];
+    if (!svgData?.startsWith('data:image/svg+xml,')) return '';
+    return decodeURIComponent(svgData.split(',')[1]);
+}
+
+export function createLayoutIcon(assetName, classNamePrefix) {
+    const icon = document.createElement('span');
+    icon.className = `${classNamePrefix}-icon`;
+    icon.setAttribute('aria-hidden', 'true');
+    icon.innerHTML = DOMPurify.sanitize(decodeSvgAsset(assetName));
+    return icon;
+}
+
+function updateVisibilityButton(
+    button,
+    item,
+    nextHiddenKeys,
+    locale,
+    classNamePrefix,
+    datasetKey,
+) {
+    const key = item.dataset[datasetKey];
+    const hidden = nextHiddenKeys.has(key);
+    const label = hidden ? locale.show : locale.hide;
+
+    button.replaceChildren(
+        createLayoutIcon(
+            hidden ? 'visibilityOff' : 'visibility',
+            classNamePrefix,
+        ),
+    );
+    button.setAttribute('aria-label', label);
+    button.setAttribute('aria-pressed', String(!hidden));
+    button.title = label;
+    item.classList.toggle(`${classNamePrefix}-item-hidden`, hidden);
+}
+
+function createVisibilityButton(
+    item,
+    nextHiddenKeys,
+    locale,
+    classNamePrefix,
+    datasetKey,
+) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = `${classNamePrefix}-visibility-button`;
+    button.addEventListener('mousedown', (event) => event.stopPropagation());
+    button.addEventListener('click', () => {
+        const key = item.dataset[datasetKey];
+        if (nextHiddenKeys.has(key)) {
+            nextHiddenKeys.delete(key);
+        } else {
+            nextHiddenKeys.add(key);
+        }
+        updateVisibilityButton(
+            button,
+            item,
+            nextHiddenKeys,
+            locale,
+            classNamePrefix,
+            datasetKey,
+        );
+    });
+    updateVisibilityButton(
+        button,
+        item,
+        nextHiddenKeys,
+        locale,
+        classNamePrefix,
+        datasetKey,
+    );
+    return button;
+}
+
+function createDisabledStatus(locale, classNamePrefix) {
+    const status = document.createElement('span');
+    status.className = `${classNamePrefix}-disabled-status`;
+    status.textContent = locale.disabled;
+    return status;
+}
+
+function createLayoutEditorItem({
+    item: layoutItem,
+    nextHiddenKeys,
+    locale,
+    classNamePrefix,
+    datasetKey,
+}) {
+    const item = document.createElement('li');
+    item.className = `${classNamePrefix}-item`;
+    item.dataset[datasetKey] = layoutItem.key;
+
+    const handle = document.createElement('span');
+    handle.className = `${classNamePrefix}-drag-handle`;
+    handle.setAttribute('aria-hidden', 'true');
+    handle.appendChild(createLayoutIcon('dragHandle', classNamePrefix));
+
+    const label = document.createElement('span');
+    label.className = `${classNamePrefix}-label`;
+    label.textContent = layoutItem.label;
+
+    if (layoutItem.disabled) {
+        item.classList.add(`${classNamePrefix}-item-disabled`);
+        item.append(handle, label, createDisabledStatus(locale, classNamePrefix));
+    } else {
+        item.append(
+            handle,
+            label,
+            createVisibilityButton(
+                item,
+                nextHiddenKeys,
+                locale,
+                classNamePrefix,
+                datasetKey,
+            ),
+        );
+    }
+
+    return item;
+}
+
+function createInitialDragState() {
+    return {
+        active: false,
+        element: null,
+        list: null,
+        clone: null,
+        startX: 0,
+        startY: 0,
+        offsetX: 0,
+        offsetY: 0,
+        holdTimer: null,
+    };
+}
+
+function setupDragList(listElement, classNamePrefix) {
+    let dragState = createInitialDragState();
+    let dropIndicator = null;
+
+    function createDropIndicator() {
+        if (dropIndicator) dropIndicator.remove();
+        dropIndicator = document.createElement('div');
+        dropIndicator.className = `${classNamePrefix}-drop-indicator`;
+        document.body.appendChild(dropIndicator);
+    }
+
+    function getDropTarget(mouseY) {
+        const items = Array.from(
+            dragState.list.querySelectorAll(`.${classNamePrefix}-item`),
+        ).filter((item) => item !== dragState.element);
+
+        let targetElement = null;
+        let insertBefore = true;
+
+        for (const item of items) {
+            const rect = item.getBoundingClientRect();
+            const midY = rect.top + rect.height / 2;
+
+            if (mouseY < midY) {
+                targetElement = item;
+                insertBefore = true;
+                break;
+            }
+        }
+
+        if (!targetElement && items.length > 0) {
+            targetElement = items[items.length - 1];
+            insertBefore = false;
+        }
+
+        return { targetElement, insertBefore };
+    }
+
+    function getListItemRects() {
+        if (!dragState.list) return new Map();
+        return new Map(
+            Array.from(
+                dragState.list.querySelectorAll(`.${classNamePrefix}-item`),
+            ).map((item) => [item, item.getBoundingClientRect()]),
+        );
+    }
+
+    function animateListShift(previousRects) {
+        if (!dragState.list) return;
+
+        const items = Array.from(
+            dragState.list.querySelectorAll(`.${classNamePrefix}-item`),
+        );
+
+        for (const item of items) {
+            if (item === dragState.element) continue;
+
+            const previousRect = previousRects.get(item);
+            if (!previousRect) continue;
+
+            const currentRect = item.getBoundingClientRect();
+            const deltaY = previousRect.top - currentRect.top;
+
+            if (!deltaY) continue;
+
+            item.style.transition = 'none';
+            item.style.transform = `translateY(${deltaY}px)`;
+
+            requestAnimationFrame(() => {
+                item.style.transition =
+                    'transform 0.16s ease, opacity 0.15s ease';
+                item.style.transform = '';
+            });
+        }
+    }
+
+    function moveDragElement(mouseY) {
+        if (!dragState.element || !dragState.list) return;
+
+        const { targetElement, insertBefore } = getDropTarget(mouseY);
+        const previousSibling = dragState.element.previousElementSibling;
+        const nextSibling = dragState.element.nextElementSibling;
+        const previousRects = getListItemRects();
+
+        if (targetElement) {
+            if (insertBefore) {
+                if (nextSibling === targetElement) return;
+                dragState.list.insertBefore(dragState.element, targetElement);
+            } else if (targetElement.nextSibling) {
+                if (previousSibling === targetElement) return;
+                dragState.list.insertBefore(
+                    dragState.element,
+                    targetElement.nextSibling,
+                );
+            } else {
+                if (previousSibling === targetElement) return;
+                dragState.list.appendChild(dragState.element);
+            }
+        } else if (dragState.element.nextElementSibling) {
+            dragState.list.appendChild(dragState.element);
+        } else {
+            return;
+        }
+
+        animateListShift(previousRects);
+    }
+
+    function showDropIndicator(targetElement, before) {
+        if (!dropIndicator) return;
+
+        const rect = targetElement.getBoundingClientRect();
+        const y = before ? rect.top : rect.bottom;
+
+        dropIndicator.style.left = rect.left + 'px';
+        dropIndicator.style.top = y - 1 + 'px';
+        dropIndicator.style.width = rect.width + 'px';
+        dropIndicator.style.display = 'block';
+    }
+
+    function hideDropIndicator() {
+        if (dropIndicator) {
+            dropIndicator.style.display = 'none';
+        }
+    }
+
+    function updateDropPosition(mouseY) {
+        if (!dragState.list) return;
+
+        const { targetElement, insertBefore } = getDropTarget(mouseY);
+        if (targetElement) {
+            showDropIndicator(targetElement, insertBefore);
+        } else {
+            hideDropIndicator();
+        }
+    }
+
+    function beginDrag(event) {
+        if (!dragState.element) return;
+
+        dragState.active = true;
+
+        const original = dragState.element;
+        const rect = original.getBoundingClientRect();
+        const clone = original.cloneNode(true);
+
+        clone.classList.add(`${classNamePrefix}-drag-clone`);
+        clone.style.position = 'fixed';
+        clone.style.left = rect.left + 'px';
+        clone.style.top = rect.top + 'px';
+        clone.style.width = rect.width + 'px';
+        clone.style.height = rect.height + 'px';
+        clone.style.margin = '0';
+
+        document.body.appendChild(clone);
+        dragState.clone = clone;
+
+        original.classList.add(`${classNamePrefix}-drag-source`);
+        createDropIndicator();
+
+        document.body.style.cursor = 'grabbing';
+        document.body.style.userSelect = 'none';
+        event.preventDefault();
+    }
+
+    function onMouseMove(event) {
+        if (!dragState.element) return;
+
+        const deltaX = Math.abs(event.clientX - dragState.startX);
+        const deltaY = Math.abs(event.clientY - dragState.startY);
+        if (!dragState.active) {
+            if (deltaX <= MOVE_THRESHOLD && deltaY <= MOVE_THRESHOLD) return;
+            clearTimeout(dragState.holdTimer);
+            beginDrag(event);
+        }
+
+        event.preventDefault();
+        if (dragState.clone) {
+            dragState.clone.style.left = `${event.clientX - dragState.offsetX}px`;
+            dragState.clone.style.top = `${event.clientY - dragState.offsetY}px`;
+        }
+        updateDropPosition(event.clientY);
+        moveDragElement(event.clientY);
+    }
+
+    function finalizeDrop(mouseY) {
+        if (!dragState.element || !dragState.list) return;
+
+        moveDragElement(mouseY);
+    }
+
+    function cleanupDragState() {
+        document.removeEventListener('mousemove', onMouseMove);
+        document.removeEventListener('mouseup', onMouseUp);
+
+        if (dragState.holdTimer) {
+            clearTimeout(dragState.holdTimer);
+        }
+
+        if (dragState.clone) dragState.clone.remove();
+        if (dragState.element) {
+            dragState.element.classList.remove(
+                `${classNamePrefix}-drag-source`,
+            );
+        }
+        if (dropIndicator) {
+            dropIndicator.remove();
+            dropIndicator = null;
+        }
+
+        dragState = createInitialDragState();
+
+        document.body.style.cursor = '';
+        document.body.style.userSelect = '';
+    }
+
+    function onMouseUp(event) {
+        const wasActive = dragState.active;
+
+        if (wasActive) {
+            finalizeDrop(event.clientY);
+        }
+
+        cleanupDragState();
+    }
+
+    function onMouseDown(event) {
+        if (event.button !== 0) return;
+        if (event.target.closest(`.${classNamePrefix}-visibility-button`)) {
+            return;
+        }
+
+        const item = event.target.closest(`.${classNamePrefix}-item`);
+        const list = item?.closest(`.${classNamePrefix}-list`);
+        if (!item || list !== event.currentTarget) return;
+
+        const rect = item.getBoundingClientRect();
+        dragState.element = item;
+        dragState.list = list;
+        dragState.startX = event.clientX;
+        dragState.startY = event.clientY;
+        dragState.offsetX = event.clientX - rect.left;
+        dragState.offsetY = event.clientY - rect.top;
+        dragState.active = false;
+
+        if (dragState.holdTimer) clearTimeout(dragState.holdTimer);
+        dragState.holdTimer = setTimeout(() => {
+            if (!dragState.active) beginDrag(event);
+        }, HOLD_THRESHOLD);
+
+        document.addEventListener('mousemove', onMouseMove);
+        document.addEventListener('mouseup', onMouseUp);
+        event.preventDefault();
+    }
+
+    listElement.addEventListener('mousedown', onMouseDown);
+
+    return () => {
+        listElement.removeEventListener('mousedown', onMouseDown);
+        cleanupDragState();
+    };
+}
+
+export function createLayoutEditorBody({
+    items,
+    nextHiddenKeys,
+    locale,
+    classNamePrefix,
+    datasetKey = 'layoutKey',
+}) {
+    const container = document.createElement('div');
+    container.className = `${classNamePrefix}-editor`;
+
+    if (!items.length) {
+        const empty = document.createElement('p');
+        empty.className = `${classNamePrefix}-empty`;
+        empty.textContent = locale.empty;
+        container.appendChild(empty);
+        return { container, list: null, cleanup: () => {} };
+    }
+
+    const list = document.createElement('ul');
+    list.className = `${classNamePrefix}-list`;
+    items.forEach((item) => {
+        list.appendChild(
+            createLayoutEditorItem({
+                item,
+                nextHiddenKeys,
+                locale,
+                classNamePrefix,
+                datasetKey,
+            }),
+        );
+    });
+    const cleanup = setupDragList(list, classNamePrefix);
+
+    container.appendChild(list);
+    return { container, list, cleanup };
+}

--- a/src/content/features/navigation/QoLToggles.js
+++ b/src/content/features/navigation/QoLToggles.js
@@ -156,11 +156,20 @@ export function init() {
             position: 'center',
         });
 
-        menu.panel.style.transform = 'translateX(-50%)';
         menu.panel.style.setProperty('min-width', '320px', 'important');
 
         const updatePosition = () => {
-            if (button.offsetWidth > 0) {
+            if (button.offsetWidth <= 0) return;
+
+            const edge =
+                button.dataset.rovalraTopbarLayoutEdge ||
+                button.closest('[data-rovalra-topbar-layout-key]')?.dataset
+                    .rovalraTopbarLayoutEdge;
+            if (edge === 'left' || edge === 'right') {
+                menu.panel.style.transform = 'none';
+                menu.panel.style.marginLeft = '0';
+            } else {
+                menu.panel.style.transform = 'translateX(-50%)';
                 menu.panel.style.marginLeft = `${button.offsetWidth / 2}px`;
             }
         };

--- a/src/content/features/sitewide/sidebarLayout.js
+++ b/src/content/features/sitewide/sidebarLayout.js
@@ -1,9 +1,11 @@
-import DOMPurify from 'dompurify';
-import { getAssets } from '../../core/assets.js';
 import { t } from '../../core/locale/i18n.js';
 import { observeElement } from '../../core/observer.js';
 import { settings } from '../../core/settings/getSettings.js';
 import { createButton } from '../../core/ui/buttons.js';
+import {
+    createLayoutEditorBody,
+    createLayoutIcon,
+} from '../../core/ui/layoutEditor.js';
 import { createOverlay } from '../../core/ui/overlay.js';
 import { createSquareButton } from '../../core/ui/profile/header/squarebutton.js';
 import { addTooltip } from '../../core/ui/tooltip.js';
@@ -11,8 +13,6 @@ import { addTooltip } from '../../core/ui/tooltip.js';
 const ORDER_STORAGE_KEY = 'rovalra_sidebar_layout_order';
 const HIDDEN_STORAGE_KEY = 'rovalra_sidebar_layout_hidden';
 const BUTTON_ID = 'rovalra-sidebar-layout-button';
-const HOLD_THRESHOLD = 200;
-const MOVE_THRESHOLD = 5;
 const SIDEBAR_ITEM_SELECTOR = [
     '.left-nav nav a[href]',
     '.left-nav nav button',
@@ -42,18 +42,6 @@ let sidebarLayoutEnabled = false;
 let sidebarUpdateFrame = 0;
 let sidebarItemObserver = null;
 let locale = { ...DEFAULT_LOCALE };
-let dropIndicator = null;
-let dragState = {
-    active: false,
-    element: null,
-    list: null,
-    clone: null,
-    startX: 0,
-    startY: 0,
-    offsetX: 0,
-    offsetY: 0,
-    holdTimer: null,
-};
 
 async function loadLocale() {
     try {
@@ -237,375 +225,24 @@ function scheduleSidebarLayoutUpdate(sidebar = currentSidebar) {
     });
 }
 
-function decodeSvgAsset(assetName) {
-    const svgData = getAssets()[assetName];
-    if (!svgData?.startsWith('data:image/svg+xml,')) return '';
-    return decodeURIComponent(svgData.split(',')[1]);
-}
-
 function createSidebarIcon(assetName) {
-    const icon = document.createElement('span');
-    icon.className = 'rovalra-sidebar-layout-icon';
-    icon.setAttribute('aria-hidden', 'true');
-    icon.innerHTML = DOMPurify.sanitize(decodeSvgAsset(assetName));
-    return icon;
-}
-
-function updateVisibilityButton(button, item, nextHiddenKeys) {
-    const key = item.dataset.sidebarKey;
-    const hidden = nextHiddenKeys.has(key);
-    const label = hidden ? locale.show : locale.hide;
-
-    button.replaceChildren(
-        createSidebarIcon(hidden ? 'visibilityOff' : 'visibility'),
-    );
-    button.setAttribute('aria-label', label);
-    button.setAttribute('aria-pressed', String(!hidden));
-    button.title = label;
-    item.classList.toggle('rovalra-sidebar-layout-item-hidden', hidden);
-}
-
-function createVisibilityButton(item, nextHiddenKeys) {
-    const button = document.createElement('button');
-    button.type = 'button';
-    button.className = 'rovalra-sidebar-layout-visibility-button';
-    button.addEventListener('mousedown', (event) => event.stopPropagation());
-    button.addEventListener('click', () => {
-        const key = item.dataset.sidebarKey;
-        if (nextHiddenKeys.has(key)) {
-            nextHiddenKeys.delete(key);
-        } else {
-            nextHiddenKeys.add(key);
-        }
-        updateVisibilityButton(button, item, nextHiddenKeys);
-    });
-    updateVisibilityButton(button, item, nextHiddenKeys);
-    return button;
-}
-
-function createDisabledStatus() {
-    const status = document.createElement('span');
-    status.className = 'rovalra-sidebar-layout-disabled-status';
-    status.textContent = locale.disabled;
-    return status;
-}
-
-function createSidebarLayoutItem(sidebarItem, nextHiddenKeys) {
-    const item = document.createElement('li');
-    item.className = 'rovalra-sidebar-layout-item';
-    item.dataset.sidebarKey = sidebarItem.key;
-
-    const handle = document.createElement('span');
-    handle.className = 'rovalra-sidebar-layout-drag-handle';
-    handle.setAttribute('aria-hidden', 'true');
-    handle.appendChild(createSidebarIcon('dragHandle'));
-
-    const label = document.createElement('span');
-    label.className = 'rovalra-sidebar-layout-label';
-    label.textContent = sidebarItem.label;
-
-    if (sidebarItem.disabled) {
-        item.classList.add('rovalra-sidebar-layout-item-disabled');
-        item.append(handle, label, createDisabledStatus());
-    } else {
-        item.append(
-            handle,
-            label,
-            createVisibilityButton(item, nextHiddenKeys),
-        );
-    }
-    return item;
-}
-
-function createDropIndicator() {
-    if (dropIndicator) dropIndicator.remove();
-    dropIndicator = document.createElement('div');
-    dropIndicator.className = 'rovalra-sidebar-layout-drop-indicator';
-    document.body.appendChild(dropIndicator);
-}
-
-function setupDragList(listElement) {
-    listElement.addEventListener('mousedown', onMouseDown);
-}
-
-function onMouseDown(event) {
-    if (event.button !== 0) return;
-    if (event.target.closest('.rovalra-sidebar-layout-visibility-button')) {
-        return;
-    }
-
-    const item = event.target.closest('.rovalra-sidebar-layout-item');
-    const list = item?.closest('.rovalra-sidebar-layout-list');
-    if (!item || list !== event.currentTarget) return;
-
-    const rect = item.getBoundingClientRect();
-    dragState.element = item;
-    dragState.list = list;
-    dragState.startX = event.clientX;
-    dragState.startY = event.clientY;
-    dragState.offsetX = event.clientX - rect.left;
-    dragState.offsetY = event.clientY - rect.top;
-    dragState.active = false;
-
-    if (dragState.holdTimer) clearTimeout(dragState.holdTimer);
-    dragState.holdTimer = setTimeout(() => {
-        if (!dragState.active) beginDrag(event);
-    }, HOLD_THRESHOLD);
-
-    document.addEventListener('mousemove', onMouseMove);
-    document.addEventListener('mouseup', onMouseUp);
-    event.preventDefault();
-}
-
-function beginDrag(event) {
-    if (!dragState.element) return;
-
-    dragState.active = true;
-
-    const original = dragState.element;
-    const rect = original.getBoundingClientRect();
-    const clone = original.cloneNode(true);
-
-    clone.classList.add('rovalra-sidebar-layout-drag-clone');
-    clone.style.position = 'fixed';
-    clone.style.left = rect.left + 'px';
-    clone.style.top = rect.top + 'px';
-    clone.style.width = rect.width + 'px';
-    clone.style.height = rect.height + 'px';
-    clone.style.margin = '0';
-
-    document.body.appendChild(clone);
-    dragState.clone = clone;
-
-    original.classList.add('rovalra-sidebar-layout-drag-source');
-    createDropIndicator();
-
-    document.body.style.cursor = 'grabbing';
-    document.body.style.userSelect = 'none';
-    event.preventDefault();
-}
-
-function getDropTarget(mouseY) {
-    const items = Array.from(
-        dragState.list.querySelectorAll('.rovalra-sidebar-layout-item'),
-    ).filter((item) => item !== dragState.element);
-
-    let targetElement = null;
-    let insertBefore = true;
-
-    for (const item of items) {
-        const rect = item.getBoundingClientRect();
-        const midY = rect.top + rect.height / 2;
-
-        if (mouseY < midY) {
-            targetElement = item;
-            insertBefore = true;
-            break;
-        }
-    }
-
-    if (!targetElement && items.length > 0) {
-        targetElement = items[items.length - 1];
-        insertBefore = false;
-    }
-
-    return { targetElement, insertBefore };
-}
-
-function getListItemRects() {
-    if (!dragState.list) return new Map();
-    return new Map(
-        Array.from(
-            dragState.list.querySelectorAll('.rovalra-sidebar-layout-item'),
-        ).map((item) => [item, item.getBoundingClientRect()]),
-    );
-}
-
-function animateListShift(previousRects) {
-    if (!dragState.list) return;
-
-    const items = Array.from(
-        dragState.list.querySelectorAll('.rovalra-sidebar-layout-item'),
-    );
-
-    for (const item of items) {
-        if (item === dragState.element) continue;
-
-        const previousRect = previousRects.get(item);
-        if (!previousRect) continue;
-
-        const currentRect = item.getBoundingClientRect();
-        const deltaY = previousRect.top - currentRect.top;
-
-        if (!deltaY) continue;
-
-        item.style.transition = 'none';
-        item.style.transform = `translateY(${deltaY}px)`;
-
-        requestAnimationFrame(() => {
-            item.style.transition = 'transform 0.16s ease, opacity 0.15s ease';
-            item.style.transform = '';
-        });
-    }
-}
-
-function moveDragElement(mouseY) {
-    if (!dragState.element || !dragState.list) return;
-
-    const { targetElement, insertBefore } = getDropTarget(mouseY);
-    const previousSibling = dragState.element.previousElementSibling;
-    const nextSibling = dragState.element.nextElementSibling;
-    const previousRects = getListItemRects();
-
-    if (targetElement) {
-        if (insertBefore) {
-            if (nextSibling === targetElement) return;
-            dragState.list.insertBefore(dragState.element, targetElement);
-        } else if (targetElement.nextSibling) {
-            if (previousSibling === targetElement) return;
-            dragState.list.insertBefore(
-                dragState.element,
-                targetElement.nextSibling,
-            );
-        } else {
-            if (previousSibling === targetElement) return;
-            dragState.list.appendChild(dragState.element);
-        }
-    } else if (dragState.element.nextElementSibling) {
-        dragState.list.appendChild(dragState.element);
-    } else {
-        return;
-    }
-
-    animateListShift(previousRects);
-}
-
-function updateDropPosition(mouseY) {
-    if (!dragState.list) return;
-
-    const { targetElement, insertBefore } = getDropTarget(mouseY);
-    if (targetElement) {
-        showDropIndicator(targetElement, insertBefore);
-    } else {
-        hideDropIndicator();
-    }
-}
-
-function showDropIndicator(targetElement, before) {
-    if (!dropIndicator) return;
-
-    const rect = targetElement.getBoundingClientRect();
-    const y = before ? rect.top : rect.bottom;
-
-    dropIndicator.style.left = rect.left + 'px';
-    dropIndicator.style.top = y - 1 + 'px';
-    dropIndicator.style.width = rect.width + 'px';
-    dropIndicator.style.display = 'block';
-}
-
-function hideDropIndicator() {
-    if (dropIndicator) {
-        dropIndicator.style.display = 'none';
-    }
-}
-
-function onMouseMove(event) {
-    if (!dragState.element) return;
-
-    const deltaX = Math.abs(event.clientX - dragState.startX);
-    const deltaY = Math.abs(event.clientY - dragState.startY);
-    if (!dragState.active) {
-        if (deltaX <= MOVE_THRESHOLD && deltaY <= MOVE_THRESHOLD) return;
-        clearTimeout(dragState.holdTimer);
-        beginDrag(event);
-    }
-
-    event.preventDefault();
-    if (dragState.clone) {
-        dragState.clone.style.left = `${event.clientX - dragState.offsetX}px`;
-        dragState.clone.style.top = `${event.clientY - dragState.offsetY}px`;
-    }
-    updateDropPosition(event.clientY);
-    moveDragElement(event.clientY);
-}
-
-function cleanupDragState() {
-    document.removeEventListener('mousemove', onMouseMove);
-    document.removeEventListener('mouseup', onMouseUp);
-
-    if (dragState.holdTimer) {
-        clearTimeout(dragState.holdTimer);
-    }
-
-    if (dragState.clone) dragState.clone.remove();
-    if (dragState.element) {
-        dragState.element.classList.remove(
-            'rovalra-sidebar-layout-drag-source',
-        );
-    }
-    if (dropIndicator) {
-        dropIndicator.remove();
-        dropIndicator = null;
-    }
-
-    dragState = {
-        active: false,
-        element: null,
-        list: null,
-        clone: null,
-        startX: 0,
-        startY: 0,
-        offsetX: 0,
-        offsetY: 0,
-        holdTimer: null,
-    };
-
-    document.body.style.cursor = '';
-    document.body.style.userSelect = '';
-}
-
-function onMouseUp(event) {
-    const wasActive = dragState.active;
-
-    if (wasActive) {
-        finalizeDrop(event.clientY);
-    }
-
-    cleanupDragState();
-}
-
-function finalizeDrop(mouseY) {
-    if (!dragState.element || !dragState.list) return;
-
-    moveDragElement(mouseY);
+    return createLayoutIcon(assetName, 'rovalra-sidebar-layout');
 }
 
 function createSidebarLayoutBody(sidebarItems, nextHiddenKeys) {
-    const container = document.createElement('div');
-    container.className = 'rovalra-sidebar-layout-editor';
-
-    if (!sidebarItems.length) {
-        const empty = document.createElement('p');
-        empty.className = 'rovalra-sidebar-layout-empty';
-        empty.textContent = locale.empty;
-        container.appendChild(empty);
-        return { container, list: null };
-    }
-
-    const list = document.createElement('ul');
-    list.className = 'rovalra-sidebar-layout-list';
-    getOrderedSidebarItems(sidebarItems).forEach((sidebarItem) => {
-        list.appendChild(createSidebarLayoutItem(sidebarItem, nextHiddenKeys));
+    return createLayoutEditorBody({
+        items: getOrderedSidebarItems(sidebarItems),
+        nextHiddenKeys,
+        locale,
+        classNamePrefix: 'rovalra-sidebar-layout',
+        datasetKey: 'sidebarKey',
     });
-    setupDragList(list);
-    container.appendChild(list);
-    return { container, list };
 }
 
 function openSidebarLayoutOverlay() {
     const sidebarItems = getSidebarItems(currentSidebar);
     const nextHiddenKeys = new Set(hiddenSidebarKeys);
-    const { container, list } = createSidebarLayoutBody(
+    const { container, list, cleanup } = createSidebarLayoutBody(
         sidebarItems,
         nextHiddenKeys,
     );
@@ -653,8 +290,8 @@ function openSidebarLayoutOverlay() {
         bodyContent: container,
         actions: [resetButton, saveButton],
         maxWidth: '620px',
-        onClose: cleanupDragState,
         showLogo: true,
+        onClose: cleanup,
     });
 }
 

--- a/src/content/features/sitewide/topbarLayout.js
+++ b/src/content/features/sitewide/topbarLayout.js
@@ -1,0 +1,1121 @@
+import { t } from '../../core/locale/i18n.js';
+import { observeElement, observeResize } from '../../core/observer.js';
+import { settings } from '../../core/settings/getSettings.js';
+import { createButton } from '../../core/ui/buttons.js';
+import {
+    createLayoutEditorBody,
+    createLayoutIcon,
+} from '../../core/ui/layoutEditor.js';
+import { createOverlay } from '../../core/ui/overlay.js';
+import { createSquareButton } from '../../core/ui/profile/header/squarebutton.js';
+import { addTooltip } from '../../core/ui/tooltip.js';
+
+const ORDER_STORAGE_KEY = 'rovalra_topbar_layout_order';
+const HIDDEN_STORAGE_KEY = 'rovalra_topbar_layout_hidden';
+const BUTTON_ID = 'rovalra-topbar-layout-button';
+const BUTTON_ITEM_ID = 'rovalra-topbar-layout-button-item';
+const TOPBAR_ROOT_SELECTOR = '#header > .container-fluid';
+const DESKTOP_PRIMARY_NAV_SELECTOR = 'ul.nav.rbx-navbar.hidden-xs.hidden-sm';
+const RIGHT_NAV_GROUP_SELECTOR =
+    '#right-navigation-header .navbar-right.rbx-navbar-right > ul.nav.navbar-right.rbx-navbar-icon-group';
+const SEARCH_MOVED_CLASS = 'rovalra-topbar-layout-search-moved';
+const DROPDOWN_ITEM_KEYS = new Set([
+    'search',
+    'qol',
+    'notifications',
+    'robuxBalance',
+    'settings',
+]);
+const DROPDOWN_EDGE_MARGIN = 12;
+const DROPDOWN_WIDTH_BY_KEY = {
+    search: 720,
+    qol: 320,
+    notifications: 360,
+    robuxBalance: 300,
+    settings: 240,
+};
+const MAX_COMPACT_GAP = 16;
+const LEFT_FLOW_ITEM_KEYS = new Set([
+    'logo',
+    'charts',
+    'marketplace',
+    'create',
+    'robux',
+    'search',
+]);
+const RIGHT_FLOW_ITEM_KEYS = new Set([
+    'profile',
+    'qol',
+    'topbarLayout',
+    'notifications',
+    'robuxBalance',
+    'settings',
+]);
+const REQUIRED_ITEM_IDS = new Set(['topbarLayout']);
+const TOPBAR_ITEM_RENDER_SELECTOR = [
+    `${TOPBAR_ROOT_SELECTOR} > .rbx-navbar-header`,
+    '#nav-logo-link',
+    `${DESKTOP_PRIMARY_NAV_SELECTOR} > li`,
+    `${DESKTOP_PRIMARY_NAV_SELECTOR} a[href]`,
+    '[data-testid="navigation-search-input"].navbar-search',
+    '#navbar-search-input',
+    `${RIGHT_NAV_GROUP_SELECTOR} > .age-bracket-label.text-header`,
+    `${RIGHT_NAV_GROUP_SELECTOR} > li#rovalra-qol-toggle`,
+    `${RIGHT_NAV_GROUP_SELECTOR} > li#${BUTTON_ITEM_ID}`,
+    `${RIGHT_NAV_GROUP_SELECTOR} > li#navbar-stream`,
+    `${RIGHT_NAV_GROUP_SELECTOR} > li#navbar-robux`,
+    `${RIGHT_NAV_GROUP_SELECTOR} > li#navbar-settings`,
+].join(', ');
+const DEFAULT_ORDER = [
+    'logo',
+    'charts',
+    'marketplace',
+    'create',
+    'robux',
+    'search',
+    'profile',
+    'qol',
+    'topbarLayout',
+    'notifications',
+    'robuxBalance',
+    'settings',
+];
+const SUPPORTED_ITEM_IDS = new Set(DEFAULT_ORDER);
+const DEFAULT_LOCALE = {
+    empty: 'RoValra was unable to find any supported topbar items.',
+    reset: 'Reset',
+    save: 'Save',
+    overlayTitle: 'Topbar Layout',
+    button: 'Topbar Layout',
+    disabled: 'Required',
+    show: 'Show',
+    hide: 'Hide',
+    labels: {
+        logo: 'Roblox Logo',
+        charts: 'Charts',
+        marketplace: 'Marketplace',
+        create: 'Create',
+        robux: 'Robux',
+        search: 'Search',
+        profile: 'Profile',
+        qol: 'Status',
+        topbarLayout: 'Topbar Layout',
+        notifications: 'Notifications',
+        robuxBalance: 'Robux Balance',
+        settings: 'Settings',
+    },
+};
+
+let savedOrder = [];
+let hiddenTopbarKeys = [];
+let originalOrder = [];
+let hasSavedLayout = false;
+let currentTopbarRoot = null;
+let initialized = false;
+let observersInitialized = false;
+let topbarLayoutEnabled = false;
+let topbarUpdateFrame = 0;
+let topbarItemObserver = null;
+let topbarResizeObservers = new Map();
+let locale = { ...DEFAULT_LOCALE };
+
+async function loadLocale() {
+    try {
+        locale = {
+            empty: await t('topbarLayout.empty'),
+            reset: await t('topbarLayout.reset'),
+            save: await t('topbarLayout.save'),
+            overlayTitle: await t('topbarLayout.overlayTitle'),
+            button: await t('topbarLayout.button'),
+            disabled: await t('topbarLayout.disabled'),
+            show: await t('topbarLayout.show'),
+            hide: await t('topbarLayout.hide'),
+            labels: {
+                logo: await t('topbarLayout.labels.logo'),
+                charts: await t('topbarLayout.labels.charts'),
+                marketplace: await t('topbarLayout.labels.marketplace'),
+                create: await t('topbarLayout.labels.create'),
+                robux: await t('topbarLayout.labels.robux'),
+                search: await t('topbarLayout.labels.search'),
+                profile: await t('topbarLayout.labels.profile'),
+                qol: await t('topbarLayout.labels.qol'),
+                topbarLayout: await t('topbarLayout.labels.topbarLayout'),
+                notifications: await t('topbarLayout.labels.notifications'),
+                robuxBalance: await t('topbarLayout.labels.robuxBalance'),
+                settings: await t('topbarLayout.labels.settings'),
+            },
+        };
+    } catch {
+        locale = { ...DEFAULT_LOCALE };
+    }
+}
+
+function normalizeTopbarPath(pathname) {
+    const normalized = pathname
+        .toLowerCase()
+        .replace(/^\/[a-z]{2}(?:-[a-z]{2})?\//, '/');
+
+    return normalized.length > 1 ? normalized.replace(/\/$/, '') : normalized;
+}
+
+function normalizeOrder(value) {
+    const order = [];
+    const seen = new Set();
+
+    if (Array.isArray(value)) {
+        value.forEach((id) => {
+            const key = String(id);
+            if (!SUPPORTED_ITEM_IDS.has(key) || seen.has(key)) return;
+            seen.add(key);
+            order.push(key);
+        });
+    }
+
+    DEFAULT_ORDER.forEach((id) => {
+        if (!seen.has(id)) order.push(id);
+    });
+
+    return order;
+}
+
+function normalizeHiddenKeys(value) {
+    const hidden = [];
+    const seen = new Set();
+
+    if (!Array.isArray(value)) return hidden;
+
+    value.forEach((id) => {
+        const key = String(id);
+        if (
+            !SUPPORTED_ITEM_IDS.has(key) ||
+            REQUIRED_ITEM_IDS.has(key) ||
+            seen.has(key)
+        ) {
+            return;
+        }
+        seen.add(key);
+        hidden.push(key);
+    });
+
+    return hidden;
+}
+
+function getPrimaryNavItem(primaryNav, link) {
+    let item = link;
+
+    while (item?.parentElement && item.parentElement !== primaryNav) {
+        item = item.parentElement;
+    }
+
+    return item?.parentElement === primaryNav ? item : null;
+}
+
+function getSupportedLinkId(link) {
+    const href = link.getAttribute('href');
+    if (!href) return null;
+
+    let url;
+    try {
+        url = new URL(href, window.location.origin);
+    } catch {
+        return null;
+    }
+
+    const path = normalizeTopbarPath(url.pathname);
+    const isRobloxHost = url.hostname === window.location.hostname;
+
+    if (isRobloxHost && (path === '/charts' || path === '/discover')) {
+        return 'charts';
+    }
+    if (isRobloxHost && (path === '/catalog' || path === '/marketplace')) {
+        return 'marketplace';
+    }
+    if (isRobloxHost && (path === '/upgrades/robux' || path === '/robux')) {
+        return 'robux';
+    }
+    if (
+        url.hostname === 'create.roblox.com' ||
+        (isRobloxHost && (path === '/develop' || path === '/create'))
+    ) {
+        return 'create';
+    }
+
+    return null;
+}
+
+function addTopbarItem(items, usedIds, id, element, options = {}) {
+    if (!SUPPORTED_ITEM_IDS.has(id) || usedIds.has(id)) return;
+    if (!(element instanceof HTMLElement) || !element.isConnected) return;
+
+    usedIds.add(id);
+    items.push({
+        key: id,
+        label: locale.labels[id] || id,
+        element,
+        disabled: options.disabled === true,
+    });
+}
+
+function getSearchElement(topbarRoot) {
+    const input =
+        topbarRoot.querySelector('#navbar-search-input') ||
+        topbarRoot.querySelector(
+            '[data-testid="navigation-search-input-field"][type="search"]',
+        );
+    if (!input) return null;
+
+    return (
+        input.closest('[data-testid="navigation-search-input"].navbar-search') ||
+        input.closest('.navbar-search') ||
+        input.closest('form[name="search-form"]')
+    );
+}
+
+function getLogoElement(topbarRoot) {
+    const logoContainer = topbarRoot.querySelector(':scope > .rbx-navbar-header');
+    if (!logoContainer?.querySelector('#nav-logo-link[href]')) return null;
+    return logoContainer;
+}
+
+function getRightNavGroup(topbarRoot) {
+    return topbarRoot.querySelector(RIGHT_NAV_GROUP_SELECTOR);
+}
+
+function getProfileElement(rightNavGroup) {
+    const profileElement = rightNavGroup?.querySelector(
+        ':scope > .age-bracket-label.text-header',
+    );
+    if (
+        !profileElement?.querySelector(
+            'a[href*="/users/"][href*="/profile"] .avatar',
+        )
+    ) {
+        return null;
+    }
+
+    return profileElement;
+}
+
+function getNotificationsElement(rightNavGroup) {
+    const notificationsElement = rightNavGroup?.querySelector(
+        ':scope > li#navbar-stream.navbar-stream',
+    );
+    if (
+        !notificationsElement?.querySelector(
+            '#common-notification-bell, #nav-ns-icon',
+        )
+    ) {
+        return null;
+    }
+
+    return notificationsElement;
+}
+
+function getRobuxBalanceElement(rightNavGroup) {
+    return rightNavGroup?.querySelector(':scope > li#navbar-robux');
+}
+
+function getSettingsElement(rightNavGroup) {
+    const settingsElement = rightNavGroup?.querySelector(
+        ':scope > li#navbar-settings',
+    );
+    if (
+        !settingsElement?.querySelector(
+            '#nav-settings, .btn-navigation-nav-settings-md',
+        )
+    ) {
+        return null;
+    }
+
+    return settingsElement;
+}
+
+function getQolElement(rightNavGroup) {
+    return rightNavGroup?.querySelector(':scope > li#rovalra-qol-toggle');
+}
+
+function compareDocumentOrder(left, right) {
+    if (left.element === right.element) return 0;
+
+    const position = left.element.compareDocumentPosition(right.element);
+    if (position & Node.DOCUMENT_POSITION_PRECEDING) return 1;
+    if (position & Node.DOCUMENT_POSITION_FOLLOWING) return -1;
+    return 0;
+}
+
+function compareRenderedTopbarOrder(left, right) {
+    const leftRect = left.element.getBoundingClientRect();
+    const rightRect = right.element.getBoundingClientRect();
+    const leftVisible = leftRect.width > 0 && leftRect.height > 0;
+    const rightVisible = rightRect.width > 0 && rightRect.height > 0;
+
+    if (leftVisible && rightVisible) {
+        const leftDelta = leftRect.left - rightRect.left;
+        if (Math.abs(leftDelta) > 0.5) return leftDelta;
+
+        const topDelta = leftRect.top - rightRect.top;
+        if (Math.abs(topDelta) > 0.5) return topDelta;
+    }
+
+    return compareDocumentOrder(left, right);
+}
+
+function getTopbarItems(topbarRoot = currentTopbarRoot) {
+    if (!topbarRoot?.isConnected) return [];
+
+    const items = [];
+    const usedIds = new Set();
+    const primaryNav = topbarRoot.querySelector(DESKTOP_PRIMARY_NAV_SELECTOR);
+    const logoElement = getLogoElement(topbarRoot);
+    if (logoElement) addTopbarItem(items, usedIds, 'logo', logoElement);
+
+    if (primaryNav) {
+        primaryNav.querySelectorAll('a[href]').forEach((link) => {
+            const id = getSupportedLinkId(link);
+            if (!id) return;
+
+            const item = getPrimaryNavItem(primaryNav, link);
+            if (!item) return;
+
+            addTopbarItem(items, usedIds, id, item);
+        });
+    }
+
+    const searchElement = getSearchElement(topbarRoot);
+    if (searchElement) addTopbarItem(items, usedIds, 'search', searchElement);
+
+    const rightNavGroup = getRightNavGroup(topbarRoot);
+    addTopbarItem(items, usedIds, 'profile', getProfileElement(rightNavGroup));
+    addTopbarItem(items, usedIds, 'qol', getQolElement(rightNavGroup));
+    addTopbarItem(
+        items,
+        usedIds,
+        'topbarLayout',
+        getTopbarLayoutButtonItem(),
+        { disabled: true },
+    );
+    addTopbarItem(
+        items,
+        usedIds,
+        'notifications',
+        getNotificationsElement(rightNavGroup),
+    );
+    addTopbarItem(
+        items,
+        usedIds,
+        'robuxBalance',
+        getRobuxBalanceElement(rightNavGroup),
+    );
+    addTopbarItem(items, usedIds, 'settings', getSettingsElement(rightNavGroup));
+
+    return items.sort(compareRenderedTopbarOrder);
+}
+
+function saveOriginalOrder(topbarItems) {
+    const currentOrder = topbarItems.map((item) => item.key);
+
+    if (hasSavedLayout) {
+        currentOrder.forEach((key) => {
+            if (!originalOrder.includes(key)) originalOrder.push(key);
+        });
+        return;
+    }
+
+    const currentKeys = new Set(currentOrder);
+    originalOrder = [
+        ...currentOrder,
+        ...originalOrder.filter((key) => !currentKeys.has(key)),
+    ];
+}
+
+function getOrderedTopbarItems(topbarItems) {
+    const order = savedOrder.length ? savedOrder : originalOrder;
+    const orderIndex = new Map(order.map((key, index) => [key, index]));
+    const originalIndex = new Map(
+        topbarItems.map((item, index) => [item.key, index]),
+    );
+
+    return [...topbarItems].sort((left, right) => {
+        const leftIndex = orderIndex.get(left.key);
+        const rightIndex = orderIndex.get(right.key);
+
+        if (leftIndex !== undefined && rightIndex !== undefined) {
+            return leftIndex - rightIndex;
+        }
+        if (leftIndex !== undefined) return -1;
+        if (rightIndex !== undefined) return 1;
+        return originalIndex.get(left.key) - originalIndex.get(right.key);
+    });
+}
+
+function cleanupTopbarLayout(root = document) {
+    root.querySelectorAll(`#right-navigation-header.${SEARCH_MOVED_CLASS}`).forEach(
+        (element) => {
+            element.classList.remove(SEARCH_MOVED_CLASS);
+            element.removeAttribute('data-rovalra-topbar-layout-search-edge');
+            element.style.removeProperty(
+                '--rovalra-topbar-layout-search-left',
+            );
+            element.style.removeProperty(
+                '--rovalra-topbar-layout-search-right',
+            );
+        },
+    );
+
+    root.querySelectorAll(
+        [
+            '[data-rovalra-topbar-layout-key]',
+            '[data-rovalra-topbar-layout-managed-sibling]',
+            '[data-rovalra-topbar-layout-managed-transform]',
+            '.rovalra-topbar-layout-hidden',
+        ].join(', '),
+    ).forEach((element) => {
+        const originalTransform =
+            element.dataset.rovalraTopbarLayoutOriginalTransform;
+
+        element.classList.remove('rovalra-topbar-layout-hidden');
+        element.style.removeProperty('order');
+        if (originalTransform !== undefined) {
+            if (originalTransform) {
+                element.style.transform = originalTransform;
+            } else {
+                element.style.removeProperty('transform');
+            }
+        }
+        delete element.dataset.rovalraTopbarLayoutKey;
+        delete element.dataset.rovalraTopbarLayoutEdge;
+        delete element.dataset.rovalraTopbarLayoutManagedSibling;
+        delete element.dataset.rovalraTopbarLayoutManagedTransform;
+        delete element.dataset.rovalraTopbarLayoutOriginalTransform;
+    });
+}
+
+function disconnectTopbarResizeObservers() {
+    topbarResizeObservers.forEach((observer) => observer.unobserve());
+    topbarResizeObservers = new Map();
+}
+
+function refreshTopbarResizeObservers(topbarRoot, topbarItems) {
+    if (!topbarRoot?.isConnected) {
+        disconnectTopbarResizeObservers();
+        return;
+    }
+
+    const observedElements = new Set([
+        topbarRoot,
+        topbarRoot.querySelector(DESKTOP_PRIMARY_NAV_SELECTOR),
+        getRightNavGroup(topbarRoot),
+        getTopbarLayoutButtonItem(),
+        getTopbarLayoutButton(),
+        ...topbarItems.map((item) => item.element),
+    ]);
+    observedElements.delete(null);
+
+    topbarResizeObservers.forEach((observer, element) => {
+        if (observedElements.has(element) && element.isConnected) return;
+
+        observer.unobserve();
+        topbarResizeObservers.delete(element);
+    });
+
+    observedElements.forEach((element) => {
+        if (topbarResizeObservers.has(element)) return;
+
+        topbarResizeObservers.set(
+            element,
+            observeResize(element, () => scheduleTopbarLayoutUpdate(topbarRoot)),
+        );
+    });
+}
+
+function isVisibleTopbarElement(element) {
+    if (!(element instanceof HTMLElement) || !element.isConnected) return false;
+
+    const style = window.getComputedStyle(element);
+    if (style.display === 'none' || style.visibility === 'hidden') return false;
+
+    const rect = element.getBoundingClientRect();
+    return rect.width > 0 && rect.height > 0;
+}
+
+function hasUnexpectedRightNavSiblings(searchElement) {
+    const parent = searchElement?.parentElement;
+    if (!(parent instanceof HTMLElement)) return false;
+
+    return Array.from(parent.children).some((child) => {
+        if (child === searchElement) return false;
+        if (child.id === BUTTON_ID) return false;
+        if (!isVisibleTopbarElement(child)) return false;
+        if (child.matches('.search-overlay')) return false;
+        if (child.matches('.navbar-right.rbx-navbar-right')) return false;
+        return true;
+    });
+}
+
+function getTopbarLayoutButton() {
+    return document.getElementById(BUTTON_ID);
+}
+
+function getTopbarLayoutButtonItem() {
+    return document.getElementById(BUTTON_ITEM_ID);
+}
+
+function createTopbarFlowEntry(element, itemByElement) {
+    if (element?.id === BUTTON_ID) {
+        return null;
+    }
+    if (!isVisibleTopbarElement(element)) return null;
+
+    const item = itemByElement.get(element);
+    const rect = element.getBoundingClientRect();
+
+    return {
+        type: item ? 'supported' : 'unknown',
+        item,
+        element,
+        rect,
+        layoutRight: rect.right,
+    };
+}
+
+function getTopbarFlowEntries(topbarRoot, itemByElement, topbarItems) {
+    const entries = [];
+    const logoElement = getLogoElement(topbarRoot);
+    const logoEntry = createTopbarFlowEntry(logoElement, itemByElement);
+    if (logoEntry) entries.push(logoEntry);
+
+    const primaryNav = topbarRoot.querySelector(DESKTOP_PRIMARY_NAV_SELECTOR);
+    if (primaryNav) {
+        Array.from(primaryNav.children).forEach((element) => {
+            const entry = createTopbarFlowEntry(element, itemByElement);
+            if (entry) entries.push(entry);
+        });
+    }
+
+    const searchItem = topbarItems.find((item) => item.key === 'search');
+    if (
+        searchItem &&
+        isVisibleTopbarElement(searchItem.element) &&
+        !hasUnexpectedRightNavSiblings(searchItem.element)
+    ) {
+        const entry = createTopbarFlowEntry(searchItem.element, itemByElement);
+        if (entry) entries.push(entry);
+    }
+
+    const rightNavGroup = getRightNavGroup(topbarRoot);
+    if (rightNavGroup) {
+        Array.from(rightNavGroup.children).forEach((element) => {
+            const entry = createTopbarFlowEntry(element, itemByElement);
+            if (entry) entries.push(entry);
+        });
+    }
+
+    return entries.sort((left, right) => left.rect.left - right.rect.left);
+}
+
+function getDropdownEdge(key, targetX, width) {
+    if (!DROPDOWN_ITEM_KEYS.has(key)) return null;
+
+    const viewportWidth =
+        document.documentElement.clientWidth || window.innerWidth;
+    const dropdownWidth = Math.min(
+        DROPDOWN_WIDTH_BY_KEY[key] || 280,
+        viewportWidth - DROPDOWN_EDGE_MARGIN * 2,
+    );
+    const centeredLeft = targetX + width / 2 - dropdownWidth / 2;
+    const centeredRight = centeredLeft + dropdownWidth;
+
+    if (centeredLeft < DROPDOWN_EDGE_MARGIN) return 'left';
+    if (centeredRight > viewportWidth - DROPDOWN_EDGE_MARGIN) return 'right';
+    return 'center';
+}
+
+function setSearchMovedState(searchElement, isMoved, edge, targetX, width) {
+    const searchRoot = searchElement?.closest('#right-navigation-header');
+    if (!searchRoot) return;
+
+    searchRoot.classList.toggle(SEARCH_MOVED_CLASS, isMoved);
+
+    if (!isMoved) {
+        searchRoot.removeAttribute('data-rovalra-topbar-layout-search-edge');
+        searchRoot.style.removeProperty('--rovalra-topbar-layout-search-left');
+        searchRoot.style.removeProperty('--rovalra-topbar-layout-search-right');
+        return;
+    }
+
+    const viewportWidth =
+        document.documentElement.clientWidth || window.innerWidth;
+    searchRoot.dataset.rovalraTopbarLayoutSearchEdge = edge;
+    searchRoot.style.setProperty(
+        '--rovalra-topbar-layout-search-left',
+        `${Math.max(DROPDOWN_EDGE_MARGIN, targetX)}px`,
+    );
+    searchRoot.style.setProperty(
+        '--rovalra-topbar-layout-search-right',
+        `${Math.max(DROPDOWN_EDGE_MARGIN, viewportWidth - targetX - width)}px`,
+    );
+}
+
+function writeTopbarTransform(element, originalTransform, deltaX) {
+    if (Math.abs(deltaX) <= 0.5) {
+        if (originalTransform) {
+            element.style.transform = originalTransform;
+        } else {
+            element.style.removeProperty('transform');
+        }
+        return;
+    }
+
+    const topbarTransform = `translateX(${deltaX}px)`;
+    element.style.transform = originalTransform
+        ? `${originalTransform} ${topbarTransform}`
+        : topbarTransform;
+}
+
+function setTopbarDropdownState(item, targetX) {
+    if (!DROPDOWN_ITEM_KEYS.has(item.key)) {
+        delete item.element.dataset.rovalraTopbarLayoutEdge;
+        return;
+    }
+
+    const width = item.element.getBoundingClientRect().width;
+    const edge = getDropdownEdge(item.key, targetX, width);
+    if (edge) {
+        item.element.dataset.rovalraTopbarLayoutEdge = edge;
+    } else {
+        delete item.element.dataset.rovalraTopbarLayoutEdge;
+    }
+}
+
+function applyTopbarTransform(element, targetX) {
+    const rect = element.getBoundingClientRect();
+    const deltaX = targetX - rect.left;
+
+    if (!element.dataset.rovalraTopbarLayoutManagedTransform) {
+        element.dataset.rovalraTopbarLayoutOriginalTransform =
+            element.style.transform || '';
+    }
+
+    element.dataset.rovalraTopbarLayoutManagedTransform = 'true';
+    const originalTransform =
+        element.dataset.rovalraTopbarLayoutOriginalTransform || '';
+    let appliedDeltaX = deltaX;
+
+    writeTopbarTransform(element, originalTransform, appliedDeltaX);
+
+    const adjustedRect = element.getBoundingClientRect();
+    const correction = targetX - adjustedRect.left;
+    if (Math.abs(correction) > 0.5) {
+        appliedDeltaX += correction;
+        writeTopbarTransform(element, originalTransform, appliedDeltaX);
+    }
+
+    return Math.abs(appliedDeltaX) > 0.5;
+}
+
+function applyTopbarFlowSegment(segment) {
+    if (segment.length < 2) return;
+
+    const orderedItems = getOrderedTopbarItems(
+        segment.map((entry) => entry.item),
+    );
+    const spacerGapIndex = getTopbarSpacerGapIndex(orderedItems);
+    const rawGaps = segment.map((entry, index) => {
+        const nextEntry = segment[index + 1];
+        if (!nextEntry) return 0;
+
+        return Math.max(0, nextEntry.rect.left - entry.layoutRight);
+    });
+    const compactGaps = rawGaps.map((gap) => Math.min(gap, MAX_COMPACT_GAP));
+    const gaps =
+        spacerGapIndex === null ? rawGaps : distributeTopbarFlexibleGap(
+            rawGaps,
+            compactGaps,
+            spacerGapIndex,
+        );
+    let targetX = segment[0].rect.left;
+
+    orderedItems.forEach((item, index) => {
+        const appliedTargetX = Math.max(0, targetX);
+        const isMoved = applyTopbarTransform(item.element, appliedTargetX);
+        if (item.key === 'search') {
+            const width = item.element.getBoundingClientRect().width;
+            const edge = getDropdownEdge(item.key, appliedTargetX, width);
+            item.element.dataset.rovalraTopbarLayoutEdge = edge;
+            setSearchMovedState(
+                item.element,
+                isMoved,
+                edge,
+                appliedTargetX,
+                width,
+            );
+        } else {
+            setTopbarDropdownState(item, appliedTargetX);
+        }
+        targetX =
+            appliedTargetX +
+            item.element.getBoundingClientRect().width +
+            gaps[index];
+    });
+}
+
+function distributeTopbarFlexibleGap(rawGaps, compactGaps, spacerGapIndex) {
+    const rawTotal = rawGaps.reduce((total, gap) => total + gap, 0);
+    const compactTotal = compactGaps.reduce((total, gap) => total + gap, 0);
+    const flexibleGap = Math.max(0, rawTotal - compactTotal);
+    const gaps = [...compactGaps];
+    gaps[spacerGapIndex] += flexibleGap;
+
+    return gaps;
+}
+
+function getTopbarSpacerGapIndex(orderedItems) {
+    if (RIGHT_FLOW_ITEM_KEYS.has(orderedItems[orderedItems.length - 1]?.key)) {
+        for (let index = orderedItems.length - 2; index >= 0; index -= 1) {
+            if (!RIGHT_FLOW_ITEM_KEYS.has(orderedItems[index].key)) {
+                return index;
+            }
+        }
+    }
+
+    let seenLeftItem = false;
+
+    for (let index = 0; index < orderedItems.length; index += 1) {
+        const item = orderedItems[index];
+        if (LEFT_FLOW_ITEM_KEYS.has(item.key)) {
+            seenLeftItem = true;
+            continue;
+        }
+
+        if (seenLeftItem && RIGHT_FLOW_ITEM_KEYS.has(item.key)) {
+            return Math.max(0, index - 1);
+        }
+    }
+
+    let seenRightItem = false;
+
+    for (let index = 0; index < orderedItems.length; index += 1) {
+        const item = orderedItems[index];
+        if (RIGHT_FLOW_ITEM_KEYS.has(item.key)) {
+            seenRightItem = true;
+            continue;
+        }
+
+        if (seenRightItem && LEFT_FLOW_ITEM_KEYS.has(item.key)) {
+            return Math.max(0, index - 1);
+        }
+    }
+
+    return null;
+}
+
+function applyTopbarFlowEntries(entries) {
+    let segment = [];
+
+    entries.forEach((entry) => {
+        if (entry.type === 'supported') {
+            segment.push(entry);
+            return;
+        }
+
+        applyTopbarFlowSegment(segment);
+        segment = [];
+    });
+
+    applyTopbarFlowSegment(segment);
+}
+
+function applyTopbarVisualOrder(topbarRoot, topbarItems) {
+    const itemByElement = new Map(
+        topbarItems.map((item) => [item.element, item]),
+    );
+    const entries = getTopbarFlowEntries(
+        topbarRoot,
+        itemByElement,
+        topbarItems,
+    );
+    applyTopbarFlowEntries(entries);
+}
+
+function applyTopbarLayout(topbarRoot = currentTopbarRoot) {
+    if (!topbarRoot?.isConnected) return;
+
+    addTopbarLayoutButton(topbarRoot);
+    cleanupTopbarLayout(topbarRoot);
+    const topbarItems = getTopbarItems(topbarRoot);
+    refreshTopbarResizeObservers(topbarRoot, topbarItems);
+    saveOriginalOrder(topbarItems);
+
+    if (!topbarLayoutEnabled || !hasSavedLayout) {
+        return;
+    }
+
+    const hiddenItems = new Set(hiddenTopbarKeys);
+
+    topbarItems.forEach((item) => {
+        item.element.dataset.rovalraTopbarLayoutKey = item.key;
+        item.element.classList.toggle(
+            'rovalra-topbar-layout-hidden',
+            hiddenItems.has(item.key),
+        );
+    });
+    applyTopbarVisualOrder(topbarRoot, topbarItems);
+}
+
+function scheduleTopbarLayoutUpdate(topbarRoot = currentTopbarRoot) {
+    if (topbarRoot) currentTopbarRoot = topbarRoot;
+    if (topbarUpdateFrame) return;
+
+    topbarUpdateFrame = requestAnimationFrame(() => {
+        topbarUpdateFrame = 0;
+        if (!currentTopbarRoot?.isConnected) return;
+        applyTopbarLayout(currentTopbarRoot);
+    });
+}
+
+function mergeSavedOrder(editedOrder) {
+    const editedIds = editedOrder.filter((id) => SUPPORTED_ITEM_IDS.has(id));
+    const editedSet = new Set(editedIds);
+    const previousOrder = savedOrder.length
+        ? savedOrder
+        : normalizeOrder(originalOrder);
+
+    return [
+        ...editedIds,
+        ...previousOrder.filter((id) => !editedSet.has(id)),
+    ];
+}
+
+function createTopbarIcon(assetName) {
+    return createLayoutIcon(assetName, 'rovalra-topbar-layout');
+}
+
+function createTopbarLayoutBody(topbarItems, nextHiddenKeys) {
+    return createLayoutEditorBody({
+        items: hasSavedLayout ? getOrderedTopbarItems(topbarItems) : topbarItems,
+        nextHiddenKeys,
+        locale,
+        classNamePrefix: 'rovalra-topbar-layout',
+        datasetKey: 'topbarKey',
+    });
+}
+
+function openTopbarLayoutOverlay() {
+    const topbarRoot =
+        currentTopbarRoot?.isConnected
+            ? currentTopbarRoot
+            : document.querySelector(TOPBAR_ROOT_SELECTOR);
+    const topbarItems = getTopbarItems(topbarRoot);
+    saveOriginalOrder(topbarItems);
+    const nextHiddenKeys = new Set(hiddenTopbarKeys);
+    const { container, list, cleanup } = createTopbarLayoutBody(
+        topbarItems,
+        nextHiddenKeys,
+    );
+    let overlayHandle = null;
+
+    const resetButton = createButton(locale.reset, 'secondary', {
+        disabled: !hasSavedLayout,
+        onClick: () => {
+            chrome.storage.local.remove(
+                [ORDER_STORAGE_KEY, HIDDEN_STORAGE_KEY],
+                () => {
+                    hasSavedLayout = false;
+                    savedOrder = [];
+                    hiddenTopbarKeys = [];
+                    cleanupTopbarLayout();
+                    applyTopbarLayout();
+                    overlayHandle?.close();
+                },
+            );
+        },
+    });
+
+    const saveButton = createButton(locale.save, 'primary', {
+        disabled: !list,
+        onClick: () => {
+            if (!list) return;
+
+            const editedOrder = Array.from(
+                list.querySelectorAll('.rovalra-topbar-layout-item'),
+            ).map((item) => item.dataset.topbarKey);
+            savedOrder = mergeSavedOrder(editedOrder);
+            hiddenTopbarKeys = normalizeHiddenKeys(Array.from(nextHiddenKeys));
+            hasSavedLayout = true;
+            chrome.storage.local.set(
+                {
+                    [ORDER_STORAGE_KEY]: savedOrder,
+                    [HIDDEN_STORAGE_KEY]: hiddenTopbarKeys,
+                },
+                () => {
+                    applyTopbarLayout();
+                    overlayHandle?.close();
+                },
+            );
+        },
+    });
+
+    overlayHandle = createOverlay({
+        title: locale.overlayTitle,
+        bodyContent: container,
+        actions: [resetButton, saveButton],
+        maxWidth: '620px',
+        onClose: cleanup,
+    });
+}
+
+function getOrCreateTopbarLayoutButton() {
+    const existingButton = getTopbarLayoutButton();
+    if (existingButton) return existingButton;
+
+    const button = createSquareButton({
+        content: createTopbarIcon('edit'),
+        id: BUTTON_ID,
+        width: '32px',
+        height: 'height-1000',
+        paddingX: 'padding-x-none',
+        radius: 'radius-medium',
+        disableTextTruncation: true,
+        onClick: openTopbarLayoutOverlay,
+    });
+    button.classList.add('rovalra-topbar-layout-button');
+    button.classList.remove('bg-action-standard', 'content-action-standard');
+    button.classList.add('bg-none', 'content-emphasis');
+    button.setAttribute('aria-label', locale.button);
+    addTooltip(button, () => locale.button, {
+        position: 'bottom',
+        showArrow: false,
+    });
+
+    return button;
+}
+
+function getOrCreateTopbarLayoutButtonItem() {
+    const existingItem = getTopbarLayoutButtonItem();
+    if (existingItem) {
+        ensureSingleTopbarLayoutButton(existingItem);
+        return existingItem;
+    }
+
+    const buttonItem = document.createElement('li');
+    buttonItem.id = BUTTON_ITEM_ID;
+    buttonItem.className =
+        'navbar-icon-item rovalra-topbar-layout-button-item';
+    ensureSingleTopbarLayoutButton(buttonItem);
+
+    return buttonItem;
+}
+
+function ensureSingleTopbarLayoutButton(buttonItem) {
+    const buttons = Array.from(buttonItem.querySelectorAll(`#${BUTTON_ID}`));
+    const button = buttons[0] || getOrCreateTopbarLayoutButton();
+
+    buttons.slice(1).forEach((duplicateButton) => duplicateButton.remove());
+    if (button.parentElement !== buttonItem) {
+        buttonItem.appendChild(button);
+    }
+
+    return button;
+}
+
+function addTopbarLayoutButton(topbarRoot = currentTopbarRoot) {
+    if (!topbarLayoutEnabled) return;
+
+    const rightNavGroup = getRightNavGroup(topbarRoot);
+    const qolElement = getQolElement(rightNavGroup);
+    if (!(rightNavGroup instanceof HTMLElement)) return;
+
+    const buttonItem = getOrCreateTopbarLayoutButtonItem();
+    ensureSingleTopbarLayoutButton(buttonItem);
+    const fallbackElement =
+        getNotificationsElement(rightNavGroup) ||
+        getRobuxBalanceElement(rightNavGroup) ||
+        getSettingsElement(rightNavGroup) ||
+        null;
+    const nextElement = qolElement?.nextSibling || fallbackElement;
+
+    if (buttonItem.parentElement !== rightNavGroup) {
+        rightNavGroup.insertBefore(buttonItem, nextElement);
+    } else if (qolElement && buttonItem.previousElementSibling !== qolElement) {
+        rightNavGroup.insertBefore(buttonItem, nextElement);
+    } else if (
+        !qolElement &&
+        fallbackElement !== buttonItem.nextElementSibling
+    ) {
+        rightNavGroup.insertBefore(buttonItem, fallbackElement);
+    }
+}
+
+function removeTopbarLayoutButton() {
+    getTopbarLayoutButtonItem()?.remove();
+    document
+        .querySelectorAll(`#${BUTTON_ID}`)
+        .forEach((button) => button.remove());
+}
+
+function attachTopbarLayout(topbarRoot) {
+    currentTopbarRoot = topbarRoot;
+    topbarItemObserver?.disconnect();
+    disconnectTopbarResizeObservers();
+    topbarItemObserver = observeElement(
+        TOPBAR_ITEM_RENDER_SELECTOR,
+        () => scheduleTopbarLayoutUpdate(topbarRoot),
+        { multiple: true, root: topbarRoot },
+    );
+    addTopbarLayoutButton(topbarRoot);
+    scheduleTopbarLayoutUpdate(topbarRoot);
+}
+
+async function loadSavedLayout() {
+    const data = await chrome.storage.local.get([
+        ORDER_STORAGE_KEY,
+        HIDDEN_STORAGE_KEY,
+    ]);
+
+    hasSavedLayout =
+        Object.prototype.hasOwnProperty.call(data, ORDER_STORAGE_KEY) ||
+        Object.prototype.hasOwnProperty.call(data, HIDDEN_STORAGE_KEY);
+    savedOrder = hasSavedLayout ? normalizeOrder(data[ORDER_STORAGE_KEY]) : [];
+    hiddenTopbarKeys = normalizeHiddenKeys(data[HIDDEN_STORAGE_KEY]);
+}
+
+function initializeStorageListener() {
+    chrome.storage.onChanged.addListener((changes, areaName) => {
+        if (areaName !== 'local') return;
+
+        if (changes.topbarLayoutEnabled) {
+            topbarLayoutEnabled =
+                changes.topbarLayoutEnabled.newValue !== false;
+
+            if (topbarLayoutEnabled) {
+                addTopbarLayoutButton();
+            } else {
+                removeTopbarLayoutButton();
+                cleanupTopbarLayout();
+            }
+            scheduleTopbarLayoutUpdate();
+        }
+
+        if (changes[ORDER_STORAGE_KEY] || changes[HIDDEN_STORAGE_KEY]) {
+            loadSavedLayout().then(() => scheduleTopbarLayoutUpdate());
+        }
+    });
+}
+
+export async function init() {
+    if (!initialized) {
+        initialized = true;
+        topbarLayoutEnabled = (await settings.topbarLayoutEnabled) !== false;
+
+        await loadLocale();
+        await loadSavedLayout();
+        initializeStorageListener();
+        window.addEventListener('resize', () => scheduleTopbarLayoutUpdate(), {
+            passive: true,
+        });
+    }
+
+    if (observersInitialized) return;
+    observersInitialized = true;
+    observeElement(TOPBAR_ROOT_SELECTOR, attachTopbarLayout);
+}

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -42,6 +42,7 @@ import { init as initKidsTheme } from './features/sitewide/kidsTheme.js';
 import { init as initKidsThemeText } from './features/sitewide/kidsThemeText.js';
 import { init as initSidebarCollapse } from './features/sitewide/sidebarCollapse.js';
 import { init as initSidebarLayout } from './features/sitewide/sidebarLayout.js';
+import { init as initTopbarLayout } from './features/sitewide/topbarLayout.js';
 import { init as initRemoveDownloadButton } from './features/sitewide/removeDownloadButton.js';
 import { init as initFriendGameLink } from './features/sitewide/friendGameLink.js';
 import { init as initPaymentMethodBonusItems } from './features/paymentmethods/bonusItems.js';
@@ -223,6 +224,7 @@ const featureRoutes = [
             initKidsThemeText,
             initSidebarCollapse,
             initSidebarLayout,
+            initTopbarLayout,
             initRemoveDownloadButton,
             initFriendGameLink,
             initThemeSwitcher,

--- a/src/css/features/sitewide/sidebar_layout.scss
+++ b/src/css/features/sitewide/sidebar_layout.scss
@@ -1,7 +1,6 @@
 .left-nav .rovalra-sidebar-layout-button {
     position: absolute;
     right: 12px;
-    bottom: 12px;
     z-index: 2;
     flex: 0 0 40px !important;
     width: 40px !important;
@@ -14,8 +13,12 @@
     transition: opacity 0.12s ease;
 }
 
-.left-nav .rovalra-sidebar-layout-button .rovalra-sidebar-layout-icon,
-.left-nav .rovalra-sidebar-layout-button svg {
+.left-nav .rovalra-sidebar-layout-button {
+    bottom: 12px;
+}
+
+.left-nav .rovalra-sidebar-layout-button
+    :is(.rovalra-sidebar-layout-icon, svg) {
     width: 22px;
     height: 22px;
 }
@@ -27,142 +30,283 @@
     pointer-events: none;
 }
 
-.rovalra-sidebar-layout-hidden {
+#right-navigation-header .rovalra-topbar-layout-button-item {
+    position: relative;
+    float: left;
+    z-index: 2;
+    flex: 0 0 32px !important;
+    width: 32px !important;
+    max-width: 32px !important;
+    min-width: 32px;
+    height: 40px !important;
+    min-height: 40px;
+    margin-left: 8px;
+    padding: 0 !important;
+    list-style: none;
+    opacity: 1;
+    visibility: visible;
+}
+
+#right-navigation-header .rovalra-topbar-layout-button {
+    width: 32px !important;
+    max-width: 32px !important;
+    min-width: 32px;
+    height: 28px !important;
+    min-height: 28px;
+    margin-top: 6px;
+    padding-right: 0 !important;
+    padding-left: 0 !important;
+    opacity: 1;
+    visibility: visible;
+}
+
+#right-navigation-header
+    .rovalra-topbar-layout-button
+    :is(.rovalra-topbar-layout-icon, svg) {
+    width: 18px;
+    height: 18px;
+}
+
+.rovalra-sidebar-layout-hidden,
+.rovalra-topbar-layout-hidden {
     display: none !important;
 }
 
-.rovalra-sidebar-layout-editor {
-    padding-bottom: 4px;
+#right-navigation-header.rovalra-topbar-layout-search-moved > .search-overlay {
+    background: transparent !important;
+    opacity: 0 !important;
+    pointer-events: none !important;
 }
 
-.rovalra-sidebar-layout-list {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    margin: 0;
-    padding: 0;
-    list-style: none;
+#right-navigation-header.rovalra-topbar-layout-search-moved
+    > .search-overlay
+    :is(ul.new-dropdown-menu, .new-dropdown-menu) {
+    box-sizing: border-box;
+    pointer-events: auto;
 }
 
-.rovalra-sidebar-layout-item {
-    display: flex;
-    min-height: 52px;
-    align-items: center;
-    gap: 12px;
-    padding: 10px 12px;
-    border-radius: 8px;
-    background-color: var(--rovalra-container-background-color);
-    cursor: grab;
-    transition:
-        transform 0.15s ease,
-        opacity 0.15s ease,
-        background-color 0.15s ease;
-    user-select: none;
+#right-navigation-header.rovalra-topbar-layout-search-moved[data-rovalra-topbar-layout-search-edge='left']
+    > .search-overlay
+    :is(ul.new-dropdown-menu, .new-dropdown-menu) {
+    right: auto !important;
+    left: var(--rovalra-topbar-layout-search-left, 12px) !important;
+    max-width: calc(
+        100vw - var(--rovalra-topbar-layout-search-left, 12px) - 12px
+    ) !important;
+    transform: none !important;
 }
 
-.rovalra-sidebar-layout-item:hover {
-    background-color: var(--rovalra-button-background-color);
+#right-navigation-header.rovalra-topbar-layout-search-moved[data-rovalra-topbar-layout-search-edge='right']
+    > .search-overlay
+    :is(ul.new-dropdown-menu, .new-dropdown-menu) {
+    right: var(--rovalra-topbar-layout-search-right, 12px) !important;
+    left: auto !important;
+    max-width: calc(
+        100vw - var(--rovalra-topbar-layout-search-right, 12px) - 12px
+    ) !important;
+    transform: none !important;
 }
 
-.rovalra-sidebar-layout-item-hidden {
-    opacity: 0.65;
+#right-navigation-header.rovalra-topbar-layout-search-moved
+    [data-rovalra-topbar-layout-key='search']
+    :is(.search-landing-container, section[data-testid='SearchLandingPageOmniFeedTestId']) {
+    box-sizing: border-box !important;
 }
 
-.rovalra-sidebar-layout-item-disabled {
-    opacity: 0.65;
+#right-navigation-header.rovalra-topbar-layout-search-moved[data-rovalra-topbar-layout-search-edge='left']
+    [data-rovalra-topbar-layout-key='search']
+    :is(.search-landing-container, section[data-testid='SearchLandingPageOmniFeedTestId']) {
+    right: auto !important;
+    left: var(--rovalra-topbar-layout-search-left, 12px) !important;
+    width: 800px !important;
+    max-width: calc(
+        100vw - var(--rovalra-topbar-layout-search-left, 12px) - 12px
+    ) !important;
+    transform: none !important;
 }
 
-.rovalra-sidebar-layout-item-hidden .rovalra-sidebar-layout-label {
-    color: var(--rovalra-secondary-text-color, #606162);
+#right-navigation-header.rovalra-topbar-layout-search-moved[data-rovalra-topbar-layout-search-edge='right']
+    [data-rovalra-topbar-layout-key='search']
+    :is(.search-landing-container, section[data-testid='SearchLandingPageOmniFeedTestId']) {
+    right: var(--rovalra-topbar-layout-search-right, 12px) !important;
+    left: auto !important;
+    width: 800px !important;
+    max-width: calc(
+        100vw - var(--rovalra-topbar-layout-search-right, 12px) - 12px
+    ) !important;
+    transform: none !important;
 }
 
-.rovalra-sidebar-layout-drag-source {
-    opacity: 0.3;
-    transform: scale(0.95);
+[data-rovalra-topbar-layout-key][data-rovalra-topbar-layout-edge='left']
+    .popover-content {
+    box-sizing: border-box !important;
+    right: auto !important;
+    left: 12px !important;
+    max-width: calc(100vw - 24px) !important;
 }
 
-.rovalra-sidebar-layout-drag-clone {
-    z-index: 99999;
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
-    opacity: 0.8;
-    pointer-events: none;
-    transition: none;
+[data-rovalra-topbar-layout-key][data-rovalra-topbar-layout-edge='right']
+    .popover-content {
+    box-sizing: border-box !important;
+    right: 12px !important;
+    left: auto !important;
+    max-width: calc(100vw - 24px) !important;
 }
 
-.rovalra-sidebar-layout-drag-handle {
-    display: inline-flex;
-    flex: 0 0 24px;
-    align-items: center;
-    justify-content: center;
-    color: var(--text-secondary, #606162);
-    cursor: inherit;
+[data-rovalra-topbar-layout-key][data-rovalra-topbar-layout-edge='left']
+    :is(.dropdown-menu, .rbx-dropdown-menu, .popover, [role='menu']) {
+    box-sizing: border-box;
+    right: auto !important;
+    left: 0 !important;
+    max-width: calc(100vw - 24px) !important;
+    transform: none !important;
 }
 
-.rovalra-sidebar-layout-drag-handle .rovalra-sidebar-layout-icon,
-.rovalra-sidebar-layout-drag-handle svg {
-    width: 22px;
-    height: 22px;
+[data-rovalra-topbar-layout-key][data-rovalra-topbar-layout-edge='right']
+    :is(.dropdown-menu, .rbx-dropdown-menu, .popover, [role='menu']) {
+    box-sizing: border-box;
+    right: 0 !important;
+    left: auto !important;
+    max-width: calc(100vw - 24px) !important;
+    transform: none !important;
 }
 
-.rovalra-sidebar-layout-drop-indicator {
-    position: fixed;
-    z-index: 99998;
-    display: none;
-    height: 2px;
-    border-radius: 1px;
-    background-color: var(--rovalra-playbutton-color, #335fff);
-    pointer-events: none;
-    transition: all 0.15s ease;
+@mixin rovalra-layout-editor($prefix) {
+    .#{$prefix}-editor {
+        padding-bottom: 4px;
+    }
+
+    .#{$prefix}-list {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        margin: 0;
+        padding: 0;
+        list-style: none;
+    }
+
+    .#{$prefix}-item {
+        display: flex;
+        min-height: 52px;
+        align-items: center;
+        gap: 12px;
+        padding: 10px 12px;
+        border-radius: 8px;
+        background-color: var(--rovalra-container-background-color);
+        cursor: grab;
+        transition:
+            transform 0.15s ease,
+            opacity 0.15s ease,
+            background-color 0.15s ease;
+        user-select: none;
+    }
+
+    .#{$prefix}-item:hover {
+        background-color: var(--rovalra-button-background-color);
+    }
+
+    .#{$prefix}-item-hidden {
+        opacity: 0.65;
+    }
+
+    .#{$prefix}-item-disabled {
+        opacity: 0.65;
+    }
+
+    .#{$prefix}-item-hidden .#{$prefix}-label {
+        color: var(--rovalra-secondary-text-color, #606162);
+    }
+
+    .#{$prefix}-drag-source {
+        opacity: 0.3;
+        transform: scale(0.95);
+    }
+
+    .#{$prefix}-drag-clone {
+        z-index: 99999;
+        box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+        opacity: 0.8;
+        pointer-events: none;
+        transition: none;
+    }
+
+    .#{$prefix}-drag-handle {
+        display: inline-flex;
+        flex: 0 0 24px;
+        align-items: center;
+        justify-content: center;
+        color: var(--text-secondary, #606162);
+        cursor: inherit;
+    }
+
+    .#{$prefix}-drag-handle :is(.#{$prefix}-icon, svg) {
+        width: 22px;
+        height: 22px;
+    }
+
+    .#{$prefix}-drop-indicator {
+        position: fixed;
+        z-index: 99998;
+        display: none;
+        height: 2px;
+        border-radius: 1px;
+        background-color: var(--rovalra-playbutton-color, #335fff);
+        pointer-events: none;
+        transition: all 0.15s ease;
+    }
+
+    .#{$prefix}-label {
+        overflow: hidden;
+        flex: 1 1 auto;
+        min-width: 0;
+        color: var(--rovalra-main-text-color);
+        font-weight: 700;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .#{$prefix}-visibility-button {
+        display: inline-flex;
+        flex: 0 0 32px;
+        width: 32px;
+        height: 32px;
+        align-items: center;
+        justify-content: center;
+        padding: 0;
+        border: 0;
+        border-radius: 8px;
+        background: transparent;
+        color: var(--rovalra-main-text-color);
+        cursor: pointer;
+    }
+
+    .#{$prefix}-visibility-button:hover {
+        background-color: var(--rovalra-button-background-color);
+    }
+
+    .#{$prefix}-disabled-status {
+        flex: 0 0 auto;
+        color: var(--rovalra-secondary-text-color, #606162);
+        font-size: 12px;
+        font-weight: 600;
+    }
+
+    .#{$prefix}-icon,
+    .#{$prefix}-icon svg {
+        display: block;
+        width: 20px;
+        height: 20px;
+    }
+
+    .#{$prefix}-icon svg {
+        fill: currentColor;
+    }
+
+    .#{$prefix}-empty {
+        margin: 0;
+        color: var(--text-secondary, #606162);
+    }
 }
 
-.rovalra-sidebar-layout-label {
-    overflow: hidden;
-    flex: 1 1 auto;
-    min-width: 0;
-    color: var(--rovalra-main-text-color);
-    font-weight: 700;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-}
-
-.rovalra-sidebar-layout-visibility-button {
-    display: inline-flex;
-    flex: 0 0 32px;
-    width: 32px;
-    height: 32px;
-    align-items: center;
-    justify-content: center;
-    padding: 0;
-    border: 0;
-    border-radius: 8px;
-    background: transparent;
-    color: var(--rovalra-main-text-color);
-    cursor: pointer;
-}
-
-.rovalra-sidebar-layout-visibility-button:hover {
-    background-color: var(--rovalra-button-background-color);
-}
-
-.rovalra-sidebar-layout-disabled-status {
-    flex: 0 0 auto;
-    color: var(--rovalra-secondary-text-color, #606162);
-    font-size: 12px;
-    font-weight: 600;
-}
-
-.rovalra-sidebar-layout-icon,
-.rovalra-sidebar-layout-icon svg {
-    display: block;
-    width: 20px;
-    height: 20px;
-}
-
-.rovalra-sidebar-layout-icon svg {
-    fill: currentColor;
-}
-
-.rovalra-sidebar-layout-empty {
-    margin: 0;
-    color: var(--text-secondary, #606162);
-}
+@include rovalra-layout-editor('rovalra-sidebar-layout');
+@include rovalra-layout-editor('rovalra-topbar-layout');


### PR DESCRIPTION
## What does this add?

Hi again! This adds a new `Topbar Layout` editor, similar to the existing Sidebar Layout editor.

It lets users reorder or hide Roblox topbar items. Like, Marketplace can be hidden without leaving an empty gap, or Search and Create can be moved to different positions. Literally anything on the Topbar.

## How it works
The feature reuses RoValra's existing layout editor and observer systems. Topbar items are detected through their links and DOM structure. The saved layout is reapplied after page reloads, Roblox navigation, topbar rerenders, and window resizing without rebuilding Roblox's original topbar DOM.
## Testing
I spent a couple hours on testing im ps it should work without any issues.
## Preview

### Default layout

<img width="1907" height="51" alt="beforeyes" src="https://github.com/user-attachments/assets/71976283-a28a-4e1a-8e1b-090e381e5efe" />

### Customized layout

<img width="1910" height="58" alt="afteryes" src="https://github.com/user-attachments/assets/3f335bc8-5e52-40ff-832c-afcbbcefbe0b" />

## Editor
<img width="590" height="808" alt="editoryes" src="https://github.com/user-attachments/assets/f81a5523-b4b6-4c47-96b7-6fdfddfa24a4" />
