### PR TITLE
feat: add customizable background image

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -35,6 +35,9 @@
     "background": {
         "service_worker": "background.js"
     },
+    "content_security_policy": {
+        "extension_pages": "script-src 'self'; object-src 'self'; img-src 'self' data: https:;"
+    },
     "optional_permissions": ["webNavigation", "contextMenus", "webRequest"],
     "declarative_net_request": {
         "rule_resources": [

--- a/manifest.json
+++ b/manifest.json
@@ -35,9 +35,7 @@
     "background": {
         "service_worker": "background.js"
     },
-    "content_security_policy": {
-        "extension_pages": "script-src 'self'; object-src 'self'; img-src 'self' data: https:;"
-    },
+
     "optional_permissions": ["webNavigation", "contextMenus", "webRequest"],
     "declarative_net_request": {
         "rule_resources": [

--- a/public/Assets/background-wallpaper.css
+++ b/public/Assets/background-wallpaper.css
@@ -1,0 +1,16 @@
+html,
+body,
+#wallpaper {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    overflow: hidden;
+}
+
+body {
+    background: transparent;
+}
+
+#wallpaper {
+    background-color: transparent;
+}

--- a/public/Assets/background-wallpaper.html
+++ b/public/Assets/background-wallpaper.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <link rel="stylesheet" href="./background-wallpaper.css" />
+    </head>
+    <body>
+        <div id="wallpaper"></div>
+        <script src="./background-wallpaper.js"></script>
+    </body>
+</html>

--- a/public/Assets/background-wallpaper.js
+++ b/public/Assets/background-wallpaper.js
@@ -1,0 +1,78 @@
+const wallpaper = document.getElementById('wallpaper');
+const VALID_SIZES = new Set(['cover', 'contain', 'auto']);
+const VALID_REPEATS = new Set(['no-repeat', 'repeat', 'repeat-x', 'repeat-y']);
+const VALID_POSITIONS = new Set([
+    'center',
+    'top',
+    'bottom',
+    'left',
+    'right',
+    'top left',
+    'top right',
+    'bottom left',
+    'bottom right',
+]);
+let currentSource = '';
+
+function isRobloxOrigin(origin) {
+    try {
+        const { hostname, protocol } = new URL(origin);
+        return protocol === 'https:' && hostname.endsWith('.roblox.com');
+    } catch {
+        return false;
+    }
+}
+
+function normalizeSource(source) {
+    if (typeof source !== 'string') return '';
+
+    try {
+        const url = new URL(source.trim());
+        return url.protocol === 'https:' ? url.href : '';
+    } catch {
+        return '';
+    }
+}
+
+function normalizeSize(size) {
+    if (VALID_SIZES.has(size)) return size;
+    if (/^\d+%$/.test(size)) return size;
+    return 'cover';
+}
+
+window.addEventListener('message', (event) => {
+    if (!isRobloxOrigin(event.origin)) return;
+
+    const data = event.data;
+    if (!data || data.type !== 'rovalra:set-background') return;
+
+    const source = normalizeSource(data.source);
+    if (!source) {
+        if (currentSource) {
+            currentSource = '';
+            wallpaper.style.backgroundImage = '';
+        }
+        return;
+    }
+
+    const size = normalizeSize(String(data.size || 'cover'));
+    const position = VALID_POSITIONS.has(data.position)
+        ? data.position
+        : 'center';
+    const repeat = VALID_REPEATS.has(data.repeat)
+        ? data.repeat
+        : 'no-repeat';
+    const attachment =
+        data.attachment === 'scroll' || data.attachment === 'fixed'
+            ? data.attachment
+            : 'fixed';
+
+    if (source !== currentSource) {
+        currentSource = source;
+        wallpaper.style.backgroundImage = `url(${JSON.stringify(source)})`;
+    }
+    wallpaper.style.backgroundSize = size;
+    wallpaper.style.backgroundPosition = position;
+    wallpaper.style.backgroundRepeat = repeat;
+    wallpaper.style.backgroundAttachment = attachment;
+});

--- a/public/Assets/locales/en.json
+++ b/public/Assets/locales/en.json
@@ -241,6 +241,42 @@
         "light": "Light",
         "dark": "Dark"
     },
+    "customThemeEditor": {
+        "background": {
+            "title": "Customize Image Settings",
+            "source": "Image Source",
+            "opacity": "Image Opacity",
+            "customSize": "Custom Scale",
+            "blur": "Blur",
+            "overrideTopbarSidebar": "Transparent Mode",
+            "size": {
+                "label": "Background Size",
+                "cover": "Cover",
+                "contain": "Contain",
+                "auto": "Auto",
+                "custom": "Custom"
+            },
+            "position": {
+                "label": "Background Position",
+                "center": "Center",
+                "top": "Top",
+                "bottom": "Bottom",
+                "left": "Left",
+                "right": "Right",
+                "topleft": "Top Left",
+                "topright": "Top Right",
+                "bottomleft": "Bottom Left",
+                "bottomright": "Bottom Right"
+            },
+            "overlay": {
+                "color": "Overlay Color",
+                "opacity": "Overlay Opacity"
+            },
+            "errors": {
+                "invalidUrl": "Enter a valid https image URL."
+            }
+        }
+    },
     "previousPrice": {
         "offSale": "Off Sale",
         "text": "Previous Price:",

--- a/src/content/core/backgroundImage.js
+++ b/src/content/core/backgroundImage.js
@@ -1,0 +1,118 @@
+export const BACKGROUND_IMAGE_SETTING = 'customBackgroundImage';
+export const BACKGROUND_IMAGE_ENABLED_SETTING = 'CustomThemeBackgroundEnabled';
+
+export const BACKGROUND_IMAGE_SIZE_OPTIONS = [
+    'cover',
+    'contain',
+    'auto',
+    'custom',
+];
+export const BACKGROUND_IMAGE_POSITION_OPTIONS = [
+    'center',
+    'top',
+    'bottom',
+    'left',
+    'right',
+    'top left',
+    'top right',
+    'bottom left',
+    'bottom right',
+];
+export const BACKGROUND_IMAGE_REPEAT_OPTIONS = [
+    'no-repeat',
+    'repeat',
+    'repeat-x',
+    'repeat-y',
+];
+
+export const DEFAULT_BACKGROUND_IMAGE = Object.freeze({
+    source: '',
+    opacity: 1,
+    size: 'cover',
+    customSize: 100,
+    position: 'center',
+    repeat: 'no-repeat',
+    blur: 0,
+    overlayColor: '#000000',
+    overlayOpacity: 0,
+    overrideTopbarSidebar: false,
+});
+
+const HEX_COLOR_PATTERN = /^#[0-9a-f]{6}$/i;
+
+function clampNumber(value, fallback, min, max, round = false) {
+    const number = Number(value);
+    if (!Number.isFinite(number)) return fallback;
+    const clamped = Math.max(min, Math.min(max, number));
+    return round ? Math.round(clamped) : clamped;
+}
+
+function sanitizeEnum(value, options, fallback) {
+    return options.includes(value) ? value : fallback;
+}
+
+function sanitizeBackgroundSource(source) {
+    if (typeof source !== 'string') return '';
+
+    try {
+        const url = new URL(source.trim());
+        return url.protocol === 'https:' ? url.href : '';
+    } catch {
+        return '';
+    }
+}
+
+export function sanitizeBackgroundImage(value) {
+    const bg = value && typeof value === 'object' ? value : {};
+
+    return {
+        source: sanitizeBackgroundSource(bg.source),
+        opacity: clampNumber(
+            bg.opacity,
+            DEFAULT_BACKGROUND_IMAGE.opacity,
+            0,
+            1,
+        ),
+        size: sanitizeEnum(
+            bg.size,
+            BACKGROUND_IMAGE_SIZE_OPTIONS,
+            DEFAULT_BACKGROUND_IMAGE.size,
+        ),
+        customSize: clampNumber(
+            bg.customSize,
+            DEFAULT_BACKGROUND_IMAGE.customSize,
+            25,
+            300,
+            true,
+        ),
+        position: sanitizeEnum(
+            bg.position,
+            BACKGROUND_IMAGE_POSITION_OPTIONS,
+            DEFAULT_BACKGROUND_IMAGE.position,
+        ),
+        repeat: sanitizeEnum(
+            bg.repeat,
+            BACKGROUND_IMAGE_REPEAT_OPTIONS,
+            DEFAULT_BACKGROUND_IMAGE.repeat,
+        ),
+        blur: clampNumber(
+            bg.blur,
+            DEFAULT_BACKGROUND_IMAGE.blur,
+            0,
+            20,
+            true,
+        ),
+        overlayColor:
+            typeof bg.overlayColor === 'string' &&
+            HEX_COLOR_PATTERN.test(bg.overlayColor)
+                ? bg.overlayColor.toLowerCase()
+                : DEFAULT_BACKGROUND_IMAGE.overlayColor,
+        overlayOpacity: clampNumber(
+            bg.overlayOpacity,
+            DEFAULT_BACKGROUND_IMAGE.overlayOpacity,
+            0,
+            1,
+        ),
+        overrideTopbarSidebar: bg.overrideTopbarSidebar === true,
+    };
+}

--- a/src/content/core/settings/handlesettings.js
+++ b/src/content/core/settings/handlesettings.js
@@ -25,6 +25,7 @@ import {
     getRemoteSettingLocks,
     refreshRemoteSettingLocks,
 } from './remoteSettingLocks.js';
+import { sanitizeBackgroundImage } from '../backgroundImage.js';
 import { sanitizeCustomTheme } from '../themeCustom.js';
 import './settingsCompat';
 
@@ -34,6 +35,7 @@ let gradientNameSyncTimeout = null;
 let donatorTierPromise = null;
 let inMemoryDonatorResponse = null;
 let inMemoryDonatorUserId = null;
+let settingsKeySyncQueue = Promise.resolve();
 const colorLiveSaveTimeouts = new Map();
 const FEATURE_STATUS_PROMPT_ACK_KEY = 'featureStatusPromptAcknowledged';
 const CUSTOM_THEME_NAME_MAX_LENGTH = 20;
@@ -487,11 +489,12 @@ export const loadSettings = async () => {
                         }
                     }
 
-                    const normalisedSettings = settings;
-                    for (const [key, value] of Object.entries(forcedSettings)) {
-                        normalisedSettings[key] = value;
+                    for (const [key, value] of Object.entries(
+                        forcedSettings,
+                    )) {
+                        settings[key] = value;
                     }
-                    resolve(normalisedSettings);
+                    resolve(settings);
                 }
             },
         );
