### PR TITLE
fix(Donation Button): should not exaust parental controls api because this is equivelent to what roblox uses when checking if parent account is attached

### DIFF
--- a/src/content/features/settings/index.js
+++ b/src/content/features/settings/index.js
@@ -316,12 +316,12 @@ async function openDonatorPerksDonationUrl() {
     }
     try {
         if (canPlayUniverse == false && canPlayUniverseReason == 'ContextualPlayabilityRequireParentApproval') {
-            const accountParentsLinked = await callRobloxApiJson({
+            const approveExperienceRecourse = await callRobloxApiJson({
                 subdomain: 'apis',
-                endpoint: '/parental-controls-api/v1/parental-controls/get-linked-parents',
+                endpoint: '/access-management/v1/upsell-feature-access?featureName=CanApproveExperience&extraParameters=W10=',
                 method: 'GET',
             });
-            accountHasParentAttached = 0 < accountParentsLinked.parents.length;
+            accountHasParentAttached = approveExperienceRecourse.recourse.includes('ParentConsent');
         }
     } catch (error) {
         console.warn('RoValra: Failed to see if there were any parents linked to account for game unblock overlay', error);


### PR DESCRIPTION
i was being dumb ig idk know if it works im still rate limited on the request endpoint but its stupid