### PR TITLE
Fix badge text being offset upwards

### DIFF
--- a/src/content/core/settings/settingConfig.js
+++ b/src/content/core/settings/settingConfig.js
@@ -1861,7 +1861,7 @@ export const SETTINGS_CONFIG = {
                         maxLength: 30,
                         showCharacterCount: true,
                         default: null,
-                        contributors: ['10646979010'],
+                        contributors: ['10646979010', '1564574922'],
                     },
                     ageKidsTextPushNavbarEnabled: {
                         label: 'Show Full Badge Text',

--- a/src/css/features/sitewide/kids_theme_text.scss
+++ b/src/css/features/sitewide/kids_theme_text.scss
@@ -15,6 +15,7 @@
         text-align: center;
         text-overflow: ellipsis;
         white-space: nowrap;
+        padding-top: 2px;
     }
 }
 


### PR DESCRIPTION
Fix badge text being offset upwards, in kids_theme_text.scss