@@ -828,6 +831,10 @@ export const handleSaveSettings = async (settingName, value) => {
                 case 'themeSlots':
                     sanitizedValue = sanitizeCustomThemeSlots(value);
                     break;
+
+                case 'backgroundImage':
+                    sanitizedValue = sanitizeBackgroundImage(value);
+                    break;
             }
         }
 
@@ -964,11 +971,34 @@ export const handleSaveSettings = async (settingName, value) => {
 };
 
 const syncToSettingsKey = (settingName, value) => {
-    chrome.storage.local.get('rovalra_settings', (result) => {
-        const settingsData = result.rovalra_settings || {};
-        settingsData[settingName] = value;
-        chrome.storage.local.set({ rovalra_settings: settingsData });
-    });
+    settingsKeySyncQueue = settingsKeySyncQueue
+        .catch(() => {})
+        .then(
+            () =>
+                new Promise((resolve, reject) => {
+                    chrome.storage.local.get('rovalra_settings', (result) => {
+                        if (chrome.runtime.lastError) {
+                            reject(chrome.runtime.lastError);
+                            return;
+                        }
+
+                        const settingsData = result.rovalra_settings || {};
+                        settingsData[settingName] = value;
+                        chrome.storage.local.set(
+                            { rovalra_settings: settingsData },
+                            () => {
+                                if (chrome.runtime.lastError) {
+                                    reject(chrome.runtime.lastError);
+                                } else {
+                                    resolve();
+                                }
+                            },
+                        );
+                    });
+                }),
+        );
+
+    return settingsKeySyncQueue;
 };
 
 export const buildSettingsKey = async () => {

--- a/src/content/core/settings/settingConfig.js
+++ b/src/content/core/settings/settingConfig.js
@@ -3,6 +3,7 @@ import {
     TRANSACTION_FIAT_CURRENCY_OPTIONS,
     TRANSACTION_FIAT_RATE_OPTIONS,
 } from '../transactions/fiatConfig.js';
+import { DEFAULT_BACKGROUND_IMAGE } from '../backgroundImage.js';
 import { DEFAULT_CUSTOM_THEME } from '../themeCustom.js';
 
 const isAprilFools = () => {
@@ -2026,6 +2027,30 @@ export const SETTINGS_CONFIG = {
                         type: 'themeSlots',
                         default: [],
                         hidden: true,
+                    },
+                },
+            },
+            CustomThemeBackgroundEnabled: {
+                label: 'Customizable Background Image',
+                description:
+                    'Allows you to add a custom background image to the Roblox website.',
+                type: 'checkbox',
+                default: false,
+                contributors: ['476449201'],
+                childSettings: {
+                    customBackgroundImage: {
+                        label: 'Background Image Configuration',
+                        type: 'backgroundImage',
+                        default: DEFAULT_BACKGROUND_IMAGE,
+                        hidden: true,
+                    },
+                    openCustomThemeBackground: {
+                        label: 'Customize Image Settings',
+                        description:
+                            "Adjust the image's opacity, blur, position, size, and more.",
+                        type: 'button',
+                        buttonText: 'Edit',
+                        event: 'rovalra:openCustomThemeBackground',
                     },
                 },
             },

--- a/src/content/core/utils/sanitize.js
+++ b/src/content/core/utils/sanitize.js
@@ -1,3 +1,5 @@
+import { sanitizeBackgroundImage } from '../backgroundImage.js';
+
 // Technically not in use but still nice to have
 export function sanitizeString(str) {
     if (typeof str !== 'string') return str;
@@ -190,6 +192,10 @@ export function sanitizeSettings(settings, SETTINGS_CONFIG = null) {
                         console.warn(`Sanitizing: Invalid image data for '${key}' - clearing`);
                         sanitizedValue = null;
                     }
+                    break;
+
+                case 'backgroundImage':
+                    sanitizedValue = sanitizeBackgroundImage(value);
                     break;
                     
                 default:

--- a/src/content/features/home/customThemeEditor.js
+++ b/src/content/features/home/customThemeEditor.js
@@ -2,6 +2,7 @@ import { createButton } from '../../core/ui/buttons.js';
 import { createOverlay } from '../../core/ui/overlay.js';
 import { createDropdown } from '../../core/ui/dropdown.js';
 import { createPillToggle } from '../../core/ui/general/pillToggle.js';
+import { ts } from '../../core/locale/i18n.js';
 import {
     handleSaveSettings,
     loadSettings,
@@ -9,12 +10,21 @@ import {
 import { createStyledInput } from '../../core/ui/catalog/input.js';
 import { CUSTOM_THEME_SLOT_COUNT } from '../../core/themeCatalog.js';
 import {
+    BACKGROUND_IMAGE_ENABLED_SETTING,
+    BACKGROUND_IMAGE_POSITION_OPTIONS,
+    BACKGROUND_IMAGE_SETTING,
+    BACKGROUND_IMAGE_SIZE_OPTIONS,
+    DEFAULT_BACKGROUND_IMAGE,
+    sanitizeBackgroundImage,
+} from '../../core/backgroundImage.js';
+import {
     CUSTOM_THEME_FIELDS,
     DEFAULT_CUSTOM_THEME,
     getCustomThemeAlphaKey,
     sanitizeCustomTheme,
 } from '../../core/themeCustom.js';
 import {
+    applyBackgroundImage,
     applyCustomTheme,
     applyCustomThemeField,
     setTheme,
@@ -22,6 +32,8 @@ import {
 import { THEME_PATH } from '../themes/themeCatalogPage.js';
 
 const ACTIVE_SESSION_KEY = 'rovalra_custom_theme_editor_active';
+const BG_EDITOR_SESSION_KEY =
+    'rovalra_custom_theme_background_editor_active';
 const PENDING_THEME_OPEN_KEY = 'rovalra_custom_theme_editor_pending_theme';
 const SELECTED_SLOT_SESSION_KEY = 'rovalra_custom_theme_editor_slot';
 const SAVE_DELAY_MS = 120;
@@ -31,16 +43,39 @@ const EDITOR_MODES = [
     { key: 'roblox', label: 'Roblox' },
     { key: 'rovalra', label: 'RoValra' },
 ];
-
+const BG_SIZE_ITEMS = [
+    { label: 'Cover', value: 'cover' },
+    { label: 'Contain', value: 'contain' },
+    { label: 'Auto', value: 'auto' },
+    { label: 'Custom', value: 'custom' },
+];
+const BG_POSITION_ITEMS = [
+    { label: 'Center', value: 'center' },
+    { label: 'Top', value: 'top' },
+    { label: 'Bottom', value: 'bottom' },
+    { label: 'Left', value: 'left' },
+    { label: 'Right', value: 'right' },
+    { label: 'Top Left', value: 'top left' },
+    { label: 'Top Right', value: 'top right' },
+    { label: 'Bottom Left', value: 'bottom left' },
+    { label: 'Bottom Right', value: 'bottom right' },
+];
+const BG_TOGGLE_SETTING = BACKGROUND_IMAGE_ENABLED_SETTING;
 let initialized = false;
 let saveTimeout = null;
+let bgSaveTimeout = null;
 let textInputTimeouts = new Map();
 let currentTheme = { ...DEFAULT_CUSTOM_THEME };
+let backgroundImageConfig = { ...DEFAULT_BACKGROUND_IMAGE };
+let backgroundEnabled = false;
 let overlayHandle = null;
 let editorInputs = new Map();
 let editorRgbInputs = new Map();
 let editorAlphaInputs = new Map();
 let editorAlphaNumberInputs = new Map();
+let bgControls = null;
+let bgUrlTimeout = null;
+let bgOverlayHandle = null;
 let pendingThemeFieldKeys = new Set();
 let applyFrame = null;
 let customThemeSlots = [];
@@ -159,6 +194,10 @@ function areThemesEqual(left, right) {
     }
 
     return true;
+}
+
+function text(key, defaultValue, options = {}) {
+    return ts(`customThemeEditor.${key}`, { defaultValue, ...options });
 }
 
 function getModeFields(mode = editorMode) {
@@ -293,6 +332,14 @@ function flushTextInputTimeouts() {
     }
 }
 
+function flushBgUrlInput() {
+    if (!bgUrlTimeout) return;
+
+    clearTimeout(bgUrlTimeout);
+    bgUrlTimeout = null;
+    if (bgControls?.urlInput) applyBgUrlInput(bgControls.urlInput);
+}
+
 async function flushSave() {
     flushTextInputTimeouts();
 
@@ -302,6 +349,37 @@ async function flushSave() {
     }
 
     await persistCurrentSlot();
+}
+
+async function persistBackgroundConfig() {
+    await handleSaveSettings(
+        BACKGROUND_IMAGE_SETTING,
+        sanitizeBackgroundImage(backgroundImageConfig),
+    );
+}
+
+function scheduleBackgroundSave() {
+    if (bgSaveTimeout) clearTimeout(bgSaveTimeout);
+    bgSaveTimeout = setTimeout(() => {
+        bgSaveTimeout = null;
+        persistBackgroundConfig().catch((error) => {
+            console.error(
+                'RoValra: Failed to save background image settings.',
+                error,
+            );
+        });
+    }, SAVE_DELAY_MS);
+}
+
+async function flushBackgroundSave() {
+    flushBgUrlInput();
+
+    if (bgSaveTimeout) {
+        clearTimeout(bgSaveTimeout);
+        bgSaveTimeout = null;
+    }
+
+    await persistBackgroundConfig();
 }
 
 function scheduleFieldApply(key) {
@@ -448,6 +526,381 @@ function syncInputs(themeValue) {
     currentTheme = sanitizeCustomTheme(themeValue);
     for (const field of getModeFields()) syncSingleInput(field.key);
     applyCustomTheme(currentTheme);
+}
+
+function getBg() {
+    return sanitizeBackgroundImage(backgroundImageConfig);
+}
+
+function applyBackgroundPreview() {
+    applyBackgroundImage(getBg(), backgroundEnabled);
+}
+
+function setBg(next, { immediate = false } = {}) {
+    backgroundImageConfig = sanitizeBackgroundImage({
+        ...getBg(),
+        ...next,
+    });
+    syncBgControls();
+    applyBackgroundPreview();
+    if (next.source && backgroundEnabled !== true) {
+        backgroundEnabled = true;
+        saveBgToggle(true);
+    }
+    if (immediate) {
+        persistBackgroundConfig().catch((error) => {
+            console.error(
+                'RoValra: Failed to save background image settings.',
+                error,
+            );
+        });
+        return;
+    }
+    scheduleBackgroundSave();
+}
+
+function saveBgToggle(enabled) {
+    handleSaveSettings(BG_TOGGLE_SETTING, enabled)
+        .catch((error) => {
+            console.error('RoValra: Failed to save background toggle.', error);
+        });
+}
+
+async function applyBgToggle(enabled) {
+    try {
+        backgroundEnabled = enabled === true;
+        if (!bgOverlayHandle) {
+            const settings = await loadSettings();
+            backgroundImageConfig = sanitizeBackgroundImage(
+                settings[BACKGROUND_IMAGE_SETTING],
+            );
+        }
+        applyBackgroundPreview();
+    } catch (error) {
+        console.error('RoValra: Failed to toggle background image.', error);
+    }
+}
+
+function normalizeBgUrl(value) {
+    try {
+        const url = new URL(String(value || '').trim());
+        return url.protocol === 'https:' ? url.href : null;
+    } catch {
+        return String(value || '').trim() ? null : '';
+    }
+}
+
+function applyBgUrlInput(urlInput, updates = {}) {
+    const bgUrl = normalizeBgUrl(urlInput.value);
+    if (bgUrl === null) {
+        setBgError(
+            text(
+                'background.errors.invalidUrl',
+                'Enter a valid https image URL.',
+            ),
+        );
+        urlInput.classList.add('rovalra-custom-theme-selector-input-invalid');
+        return;
+    }
+
+    setBgError('');
+    urlInput.classList.remove('rovalra-custom-theme-selector-input-invalid');
+    if (bgUrl) {
+        backgroundEnabled = true;
+        saveBgToggle(true);
+    }
+    setBg(
+        {
+            ...updates,
+            source: bgUrl,
+        },
+        { immediate: true },
+    );
+}
+
+function scheduleBgUrlInput(urlInput) {
+    if (bgUrlTimeout) clearTimeout(bgUrlTimeout);
+    bgUrlTimeout = setTimeout(() => {
+        bgUrlTimeout = null;
+        applyBgUrlInput(urlInput);
+    }, TEXT_INPUT_DELAY_MS);
+}
+
+function setBgError(message = '') {
+    if (!bgControls?.error) return;
+    bgControls.error.textContent = message;
+    bgControls.error.hidden = !message;
+}
+
+function createBgToggle({ checked = false, ariaLabel, onChange }) {
+    const label = document.createElement('label');
+    label.className = 'toggle-switch rovalra-custom-theme-background-toggle';
+
+    const input = document.createElement('input');
+    input.type = 'checkbox';
+    input.checked = checked;
+    input.setAttribute('aria-label', ariaLabel);
+    input.addEventListener('change', () => onChange(input.checked));
+
+    const slider = document.createElement('span');
+    slider.className = 'slider';
+
+    label.append(input, slider);
+
+    return { element: label, input };
+}
+
+function createBgRow(labelText, control) {
+    const row = document.createElement('div');
+    row.className = 'rovalra-custom-theme-background-row';
+
+    const label = document.createElement('label');
+    label.className = 'rovalra-custom-theme-selector-label';
+    label.textContent = labelText;
+
+    row.append(label, control);
+    return row;
+}
+
+function createBgRange({ label, min, max, step = 1, value, unit = '', onInput }) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'rovalra-custom-theme-background-range';
+
+    const input = document.createElement('input');
+    input.type = 'range';
+    input.min = String(min);
+    input.max = String(max);
+    input.step = String(step);
+    input.value = String(value);
+    input.setAttribute('aria-label', label);
+
+    const valueEl = document.createElement('span');
+    valueEl.className = 'rovalra-custom-theme-background-range-value';
+
+    const update = (next) => {
+        valueEl.textContent = `${next}${unit}`;
+        input.setAttribute('aria-valuetext', valueEl.textContent);
+    };
+
+    input.addEventListener('input', () => {
+        update(input.value);
+        onInput(Number(input.value));
+    });
+
+    update(value);
+    wrapper.append(input, valueEl);
+
+    const row = createBgRow(label, wrapper);
+    row.rovalraRangeInput = input;
+    row.rovalraRangeValue = valueEl;
+    return row;
+}
+
+function syncBgRange(row, value, unit) {
+    row.rovalraRangeInput.value = value;
+    row.rovalraRangeValue.textContent = `${value}${unit}`;
+    row.rovalraRangeInput.setAttribute(
+        'aria-valuetext',
+        row.rovalraRangeValue.textContent,
+    );
+}
+
+function syncBgControls() {
+    if (!bgControls) return;
+
+    const bg = getBg();
+    const opacity = Math.round(bg.opacity * 100);
+    const overlay = Math.round(bg.overlayOpacity * 100);
+
+    bgControls.urlInput.value = bg.source;
+    syncBgRange(bgControls.opacityRow, opacity, '%');
+    syncBgRange(bgControls.blurRow, bg.blur, 'px');
+    syncBgRange(bgControls.customSizeRow, bg.customSize, '%');
+    bgControls.customSizeRow.hidden = bg.size !== 'custom';
+    bgControls.overlayColor.value = bg.overlayColor;
+    syncBgRange(bgControls.overlayOpacityRow, overlay, '%');
+    bgControls.overrideTopbarSidebar.checked = bg.overrideTopbarSidebar;
+    bgControls.sizeDropdown.setValue(bg.size);
+    bgControls.positionDropdown.setValue(bg.position);
+}
+
+function createBgDropdown(items, value, validValues, onChange) {
+    const dropdown = createDropdown({
+        items,
+        initialValue: value,
+        onValueChange: (next) => {
+            if (!validValues.includes(next)) return;
+            onChange(next);
+        },
+    });
+    dropdown.element.classList.add('rovalra-custom-theme-background-dropdown');
+    dropdown.panel.classList.add(
+        'rovalra-custom-theme-background-dropdown-panel',
+    );
+    return dropdown;
+}
+
+function createBgSection() {
+    const bg = getBg();
+    const section = document.createElement('section');
+    section.className =
+        'rovalra-custom-theme-background-section rovalra-custom-theme-background-section-compact';
+    const { container: urlContainer, input: urlInput } = createStyledInput({
+        id: 'rovalra-custom-theme-background-url',
+        label: '',
+        placeholder: 'https://example.com/image.png',
+        value: bg.source,
+    });
+    urlContainer.classList.add('rovalra-custom-theme-background-url-wrapper');
+    urlInput.type = 'url';
+    urlInput.addEventListener('input', () => scheduleBgUrlInput(urlInput));
+    urlInput.addEventListener('change', () => applyBgUrlInput(urlInput));
+
+    const sourceControls = document.createElement('div');
+    sourceControls.className = 'rovalra-custom-theme-background-source';
+    sourceControls.append(urlContainer);
+
+    const sourceRow = createBgRow(
+        text('background.source', 'Image Source'),
+        sourceControls,
+    );
+
+    const error = document.createElement('div');
+    error.className = 'rovalra-custom-theme-background-error';
+    error.hidden = true;
+    error.setAttribute('role', 'alert');
+
+    const opacityRow = createBgRange({
+        label: text('background.opacity', 'Image Opacity'),
+        min: 0,
+        max: 100,
+        value: Math.round(bg.opacity * 100),
+        unit: '%',
+        onInput: (value) => setBg({ opacity: value / 100 }),
+    });
+
+    const sizeDropdown = createBgDropdown(
+        BG_SIZE_ITEMS.map((item) => ({
+            ...item,
+            label: text(`background.size.${item.value}`, item.label),
+        })),
+        bg.size,
+        BACKGROUND_IMAGE_SIZE_OPTIONS,
+        (size) => setBg({ size }, { immediate: true }),
+    );
+    const sizeRow = createBgRow(
+        text('background.size.label', 'Background Size'),
+        sizeDropdown.element,
+    );
+
+    const customSizeRow = createBgRange({
+        label: text('background.customSize', 'Custom Scale'),
+        min: 25,
+        max: 300,
+        value: bg.customSize,
+        unit: '%',
+        onInput: (customSize) => setBg({ customSize }),
+    });
+    customSizeRow.hidden = bg.size !== 'custom';
+
+    const positionDropdown = createBgDropdown(
+        BG_POSITION_ITEMS.map((item) => ({
+            ...item,
+            label: text(
+                `background.position.${item.value.replaceAll(' ', '')}`,
+                item.label,
+            ),
+        })),
+        bg.position,
+        BACKGROUND_IMAGE_POSITION_OPTIONS,
+        (position) => setBg({ position }, { immediate: true }),
+    );
+
+    const blurRow = createBgRange({
+        label: text('background.blur', 'Blur'),
+        min: 0,
+        max: 20,
+        value: bg.blur,
+        unit: 'px',
+        onInput: (blur) => setBg({ blur }),
+    });
+
+    const overlayColor = document.createElement('input');
+    overlayColor.type = 'color';
+    overlayColor.value = bg.overlayColor;
+    overlayColor.setAttribute(
+        'aria-label',
+        text('background.overlay.color', 'Overlay Color'),
+    );
+    overlayColor.addEventListener('input', () =>
+        setBg({ overlayColor: overlayColor.value }),
+    );
+    const overlayColorRow = createBgRow(
+        text('background.overlay.color', 'Overlay Color'),
+        overlayColor,
+    );
+
+    const overlayOpacityRow = createBgRange({
+        label: text('background.overlay.opacity', 'Overlay Opacity'),
+        min: 0,
+        max: 100,
+        value: Math.round(bg.overlayOpacity * 100),
+        unit: '%',
+        onInput: (value) => setBg({ overlayOpacity: value / 100 }),
+    });
+
+    const { element: overrideTopbarSidebarToggle, input: overrideTopbarSidebarInput } = createBgToggle({
+        checked: bg.overrideTopbarSidebar,
+        ariaLabel: text(
+            'background.overrideTopbarSidebar',
+            'Transparent Mode',
+        ),
+        onChange: (overrideTopbarSidebar) =>
+            setBg({ overrideTopbarSidebar }, { immediate: true }),
+    });
+
+    const overrideTopbarSidebarRow = createBgRow(
+        text(
+            'background.overrideTopbarSidebar',
+            'Transparent Mode',
+        ),
+        overrideTopbarSidebarToggle,
+    );
+    overrideTopbarSidebarRow.classList.add(
+        'rovalra-custom-theme-background-toggle-row',
+    );
+
+    section.append(
+        sourceRow,
+        error,
+        opacityRow,
+        blurRow,
+        overlayOpacityRow,
+        overlayColorRow,
+        overrideTopbarSidebarRow,
+        sizeRow,
+        customSizeRow,
+        createBgRow(
+            text('background.position.label', 'Background Position'),
+            positionDropdown.element,
+        ),
+    );
+
+    bgControls = {
+        urlInput,
+        error,
+        opacityRow,
+        sizeDropdown,
+        customSizeRow,
+        positionDropdown,
+        blurRow,
+        overlayColor,
+        overlayOpacityRow,
+        overrideTopbarSidebar: overrideTopbarSidebarInput,
+    };
+    syncBgControls();
+
+    return section;
 }
 
 function syncSlotDropdownLabels() {
@@ -752,6 +1205,78 @@ function createEditorBody() {
     return body;
 }
 
+async function openBgEditor() {
+    if (bgOverlayHandle) return;
+
+    sessionStorage.setItem(BG_EDITOR_SESSION_KEY, 'true');
+
+    const settings = await loadSettings();
+    backgroundImageConfig = sanitizeBackgroundImage(
+        settings[BACKGROUND_IMAGE_SETTING],
+    );
+    backgroundEnabled = settings[BG_TOGGLE_SETTING] === true;
+    applyBackgroundPreview();
+
+    const closeButton = createButton('Close', 'primary', {
+        onClick: () => {
+            flushBackgroundSave()
+                .catch((error) => {
+                    console.error(
+                        'RoValra: Failed to save custom background.',
+                        error,
+                    );
+                })
+                .finally(() => bgOverlayHandle?.close());
+        },
+    });
+
+    const resetButton = createButton('Reset', 'secondary', {
+        onClick: () => {
+            setBgError('');
+            backgroundImageConfig = { ...DEFAULT_BACKGROUND_IMAGE };
+            backgroundEnabled = false;
+            saveBgToggle(false);
+            syncBgControls();
+            applyBackgroundPreview();
+            persistBackgroundConfig().catch((error) => {
+                console.error(
+                    'RoValra: Failed to reset background image settings.',
+                    error,
+                );
+            });
+        },
+    });
+
+    const body = document.createElement('div');
+    body.className =
+        'rovalra-custom-theme-selector-body rovalra-custom-theme-background-body';
+    body.append(createBgSection());
+
+    bgOverlayHandle = createOverlay({
+        title: text('background.title', 'Customize Image Settings'),
+        bodyContent: body,
+        actions: [resetButton, closeButton],
+        maxWidth: '420px',
+        maxHeight: 'calc(100vh - 96px)',
+        preventBackdropClose: true,
+        onClose: () => {
+            if (bgUrlTimeout) clearTimeout(bgUrlTimeout);
+            bgUrlTimeout = null;
+            if (bgSaveTimeout) clearTimeout(bgSaveTimeout);
+            bgSaveTimeout = null;
+            destroyBgControls();
+            sessionStorage.removeItem(BG_EDITOR_SESSION_KEY);
+            bgOverlayHandle = null;
+        },
+    });
+    bgOverlayHandle.overlay.classList.add(
+        'rovalra-custom-theme-selector-overlay',
+        'rovalra-custom-theme-background-overlay',
+    );
+    document.body.style.overflow = '';
+    syncBgControls();
+}
+
 function closeEditor() {
     if (!overlayHandle) return;
     const { close } = overlayHandle;
@@ -874,6 +1399,25 @@ function maybeRestoreOpenEditor() {
     });
 }
 
+function destroyBgControls() {
+    bgControls?.sizeDropdown.destroy();
+    bgControls?.positionDropdown.destroy();
+    bgControls = null;
+}
+
+function maybeRestoreBgEditor() {
+    if (sessionStorage.getItem(BG_EDITOR_SESSION_KEY) !== 'true') return;
+
+    if (bgOverlayHandle && !document.body.contains(bgOverlayHandle.overlay)) bgOverlayHandle = null;
+
+    openBgEditor().catch((error) => {
+        console.error(
+            'RoValra: Failed to restore custom background settings.',
+            error,
+        );
+    });
+}
+
 export function init() {
     if (!initialized) {
         initialized = true;
@@ -883,6 +1427,20 @@ export function init() {
                 routeTheme: true,
                 slotIndex: event.detail?.slotIndex ?? 0,
             });
+        });
+
+        document.addEventListener('rovalra:openCustomThemeBackground', () => {
+            openBgEditor().catch((error) => {
+                console.error(
+                    'RoValra: Failed to open custom background settings.',
+                    error,
+                );
+            });
+        });
+
+        document.addEventListener('rovalra:settingSaved', (event) => {
+            if (event.detail?.name !== BG_TOGGLE_SETTING) return;
+            applyBgToggle(event.detail.value === true);
         });
 
         chrome.storage.onChanged.addListener((changes, namespace) => {
@@ -899,13 +1457,19 @@ export function init() {
         });
 
         window.addEventListener('popstate', maybeRestoreOpenEditor);
+        window.addEventListener('popstate', maybeRestoreBgEditor);
+        window.addEventListener('rovalra:urlChanged', maybeRestoreBgEditor);
     }
 
     if (document.readyState === 'loading') {
         document.addEventListener('DOMContentLoaded', maybeRestoreOpenEditor, {
             once: true,
         });
+        document.addEventListener('DOMContentLoaded', maybeRestoreBgEditor, {
+            once: true,
+        });
     } else {
         maybeRestoreOpenEditor();
+        maybeRestoreBgEditor();
     }
 }

--- a/src/content/features/sitewide/themeSwitcher.js
+++ b/src/content/features/sitewide/themeSwitcher.js
@@ -1,6 +1,12 @@
 import { settings } from '../../core/settings/getSettings';
 import { observeAttributes } from '../../core/observer.js';
 import {
+    BACKGROUND_IMAGE_ENABLED_SETTING,
+    BACKGROUND_IMAGE_SETTING,
+    DEFAULT_BACKGROUND_IMAGE,
+    sanitizeBackgroundImage,
+} from '../../core/backgroundImage.js';
+import {
     CUSTOM_THEME_FIELDS,
     DEFAULT_CUSTOM_THEME,
     getCustomThemeAlphaKey,
@@ -50,6 +56,27 @@ const HEX_COLOR_PATTERN = /^#[0-9a-f]{6}$/i;
 const CUSTOM_THEME_FIELD_MAP = new Map(
     CUSTOM_THEME_FIELDS.map((field) => [field.key, field]),
 );
+const BG_LAYER_ID = 'rovalra-custom-background-layer';
+const BG_ACTIVE_CLASS = 'rovalra-custom-background-image-active';
+const BG_NAV_OVERRIDE_CLASS = 'rovalra-custom-background-nav-override';
+const BG_CSS_PROPERTIES = [
+    '--rovalra-background-image-opacity',
+    '--rovalra-background-image-size',
+    '--rovalra-background-image-position',
+    '--rovalra-background-image-repeat',
+    '--rovalra-background-image-blur',
+    '--rovalra-background-overlay-color',
+    '--rovalra-background-overlay-opacity',
+];
+const BG_OVERLAY_CLASS = 'rovalra-custom-background-overlay';
+const BG_FRAME_CLASS = 'rovalra-custom-background-frame';
+const BG_FRAME_PATH = 'public/Assets/background-wallpaper.html';
+const BG_SUPPORTED_HOSTS = new Set(['www.roblox.com', 'roblox.com']);
+const EXTENSION_ORIGIN = new URL(chrome.runtime.getURL('/')).origin;
+
+function isBackgroundImageSupportedHost() {
+    return BG_SUPPORTED_HOSTS.has(window.location.hostname);
+}
 
 async function loadThemeData() {
     if (Object.keys(ThemeData).length > 0) return;
@@ -168,6 +195,8 @@ async function prepareRenderedTheme(changes = null) {
                 'ThemeSwitcherEnabled',
                 'ThemeSwitcher',
                 'customUserTheme',
+                BACKGROUND_IMAGE_SETTING,
+                BACKGROUND_IMAGE_ENABLED_SETTING,
             ]) {
                 if (storageChanges[key]) {
                     relevantChanges[key] = storageChanges[key];
@@ -188,6 +217,7 @@ async function prepareRenderedTheme(changes = null) {
         themeEnforcementEnabled = false;
         activeThemeKey = null;
         activeCustomThemeValue = undefined;
+        await applyStoredBackgroundImage(changes);
         return;
     }
 
@@ -210,6 +240,8 @@ async function prepareRenderedTheme(changes = null) {
         case theme:
             console.error(`(RoValra) Theme Switcher: Unknown theme "${theme}"`);
     }
+
+    await applyStoredBackgroundImage(changes);
 }
 
 export async function refreshThemeSwitcher() {
@@ -217,6 +249,182 @@ export async function refreshThemeSwitcher() {
 }
 
 // Custom themes
+
+function getBgRoot() {
+    return document.body || document.documentElement;
+}
+
+function pruneBgLayers(primaryLayer) {
+    document.querySelectorAll(`#${BG_LAYER_ID}`).forEach((layer) => {
+        if (layer !== primaryLayer) layer.remove();
+    });
+}
+
+function createBgFrame() {
+    const frame = document.createElement('iframe');
+    frame.className = BG_FRAME_CLASS;
+    frame.src = chrome.runtime.getURL(BG_FRAME_PATH);
+    frame.setAttribute('aria-hidden', 'true');
+    frame.tabIndex = -1;
+    return frame;
+}
+
+function getBgParts() {
+    const root = getBgRoot();
+    let layer = document.getElementById(BG_LAYER_ID);
+
+    if (layer && layer.parentElement !== root) {
+        layer.remove();
+        layer = null;
+    }
+
+    if (!layer) {
+        layer = document.createElement('div');
+        layer.id = BG_LAYER_ID;
+        layer.setAttribute('aria-hidden', 'true');
+        layer.tabIndex = -1;
+        root.appendChild(layer);
+    }
+
+    let frame = layer.querySelector(`.${BG_FRAME_CLASS}`);
+    let overlay = layer.querySelector(`.${BG_OVERLAY_CLASS}`);
+
+    if (!frame) {
+        frame = createBgFrame();
+        layer.prepend(frame);
+    }
+
+    if (!overlay) {
+        overlay = document.createElement('div');
+        overlay.className = BG_OVERLAY_CLASS;
+        layer.appendChild(overlay);
+    }
+
+    pruneBgLayers(layer);
+    return { root, frame, overlay };
+}
+
+function clearBackgroundImage() {
+    const root = getBgRoot();
+    const classTargets = new Set([root, document.documentElement]);
+    if (document.body) classTargets.add(document.body);
+
+    for (const target of classTargets) {
+        target.classList.remove(BG_ACTIVE_CLASS, BG_NAV_OVERRIDE_CLASS);
+    }
+
+    for (const property of BG_CSS_PROPERTIES) {
+        for (const target of classTargets) {
+            target.style.removeProperty(property);
+        }
+    }
+
+    document.querySelectorAll(`#${BG_LAYER_ID}`).forEach((layer) => {
+        layer.remove();
+    });
+}
+
+function getBgState(bg) {
+    return {
+        source: bg.source,
+        size: bg.size === 'custom' ? `${bg.customSize}%` : bg.size,
+        position: bg.position,
+        repeat: bg.repeat,
+        attachment: 'fixed',
+        opacity: String(bg.opacity),
+        filter: `blur(${bg.blur}px)`,
+        overlayColor: bg.overlayColor,
+        overlayOpacity: String(bg.overlayOpacity),
+    };
+}
+
+function postBgState(frame, state) {
+    if (!frame.contentWindow) return;
+
+    frame.contentWindow.postMessage(
+        {
+            type: 'rovalra:set-background',
+            source: state.source,
+            size: state.size,
+            position: state.position,
+            repeat: state.repeat,
+            attachment: state.attachment,
+            opacity: state.opacity,
+            filter: state.filter,
+        },
+        EXTENSION_ORIGIN,
+    );
+}
+
+function setStyle(style, property, value) {
+    if (style[property] !== value) style[property] = value;
+}
+
+function setVar(element, property, value) {
+    if (element.style.getPropertyValue(property) !== value) {
+        element.style.setProperty(property, value);
+    }
+}
+
+function applyBackground(value) {
+    const bg = sanitizeBackgroundImage(value);
+
+    if (!bg.source) {
+        clearBackgroundImage();
+        return;
+    }
+
+    const { root, frame, overlay } = getBgParts();
+    const state = getBgState(bg);
+
+    root.classList.add(BG_ACTIVE_CLASS);
+    document.body?.classList.add(BG_ACTIVE_CLASS);
+    root.classList.toggle(BG_NAV_OVERRIDE_CLASS, bg.overrideTopbarSidebar);
+    document.body?.classList.toggle(
+        BG_NAV_OVERRIDE_CLASS,
+        bg.overrideTopbarSidebar,
+    );
+    Object.entries({
+        '--rovalra-background-image-opacity': state.opacity,
+        '--rovalra-background-image-size': state.size,
+        '--rovalra-background-image-position': state.position,
+        '--rovalra-background-image-repeat': state.repeat,
+        '--rovalra-background-image-blur': `${bg.blur}px`,
+        '--rovalra-background-overlay-color': state.overlayColor,
+        '--rovalra-background-overlay-opacity': state.overlayOpacity,
+    }).forEach(([property, value]) => setVar(root, property, value));
+
+    setStyle(frame.style, 'opacity', state.opacity);
+    setStyle(frame.style, 'filter', state.filter);
+    postBgState(frame, state);
+    frame.onload = () => postBgState(frame, state);
+
+    setStyle(overlay.style, 'backgroundColor', state.overlayColor);
+    setStyle(overlay.style, 'opacity', state.overlayOpacity);
+}
+
+export function applyBackgroundImage(config, enabled) {
+    if (enabled !== true || !isBackgroundImageSupportedHost()) {
+        clearBackgroundImage();
+        return;
+    }
+
+    applyBackground(config);
+}
+
+async function applyStoredBackgroundImage(changes = null) {
+    const enabled = changes?.[BACKGROUND_IMAGE_ENABLED_SETTING]
+        ? changes[BACKGROUND_IMAGE_ENABLED_SETTING].newValue === true
+        : (await settings[BACKGROUND_IMAGE_ENABLED_SETTING]) === true;
+    const config = changes?.[BACKGROUND_IMAGE_SETTING]
+        ? changes[BACKGROUND_IMAGE_SETTING].newValue
+        : await settings[BACKGROUND_IMAGE_SETTING];
+
+    applyBackgroundImage(
+        sanitizeBackgroundImage(config || DEFAULT_BACKGROUND_IMAGE),
+        enabled,
+    );
+}
 
 function getThemeFieldCssValue(theme, field) {
     const source = theme && typeof theme === 'object' ? theme : {};

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -629,6 +629,7 @@ async function handleUrlChange() {
         lastPath = currentPath;
 
         runFeaturesForPage();
+        window.dispatchEvent(new CustomEvent('rovalra:urlChanged'));
 
         detectTheme().then((theme) => dispatchThemeEvent(theme));
     }

--- a/src/css/features/home/customThemeEditor.scss
+++ b/src/css/features/home/customThemeEditor.scss
@@ -71,6 +71,7 @@
 
     .rovalra-catalog-input-base {
         min-height: 38px;
+        border: 1px solid var(--rovalra-border-color);
         border-radius: 6px;
         background: var(--rovalra-button-background-color);
     }
@@ -258,6 +259,136 @@
 
 .rovalra-custom-theme-selector-input-invalid {
     box-shadow: 0 0 0 2px #d93838 !important;
+}
+
+.rovalra-custom-theme-background-section {
+    display: grid;
+    gap: 10px;
+    margin-top: 4px;
+    padding-top: 12px;
+    border-top: 1px solid var(--rovalra-border-color);
+}
+
+.rovalra-custom-theme-background-section-compact {
+    margin-top: 0;
+    padding-top: 0;
+    border-top: 0;
+}
+
+.rovalra-custom-theme-background-row {
+    display: grid;
+    gap: 7px;
+}
+
+.rovalra-custom-theme-background-row > .rovalra-custom-theme-selector-label {
+    font-size: 12px;
+}
+
+.rovalra-custom-theme-background-toggle-row {
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+
+    > .rovalra-custom-theme-selector-label {
+        font-size: 13px;
+        line-height: 1;
+    }
+}
+
+.rovalra-custom-theme-background-source {
+    display: grid;
+    gap: 8px;
+}
+
+.rovalra-custom-theme-background-url-wrapper {
+    min-width: 0;
+
+    .rovalra-catalog-input-base {
+        min-height: 38px;
+        border-radius: 6px;
+        background: var(--rovalra-button-background-color);
+    }
+
+    .rovalra-catalog-input-label {
+        display: none;
+    }
+
+    .rovalra-catalog-input-fieldset {
+        display: none;
+    }
+
+    .rovalra-catalog-input-base.Mui-focused {
+        border: 2px solid var(--rovalra-playbutton-color);
+    }
+
+    .rovalra-catalog-input-base.Mui-focused .rovalra-catalog-input-field {
+        padding: 0 9px;
+    }
+
+    .rovalra-catalog-input-field {
+        min-height: 38px;
+        padding: 0 10px;
+        font-size: 13px !important;
+        line-height: 38px !important;
+    }
+}
+
+.rovalra-custom-theme-background-range {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 48px;
+    align-items: center;
+    gap: 8px;
+}
+
+.rovalra-custom-theme-background-range input[type='range'] {
+    min-width: 0;
+    accent-color: var(--rovalra-playbutton-color);
+}
+
+.rovalra-custom-theme-background-range-value {
+    color: var(--rovalra-secondary-text-color);
+    font-size: 12px;
+    font-weight: 700;
+    text-align: right;
+}
+
+.rovalra-custom-theme-background-dropdown,
+.rovalra-custom-theme-background-dropdown .rovalra-dropdown-trigger {
+    width: 100%;
+}
+
+.rovalra-custom-theme-background-row input[type='color'] {
+    width: 42px;
+    height: 36px;
+    padding: 0;
+    border: 1px solid rgb(66 65 65 / 45%);
+    border-radius: 6px;
+    background: currentColor;
+    cursor: pointer;
+    appearance: none;
+    -webkit-appearance: none;
+    overflow: hidden;
+}
+
+.rovalra-custom-theme-background-row
+    input[type='color']::-webkit-color-swatch-wrapper {
+    padding: 0;
+}
+
+.rovalra-custom-theme-background-row input[type='color']::-webkit-color-swatch {
+    border: 0;
+    border-radius: 5px;
+}
+
+.rovalra-custom-theme-background-row input[type='color']::-moz-color-swatch {
+    border: 0;
+    border-radius: 5px;
+}
+
+.rovalra-custom-theme-background-error {
+    color: #d93838;
+    font-size: 12px;
+    font-weight: 700;
+    line-height: 1.35;
 }
 
 @media (max-width: 640px) {

--- a/src/css/sitewide/themes/custom-user.scss
+++ b/src/css/sitewide/themes/custom-user.scss
@@ -213,3 +213,461 @@
         border-color: var(--rovalra-custom-user-playButton) !important;
     }
 }
+
+#rovalra-custom-background-layer {
+    position: fixed;
+    inset: 0;
+    z-index: 0;
+    overflow: hidden;
+    pointer-events: none;
+    user-select: none;
+
+    .rovalra-custom-background-frame,
+    .rovalra-custom-background-overlay {
+        position: absolute;
+        pointer-events: none;
+    }
+
+    .rovalra-custom-background-frame {
+        border: 0;
+        width: 100%;
+        height: 100%;
+        inset: 0;
+        opacity: var(--rovalra-background-image-opacity, 1);
+        filter: blur(var(--rovalra-background-image-blur, 0));
+    }
+
+    .rovalra-custom-background-overlay {
+        inset: 0;
+        background: var(--rovalra-background-overlay-color, #000000);
+        opacity: var(--rovalra-background-overlay-opacity, 0);
+    }
+}
+
+body:not(.rovalra-custom-background-image-active)
+    #rovalra-custom-background-layer {
+    display: none;
+}
+
+html.rovalra-custom-background-image-active,
+body.rovalra-custom-background-image-active {
+    background-color: transparent !important;
+    overflow-x: clip;
+}
+
+body.rovalra-custom-background-image-active {
+    main.container-main,
+    #container-main,
+    #content.content,
+    .content#content {
+        position: relative;
+        z-index: 1;
+        background-color: transparent !important;
+        background-image: none !important;
+    }
+
+    &.rovalra-custom-background-nav-override {
+    .alert.alert-loading,
+    .alert.alert-warning,
+    .alert.alert-success {
+        display: none !important;
+    }
+
+    .catalog-header,
+    .search-bars,
+    .topic-container {
+        position: static !important;
+        top: auto !important;
+        z-index: auto !important;
+    }
+
+    main.container-main,
+    #container-main,
+    #content.content,
+    .content#content {
+        position: relative;
+        z-index: 1;
+        background-color: transparent !important;
+        background-image: none !important;
+    }
+
+    .groups-list-sidebar,
+    .group-banner,
+    .group-banner-flat,
+    .group-section-content,
+    .catalog-header,
+    .search-bars,
+    .topic-container,
+    &:has(#item-container) .container-list:has(.item-card-container),
+    #inventory-container #vertical-menu,
+    #avatar-react-container #horizontal-tabs,
+    #avatar-react-container #horizontal-tabs .rbx-tab-heading,
+    #avatar-react-container .avatar-back,
+    #item-list-container-recommendations #populated-item-list,
+    #inventory-container .container-list.recommendations-container,
+    #inventory-container .section-content-off,
+    #item-container .section-content:not(.top-section),
+    #friends-web-app .avatar-card-container,
+    #friends-web-app .avatar-card-btns,
+    #friends-web-app .nav.nav-tabs,
+    #friends-web-app .rbx-tab-heading,
+    #friends-web-app .section-content-off,
+    #friends-web-app .rovalra-bulk-unfriend-btn,
+    #game-detail-page #horizontal-tabs,
+    #game-detail-page #horizontal-tabs .rbx-tab-heading,
+    #game-detail-page .section-content-off,
+    #game-detail-page .rovalra-region-stats-bar,
+    #game-detail-page .rovalra-stat-item,
+    #game-detail-page .rovalra-server-card,
+    #game-detail-page .rovalra-server-avatar span,
+    #game-detail-page .card-item-public-server,
+    #game-detail-page .experience-events-tile .info-container,
+    #game-detail-page .game-badges-list .stack-row.badge-row,
+    #game-detail-page .game-badges-list .badge-image-container,
+    #group-search-web-app group-landing > .section-content,
+    group-forums .section-disclaimer.section-content-off,
+    configure-group-page #groups-configure-vertical-menu,
+    configure-group-allies #horizontal-tabs,
+    configure-group-allies #horizontal-tabs .rbx-tab-heading,
+    configure-group-settings .section-content.remove-panel > .section-content,
+    revenue-summary table.section-content,
+    transactions #group-transactions-container .foundation-web-feedback-banner,
+    transactions #group-transactions-container table.transactions,
+    transactions #group-transactions-container table.transactions td,
+    transactions #group-transactions-container .section-content-off,
+    configure-group-content-moderation .section-content.slowmode-section,
+    configure-group-content-moderation .section-disclaimer.section-content-off,
+    configure-group-allies .group-affiliates .section-content-off,
+    audit-log table.audit-log,
+    audit-log table.audit-log td,
+    .rovalra-showcase-game,
+    #games-switcher,
+    #games-switcher .slide-item-container-left,
+    #games-switcher .slide-item-container-right,
+    #rovalra-home-layout-button,
+    .item-card-thumb-container,
+    .item-card-thumb-container .thumbnail-2d-container,
+    .profile-slide-container #groups-switcher,
+    .profile-slide-container #groups-switcher .slide-item-image,
+    .profile-slide-container #groups-switcher .thumbnail-2d-container,
+    .profile-slide-container #groups-switcher .slide-item-container-right,
+    .profile-platform-container
+        .currently-wearing-avatar-with-background
+        > .profile-avatar-left,
+    .profile-platform-container
+        .currently-wearing-avatar-with-background
+        :is(.avatar-toggle-button, .action-buttons)
+        .foundation-web-button,
+    .profile-platform-container
+        .user-profile-header-details-avatar-container
+        .thumbnail-2d-container.avatar-card-image,
+    .user-profile-header-details-avatar-container:is(.avatar-headshot-lg, .avatar-headshot-xl)
+        .avatar-card-fullbody
+        > .thumbnail-2d-container.avatar-card-image,
+    .profile-platform-container #user-profile-header-bg .avatar-card-image,
+    .profile-platform-container
+        .currently-wearing-avatar-with-background
+        + .profile-header-overlay
+        #user-profile-header-bg
+        .avatar-card-image,
+    .profile-platform-container
+        .user-profile-header-details-avatar-container
+        .rovalra-improved-avatar-card,
+    .user-profile-header-details-avatar-container:is(.avatar-headshot-lg, .avatar-headshot-xl)
+        .rovalra-improved-avatar-card,
+    .base-tile-thumbnail,
+    #buy-robux-popover,
+    #buy-robux-popover .dropdown-menu,
+    #notification-stream-popover,
+    #notification-stream-popover .notification-content-view,
+    #notification-stream-popover .notification-stream-header,
+    #notification-stream-popover .notification-stream-banner,
+    #notification-stream-popover .notification-stream-body,
+    #notification-stream-popover .notification-stream-list,
+    #notification-stream-popover .sendr-notification-background,
+    .rovalra-dropdown-content-panel,
+    #settings-popover,
+    #settings-popover-menu,
+    #avatar-shop-keyword-input,
+    #robux-redesign-page .bg-surface-100.medium\:radius-circle,
+    #robux-redesign-page .radius-large.stroke-standard.stroke-default.bg-surface-100,
+    #user-account .menu-vertical,
+    #user-account .section-content.content-maturity,
+    #user-account .screentime-chart-container,
+    #user-account .section-content.parental-consent-toggle-container,
+    #user-account .inline-setting-component.section-content,
+    #user-account .radio-buttons-group.section-content,
+    #user-account .section-content.app-authorization-table-body,
+    #transactions-web-app table.summary,
+    #transactions-web-app table.transactions,
+    #transactions-web-app table.transactions td,
+    #trades-web-app .message-banner.money-page-banner,
+    #trades-web-app .container-empty,
+    #configure-private-server-web-app .stroke-standard.stroke-default.bg-surface-100,
+    #SponsoredPage,
+    #SponsoredPage .header,
+    #SponsoredPage #section2,
+    #SponsoredPage .section,
+    #settings-container #setting-section-content .setting,
+    #settings-container #setting-section-content .rovalra-donator-card,
+    #settings-container #setting-section-content .rovalra-donator-tier-heading,
+    #settings-container #setting-section-content .rovalra-donator-perks-table-wrap,
+    #settings-container #setting-section-content .rovalra-changelog-card,
+    #settings-container #setting-section-content .rovalra-account-standing-card,
+    #settings-container #setting-section-content .rovalra-donator-perks-table,
+    #settings-container #setting-section-content .rovalra-donator-perks-table th,
+    #settings-container #setting-section-content .rovalra-donator-perks-table td,
+    #settings-container #rovalra-store-border-container .rovalra-pill-toggle,
+    #settings-container
+        #rovalra-store-border-container
+        .rovalra-pill-toggle
+        div[role='presentation'],
+    #settings-container #rovalra-store-border-container [data-border-card],
+    #settings-container
+        #rovalra-store-border-container
+        > div[style*='background: var(--rovalra-container-background-color'],
+    #settings-container
+        #setting-section-content
+        .rovalra-donator-tier-copy
+        > span[style*='background-color: var(--rovalra-container-background-color'],
+    #settings-container
+        #setting-section-content
+        div[style*='background-color: var(--rovalra-container-background-color'],
+    #private-message-web-app .private-message-row,
+    #private-message-web-app .bg-surface-100.stroke-standard {
+        background-color: transparent !important;
+        background-image: none !important;
+    }
+
+    .groups-list-sidebar,
+    .group-banner,
+    .group-section-content,
+    .catalog-header,
+    .search-bars,
+    .topic-container,
+    &:has(#item-container) .container-list:has(.item-card-container),
+    #item-list-container-recommendations #populated-item-list,
+    #inventory-container .container-list.recommendations-container,
+    #inventory-container .section-content-off,
+    #item-container .section-content:not(.top-section),
+    #friends-web-app .avatar-card-container,
+    #friends-web-app .avatar-card-btns,
+    #friends-web-app .nav.nav-tabs,
+    #friends-web-app .section-content-off,
+    #friends-web-app .rovalra-bulk-unfriend-btn,
+    #game-detail-page #horizontal-tabs,
+    #game-detail-page #horizontal-tabs .rbx-tab-heading,
+    #game-detail-page #horizontal-tabs .rbx-tab,
+    #game-detail-page .section-content-off,
+    #game-detail-page .rovalra-region-stats-bar,
+    #game-detail-page .rovalra-stat-item,
+    #game-detail-page .rovalra-server-card,
+    #game-detail-page .card-item-public-server,
+    #game-detail-page .experience-events-tile .info-container,
+    #game-detail-page .game-badges-list .stack-row.badge-row,
+    #game-detail-page .game-badges-list .badge-image-container,
+    #group-search-web-app group-landing > .section-content,
+    group-forums .section-disclaimer.section-content-off,
+    configure-group-settings .section-content.remove-panel > .section-content,
+    revenue-summary table.section-content,
+    transactions #group-transactions-container .foundation-web-feedback-banner,
+    transactions #group-transactions-container table.transactions,
+    transactions #group-transactions-container table.transactions td,
+    transactions #group-transactions-container .section-content-off,
+    configure-group-content-moderation .section-content.slowmode-section,
+    configure-group-content-moderation .section-disclaimer.section-content-off,
+    configure-group-allies .group-affiliates .section-content-off,
+    audit-log table.audit-log,
+    audit-log table.audit-log td,
+    .rovalra-showcase-game,
+    #games-switcher,
+    #games-switcher .slide-item-container-left,
+    #games-switcher .slide-item-container-right,
+    #rovalra-home-layout-button,
+    .item-card-thumb-container,
+    .item-card-thumb-container .thumbnail-2d-container,
+    .profile-slide-container #groups-switcher,
+    .profile-slide-container #groups-switcher .slide-item-image,
+    .profile-slide-container #groups-switcher .thumbnail-2d-container,
+    .profile-slide-container #groups-switcher .slide-item-container-right,
+    .profile-platform-container
+        .currently-wearing-avatar-with-background
+        > .profile-avatar-left,
+    .profile-platform-container
+        .currently-wearing-avatar-with-background
+        :is(.avatar-toggle-button, .action-buttons)
+        .foundation-web-button,
+    .profile-platform-container
+        .user-profile-header-details-avatar-container
+        .thumbnail-2d-container.avatar-card-image,
+    .user-profile-header-details-avatar-container:is(.avatar-headshot-lg, .avatar-headshot-xl)
+        .avatar-card-fullbody
+        > .thumbnail-2d-container.avatar-card-image,
+    .profile-platform-container
+        .user-profile-header-details-avatar-container
+        .rovalra-improved-avatar-card,
+    .user-profile-header-details-avatar-container:is(.avatar-headshot-lg, .avatar-headshot-xl)
+        .rovalra-improved-avatar-card,
+    .base-tile-thumbnail,
+    #buy-robux-popover,
+    #buy-robux-popover .dropdown-menu,
+    #notification-stream-popover,
+    #notification-stream-popover .notification-content-view,
+    #notification-stream-popover .notification-stream-header,
+    #notification-stream-popover .notification-stream-banner,
+    #notification-stream-popover .notification-stream-body,
+    #notification-stream-popover .notification-stream-list,
+    #notification-stream-popover .sendr-notification-background,
+    .rovalra-dropdown-content-panel,
+    #settings-popover,
+    #settings-popover-menu,
+    #avatar-shop-keyword-input,
+    #robux-redesign-page .bg-surface-100.medium\:radius-circle,
+    #robux-redesign-page .radius-large.stroke-standard.stroke-default.bg-surface-100,
+    #user-account .menu-vertical,
+    #user-account .menu-option-content.active,
+    #user-account .section-content.content-maturity,
+    #user-account .screentime-chart-container,
+    #user-account .section-content.parental-consent-toggle-container,
+    #user-account .inline-setting-component.section-content,
+    #user-account .radio-buttons-group.section-content,
+    #user-account .section-content.app-authorization-table-body,
+    #user-account .app-authorization-row,
+    #transactions-web-app table.summary,
+    #transactions-web-app table.transactions,
+    #transactions-web-app table.transactions td,
+    #trades-web-app .message-banner.money-page-banner,
+    #trades-web-app .container-empty,
+    #configure-private-server-web-app .stroke-standard.stroke-default.bg-surface-100,
+    #SponsoredPage,
+    #SponsoredPage .header,
+    #SponsoredPage #section2,
+    #SponsoredPage .section,
+    #settings-container #setting-section-content .setting,
+    #settings-container #setting-section-content .rovalra-donator-card,
+    #settings-container #setting-section-content .rovalra-donator-tier-heading,
+    #settings-container #setting-section-content .rovalra-donator-perks-table-wrap,
+    #settings-container #setting-section-content .rovalra-changelog-card,
+    #settings-container #setting-section-content .rovalra-account-standing-card,
+    #settings-container #setting-section-content .rovalra-donator-perks-table,
+    #settings-container #setting-section-content .rovalra-donator-perks-table th,
+    #settings-container #setting-section-content .rovalra-donator-perks-table td,
+    #settings-container #rovalra-store-border-container .rovalra-pill-toggle,
+    #settings-container #rovalra-store-border-container [data-border-card],
+    #settings-container
+        #rovalra-store-border-container
+        > div[style*='background: var(--rovalra-container-background-color'],
+    #settings-container
+        #setting-section-content
+        .rovalra-donator-tier-copy
+        > span[style*='background-color: var(--rovalra-container-background-color'],
+    #settings-container
+        #setting-section-content
+        div[style*='background-color: var(--rovalra-container-background-color'],
+    #private-message-web-app .overflow-hidden.radius-medium.stroke-standard,
+    #private-message-web-app .private-message-row,
+    #private-message-web-app .bg-surface-100.stroke-standard {
+        border-color: transparent !important;
+        box-shadow: none !important;
+    }
+
+    .rovalra-custom-theme-background-dropdown-panel {
+        background-color: var(--rovalra-custom-user-surface100) !important;
+        border-color: var(--rovalra-custom-user-borderColor) !important;
+        box-shadow: 0 4px 12px rgb(0 0 0 / 35%) !important;
+    }
+
+    #header,
+    #header > .container-fluid,
+    #header .rbx-navbar-header,
+    #header ul.nav.rbx-navbar,
+    #header [data-testid='navigation-search-input'].navbar-search,
+    #header .navbar-search,
+    #header form[name='search-form'],
+    #header [data-testid='navigation-search-input-field'],
+    #header .navbar-search .input-field,
+    #header .navbar-search .form-control,
+    #navbar-search-input,
+    #right-navigation-header,
+    #right-navigation-header > .navbar-right.rbx-navbar-right,
+    #left-navigation-container,
+    .left-nav,
+    #left-navigation-container .left-nav,
+    .left-nav > div,
+    .left-nav [class*='bg-surface'],
+    #left-navigation-container .left-nav nav,
+    #chat-container,
+    #chat-main,
+    [data-testid='chat-container'],
+    #chat-container .chat-main,
+    #chat-container .chat-header,
+    #chat-container .chat-window,
+    #chat-container .chat-dialog,
+    .chat-container,
+    .chat-main,
+    .chat-header,
+    .chat-window,
+    .chat-dialog {
+        background-color: transparent !important;
+        background-image: none !important;
+    }
+
+    #header,
+    #header > .container-fluid,
+    #header [data-testid='navigation-search-input'].navbar-search,
+    #header .navbar-search,
+    #header form[name='search-form'],
+    #header [data-testid='navigation-search-input-field'],
+    #navbar-search-input,
+    #left-navigation-container,
+    .left-nav,
+    #left-navigation-container .left-nav,
+    .left-nav > div,
+    .left-nav [class*='border'],
+    .left-nav [class*='shadow'],
+    #chat-container,
+    #chat-main,
+    [data-testid='chat-container'],
+    #chat-container .chat-main,
+    .chat-container,
+    .chat-main,
+    .chat-dialog {
+        border-color: transparent !important;
+        box-shadow: none !important;
+    }
+
+    .left-nav::before,
+    .left-nav::after,
+    .left-nav *::before,
+    .left-nav *::after {
+        background-color: transparent !important;
+        border-color: transparent !important;
+        box-shadow: none !important;
+    }
+
+    .left-nav,
+    .left-nav [class*='scroll-y'] {
+        scrollbar-color: transparent transparent !important;
+    }
+
+    .left-nav::-webkit-scrollbar,
+    .left-nav *::-webkit-scrollbar {
+        width: 0 !important;
+        height: 0 !important;
+        background: transparent !important;
+    }
+
+    .left-nav::-webkit-scrollbar-thumb,
+    .left-nav::-webkit-scrollbar-track,
+    .left-nav *::-webkit-scrollbar-thumb,
+    .left-nav *::-webkit-scrollbar-track {
+        background: transparent !important;
+        border-color: transparent !important;
+    }
+
+    #header .stroke-default.self-stretch,
+    .left-nav .stroke-default.self-stretch {
+        display: none !important;
+    }
+}
+}


### PR DESCRIPTION
Hi hi hi! I saw the latest change in the contribution guidelines ("Please keep PRs simple, single-feature focused, and avoid big overhauls or giant features."). i completely understand dat but i genuinely think this feature is worth adding.

This feature lets users set any background image for the Roblox website using an image URL (only the URL is stored, never the image itself).

It works especially well with Transparent Mode. I spent quite a while using it myself and adjusted as many parts of the website as possible so transparent sections blend naturally with the background. The end result feels polished & beatiful.

i've also included a few previews below that I tested myself:

## PREVIEW
<img width="1905" height="1079" alt="MessagesPage" src="https://github.com/user-attachments/assets/92b527de-3965-44b6-865e-7db11a51aa0c" />

<img width="1905" height="1079" alt="InventoryPage" src="https://github.com/user-attachments/assets/7ba94449-a2ce-431c-9dd1-a3e771deb65e" />

<img width="1906" height="1079" alt="RoValraSettingsPage" src="https://github.com/user-attachments/assets/4918003e-263d-4847-842e-5bd73fc28601" />

<img width="1907" height="1079" alt="CommunitiesPage" src="https://github.com/user-attachments/assets/a61b2437-dc56-4c08-9331-2d9b8ad5343b" />


<img width="1907" height="1079" alt="HomePage" src="https://github.com/user-attachments/assets/e87373f0-77b2-4708-b86b-7ed09aecbc84" />


<img width="1903" height="1079" alt="CatalogPage" src="https://github.com/user-attachments/assets/20ea341b-ab1d-4ac9-ab75-8a5851c3e978" />

<img width="340" height="517" alt="settings" src="https://github.com/user-attachments/assets/bb451e3e-0b84-4874-be01-139bdb421cbe" />



