### PR TITLE
Add friend labels

### DIFF
--- a/public/Assets/locales/en.json
+++ b/public/Assets/locales/en.json
@@ -59,6 +59,17 @@
             "settings": "Settings"
         }
     },
+    "friendLabels": {
+        "menuAction": "Set Friend Label",
+        "dialogTitle": "Label {{displayName}}",
+        "inputLabel": "Friend Label",
+        "inputPlaceholder": "Close Friends, School,",
+        "existingLabels": "Existing labels",
+        "friendFallback": "Friend",
+        "save": "Save",
+        "remove": "Remove",
+        "cancel": "Cancel"
+    },
     "underratedGames": {
         "topic": "Underrated Games",
         "subtitle": "Underrated games hand picked by the RoValra community.",

--- a/src/content/core/settings/settingConfig.js
+++ b/src/content/core/settings/settingConfig.js
@@ -1170,6 +1170,19 @@ export const SETTINGS_CONFIG = {
                 default: false,
                 contributors: ['476449201'],
             },
+
+
+            friendLabelsEnabled: {
+                label: 'Friend Labels',
+                description: [
+                    'Lets you assign a label to your friends on the Home page.',
+                ],
+                type: 'checkbox',
+                default: false,
+                storageKey: 'rovalra_friend_labels',
+                contributors: ['4632962611'],
+            },
+
             friendUsernamesEnabled: {
                 label: 'Show Usernames On Friend Cards',
                 description: [

--- a/src/content/features/home/friendLabels.js
+++ b/src/content/features/home/friendLabels.js
@@ -10,12 +10,29 @@ const SETTING_NAME = 'friendLabelsEnabled';
 const STORAGE_KEY = 'rovalra_friend_labels';
 
 const CARD_SELECTOR = '.friends-carousel-tile';
+
+/* Legacy Roblox friend dropdown */
 const DROPDOWN_LIST_SELECTOR = '.friend-tile-dropdown ul';
+
+/*
+ * The modern Roblox friend tooltip is rendered in a document-level portal,
+ * rather than inside the friend card. Watch interactive controls and verify
+ * that they belong to the friend tooltip before modifying them.
+ */
+const MODERN_TOOLTIP_ROOT_SELECTOR = [
+    '[role="dialog"]',
+    '[role="menu"]',
+    '[role="tooltip"]',
+    '[class*="popover" i]',
+    '[class*="dropdown" i]',
+].join(', ');
 
 const HOST_CLASS = 'rovalra-friend-label-host';
 const LABEL_CLASS = 'rovalra-friend-label';
 const MENU_ITEM_CLASS = 'rovalra-friend-label-menu-item';
 const MENU_BUTTON_CLASS = 'rovalra-friend-label-menu-button';
+const MODERN_TOOLTIP_ITEM_CLASS = 'rovalra-friend-label-modern-item';
+const MODERN_TOOLTIP_BUTTON_CLASS = 'rovalra-friend-label-modern-button';
 
 const MAX_LABEL_LENGTH = 24;
 
@@ -23,6 +40,7 @@ let enabled = false;
 let observersRegistered = false;
 let storageListenerRegistered = false;
 let friendLabels = {};
+let lastInteractedFriendCard = null;
 
 function sanitizeLabels(value) {
     if (!value || typeof value !== 'object' || Array.isArray(value)) {
@@ -79,26 +97,59 @@ function getDisplayNameText(context) {
     return context.displayName?.textContent?.trim() || '';
 }
 
+function unwrapLabelHost(host) {
+    if (
+        !(host instanceof HTMLElement) ||
+        !host.classList.contains(HOST_CLASS)
+    ) {
+        return;
+    }
+
+    const parent = host.parentElement;
+
+    if (!(parent instanceof HTMLElement)) {
+        return;
+    }
+
+    while (host.firstChild) {
+        parent.insertBefore(host.firstChild, host);
+    }
+
+    host.remove();
+}
+
 function findLabelHost(context) {
     if (!(context.displayName instanceof HTMLElement)) {
         return null;
     }
 
-    const labelContainer = context.displayName.closest(
-        '.user-card-labels, .user-card-labels-no-username',
-    );
+    /*
+     * Wrap only the name row itself. Roblox keeps the current-game/presence
+     * text as a sibling, so this prevents Friend Labels from taking ownership
+     * of and restyling the playing-status layout.
+     */
+    const nameElement =
+        context.displayName.closest(
+            '.user-card-name, .friends-carousel-display-name, .avatar-name',
+        ) || context.displayName;
 
-    if (labelContainer) {
-        return labelContainer;
+    const currentParent = nameElement.parentElement;
+
+    if (!(currentParent instanceof HTMLElement)) {
+        return null;
     }
 
-    const nameRow = context.displayName.closest('.user-card-name');
-
-    if (nameRow?.parentElement) {
-        return nameRow.parentElement;
+    if (currentParent.classList.contains(HOST_CLASS)) {
+        return currentParent;
     }
 
-    return context.displayName.parentElement;
+    const host = document.createElement('div');
+    host.className = HOST_CLASS;
+
+    currentParent.insertBefore(host, nameElement);
+    host.appendChild(nameElement);
+
+    return host;
 }
 
 function removeRenderedLabel(card) {
@@ -110,7 +161,7 @@ function removeRenderedLabel(card) {
     label?.remove();
 
     if (host && !host.querySelector(`.${LABEL_CLASS}`)) {
-        host.classList.remove(HOST_CLASS);
+        unwrapLabelHost(host);
     }
 }
 
@@ -147,7 +198,19 @@ function renderFriendLabel(card, suppliedContext = null) {
         existingLabel.dataset.userId = String(context.userId);
 
         if (existingLabel.parentElement !== host) {
+            const previousHost = existingLabel.closest(
+                `.${HOST_CLASS}`,
+            );
+
             host.appendChild(existingLabel);
+
+            if (
+                previousHost &&
+                previousHost !== host &&
+                !previousHost.querySelector(`.${LABEL_CLASS}`)
+            ) {
+                unwrapLabelHost(previousHost);
+            }
         }
 
         return;
@@ -172,22 +235,28 @@ function refreshExistingCards() {
 
 function removeFeatureUi() {
     document.querySelectorAll(`.${LABEL_CLASS}`).forEach((label) => {
-        const host = label.closest(`.${HOST_CLASS}`);
-
         label.remove();
-
-        if (host && !host.querySelector(`.${LABEL_CLASS}`)) {
-            host.classList.remove(HOST_CLASS);
-        }
     });
 
     document.querySelectorAll(`.${HOST_CLASS}`).forEach((host) => {
-        host.classList.remove(HOST_CLASS);
+        unwrapLabelHost(host);
     });
 
     document.querySelectorAll(`.${MENU_ITEM_CLASS}`).forEach((item) => {
         item.remove();
     });
+
+    document
+        .querySelectorAll(`.${MODERN_TOOLTIP_BUTTON_CLASS}`)
+        .forEach((button) => {
+            button.remove();
+        });
+
+    document
+        .querySelectorAll('[data-rovalra-friend-label-pending]')
+        .forEach((element) => {
+            delete element.dataset.rovalraFriendLabelPending;
+        });
 }
 
 function getExistingLabels() {
@@ -357,58 +426,401 @@ async function openLabelEditor(card, context) {
     });
 }
 
+function normalizeControlText(element) {
+    return (
+        element?.textContent
+            ?.replace(/\s+/g, ' ')
+            .trim()
+            .toLowerCase() || ''
+    );
+}
+
+function getTooltipControls(root) {
+    if (!(root instanceof HTMLElement)) {
+        return [];
+    }
+
+    return [
+        ...root.querySelectorAll('button, a, [role="button"]'),
+    ].filter(
+        (element) =>
+            element instanceof HTMLElement &&
+            element.offsetParent !== null,
+    );
+}
+
+function isModernFriendTooltip(root) {
+    if (!(root instanceof HTMLElement)) {
+        return false;
+    }
+
+    const controlTexts = new Set(
+        getTooltipControls(root).map(normalizeControlText),
+    );
+
+    const hasViewProfile = controlTexts.has('view profile');
+    const hasFriendAction =
+        controlTexts.has('chat') || controlTexts.has('join');
+
+    return hasViewProfile && hasFriendAction;
+}
+
+function getUserIdFromProfileLink(root) {
+    if (!(root instanceof HTMLElement)) {
+        return null;
+    }
+
+    const profileLink = root.querySelector('a[href*="/users/"]');
+    const href = profileLink?.getAttribute('href') || '';
+    const match = href.match(/\/users\/(\d+)(?:\/|$)/);
+
+    return match ? match[1] : null;
+}
+
+function findFriendCardByUserId(userId) {
+    if (!userId) return null;
+
+    for (const card of document.querySelectorAll(CARD_SELECTOR)) {
+        const context = getUserCardContext(card);
+
+        if (String(context.userId) === String(userId)) {
+            return card;
+        }
+    }
+
+    return null;
+}
+
+function findHoveredFriendCard() {
+    for (const card of document.querySelectorAll(CARD_SELECTOR)) {
+        if (card.matches(':hover')) {
+            return card;
+        }
+    }
+
+    return null;
+}
+
+function findFriendCardByTooltipText(tooltip) {
+    if (!(tooltip instanceof HTMLElement)) {
+        return null;
+    }
+
+    const tooltipText =
+        tooltip.textContent
+            ?.replace(/\s+/g, ' ')
+            .trim()
+            .toLowerCase() || '';
+
+    if (!tooltipText) {
+        return null;
+    }
+
+    const cards = [...document.querySelectorAll(CARD_SELECTOR)];
+
+    cards.sort((firstCard, secondCard) => {
+        const firstName = getDisplayNameText(
+            getUserCardContext(firstCard),
+        );
+        const secondName = getDisplayNameText(
+            getUserCardContext(secondCard),
+        );
+
+        return secondName.length - firstName.length;
+    });
+
+    for (const card of cards) {
+        const context = getUserCardContext(card);
+        const displayName = getDisplayNameText(context)
+            .replace(/\s+/g, ' ')
+            .trim()
+            .toLowerCase();
+
+        if (displayName && tooltipText.includes(displayName)) {
+            return card;
+        }
+    }
+
+    return null;
+}
+
+function resolveModernTooltipCard(tooltip) {
+    const linkedUserId = getUserIdFromProfileLink(tooltip);
+    const linkedCard = findFriendCardByUserId(linkedUserId);
+
+    if (linkedCard) {
+        lastInteractedFriendCard = linkedCard;
+        return linkedCard;
+    }
+
+    const hoveredCard = findHoveredFriendCard();
+
+    if (hoveredCard) {
+        lastInteractedFriendCard = hoveredCard;
+        return hoveredCard;
+    }
+
+    const activeCard = document.activeElement?.closest?.(
+        CARD_SELECTOR,
+    );
+
+    if (activeCard instanceof HTMLElement) {
+        lastInteractedFriendCard = activeCard;
+        return activeCard;
+    }
+
+    const textMatchedCard = findFriendCardByTooltipText(tooltip);
+
+    if (textMatchedCard) {
+        lastInteractedFriendCard = textMatchedCard;
+        return textMatchedCard;
+    }
+
+    if (
+        lastInteractedFriendCard instanceof HTMLElement &&
+        lastInteractedFriendCard.isConnected
+    ) {
+        return lastInteractedFriendCard;
+    }
+
+    return null;
+}
+
+function rememberFriendCard(card) {
+    if (!(card instanceof HTMLElement)) {
+        return;
+    }
+
+    if (card.dataset.rovalraFriendLabelTracking === 'true') {
+        return;
+    }
+
+    card.dataset.rovalraFriendLabelTracking = 'true';
+
+    const remember = () => {
+        lastInteractedFriendCard = card;
+    };
+
+    card.addEventListener('pointerenter', remember);
+    card.addEventListener('pointerdown', remember);
+    card.addEventListener('focusin', remember);
+}
+
+function findModernActionMount(tooltip, viewProfileControl) {
+    const controls = getTooltipControls(tooltip);
+
+    const peerControl = controls.find((control) => {
+        const text = normalizeControlText(control);
+
+        return text === 'chat' || text === 'join';
+    });
+
+    if (
+        peerControl?.parentElement ===
+        viewProfileControl.parentElement
+    ) {
+        return {
+            reference: viewProfileControl,
+            wrapperSource: null,
+        };
+    }
+
+    const viewWrapper = viewProfileControl.parentElement;
+    const peerWrapper = peerControl?.parentElement;
+
+    if (
+        viewWrapper instanceof HTMLElement &&
+        peerWrapper instanceof HTMLElement &&
+        viewWrapper.parentElement === peerWrapper.parentElement
+    ) {
+        return {
+            reference: viewWrapper,
+            wrapperSource: viewWrapper,
+        };
+    }
+
+    return {
+        reference: viewProfileControl,
+        wrapperSource: null,
+    };
+}
+
+async function attachModernTooltipAction(tooltip) {
+    if (!enabled || !(tooltip instanceof HTMLElement)) {
+        return;
+    }
+
+    if (!isModernFriendTooltip(tooltip)) {
+        return;
+    }
+
+    if (
+        tooltip.querySelector(`.${MODERN_TOOLTIP_BUTTON_CLASS}`) ||
+        tooltip.dataset.rovalraFriendLabelPending === 'true'
+    ) {
+        return;
+    }
+
+    tooltip.dataset.rovalraFriendLabelPending = 'true';
+
+    try {
+        const controls = getTooltipControls(tooltip);
+        const viewProfileControl = controls.find(
+            (element) =>
+                normalizeControlText(element) === 'view profile',
+        );
+
+        if (!viewProfileControl) {
+            return;
+        }
+
+        const card = resolveModernTooltipCard(tooltip);
+        const context = card ? getUserCardContext(card) : null;
+
+        if (!context?.userId) {
+            return;
+        }
+
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = [
+            MENU_BUTTON_CLASS,
+            MODERN_TOOLTIP_BUTTON_CLASS,
+        ].join(' ');
+        button.textContent = await t('friendLabels.menuAction');
+
+        button.addEventListener('pointerdown', (event) => {
+            event.stopPropagation();
+        });
+
+        button.addEventListener('click', async (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+
+            const currentCard = resolveModernTooltipCard(tooltip);
+
+            if (!currentCard) {
+                return;
+            }
+
+            const currentContext = getUserCardContext(currentCard);
+
+            if (!currentContext.userId) {
+                return;
+            }
+
+            await openLabelEditor(currentCard, currentContext);
+        });
+
+        const mount = findModernActionMount(
+            tooltip,
+            viewProfileControl,
+        );
+
+        if (mount.wrapperSource) {
+            const wrapper = document.createElement(
+                mount.wrapperSource.tagName.toLowerCase(),
+            );
+
+            wrapper.className = mount.wrapperSource.className;
+            wrapper.classList.add(
+                MENU_ITEM_CLASS,
+                MODERN_TOOLTIP_ITEM_CLASS,
+            );
+
+            wrapper.appendChild(button);
+
+            mount.reference.insertAdjacentElement(
+                'afterend',
+                wrapper,
+            );
+
+            return;
+        }
+
+        const wrapper = document.createElement('div');
+
+        wrapper.className = [
+            MENU_ITEM_CLASS,
+            MODERN_TOOLTIP_ITEM_CLASS,
+        ].join(' ');
+
+        wrapper.appendChild(button);
+        mount.reference.insertAdjacentElement('afterend', wrapper);
+    } finally {
+        delete tooltip.dataset.rovalraFriendLabelPending;
+    }
+}
+
+function attachActionsToExistingModernTooltips() {
+    document
+        .querySelectorAll(MODERN_TOOLTIP_ROOT_SELECTOR)
+        .forEach((tooltip) => {
+            attachModernTooltipAction(tooltip);
+        });
+}
+
 async function attachDropdownAction(menuList) {
     if (!enabled || !(menuList instanceof HTMLElement)) {
         return;
     }
 
-    if (menuList.querySelector(`.${MENU_ITEM_CLASS}`)) {
+    if (
+        menuList.querySelector(`.${MENU_ITEM_CLASS}`) ||
+        menuList.dataset.rovalraFriendLabelPending === 'true'
+    ) {
         return;
     }
 
-    const dropdown = menuList.closest('.friend-tile-dropdown');
-    const card = dropdown?.closest(CARD_SELECTOR);
+    menuList.dataset.rovalraFriendLabelPending = 'true';
 
-    if (!card) return;
+    try {
+        const dropdown = menuList.closest('.friend-tile-dropdown');
+        const card = dropdown?.closest(CARD_SELECTOR);
 
-    const context = getUserCardContext(card);
+        if (!card) return;
 
-    if (!context.userId) return;
+        const context = getUserCardContext(card);
 
-    const item = document.createElement('li');
-    item.className = MENU_ITEM_CLASS;
+        if (!context.userId) return;
 
-    const button = createButton(
-        await t('friendLabels.menuAction'),
-        'secondary',
-        {
-            onClick: async (event) => {
-                event.preventDefault();
-                event.stopPropagation();
+        const item = document.createElement('li');
+        item.className = MENU_ITEM_CLASS;
 
-                const currentCard =
-                    button.closest(CARD_SELECTOR) || card;
+        const button = createButton(
+            await t('friendLabels.menuAction'),
+            'secondary',
+            {
+                onClick: async (event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
 
-                const currentContext =
-                    getUserCardContext(currentCard);
+                    const currentCard =
+                        button.closest(CARD_SELECTOR) || card;
 
-                if (!currentContext.userId) return;
+                    const currentContext =
+                        getUserCardContext(currentCard);
 
-                await openLabelEditor(
-                    currentCard,
-                    currentContext,
-                );
+                    if (!currentContext.userId) return;
+
+                    await openLabelEditor(
+                        currentCard,
+                        currentContext,
+                    );
+                },
             },
-        },
-    );
+        );
 
-    button.classList.add(
-        MENU_BUTTON_CLASS,
-        'friend-tile-dropdown-button',
-    );
+        button.classList.add(
+            MENU_BUTTON_CLASS,
+            'friend-tile-dropdown-button',
+        );
 
-    item.appendChild(button);
-    menuList.appendChild(item);
+        item.appendChild(button);
+        menuList.appendChild(item);
+    } finally {
+        delete menuList.dataset.rovalraFriendLabelPending;
+    }
 }
 
 function registerObservers() {
@@ -419,6 +831,7 @@ function registerObservers() {
     observeElement(
         CARD_SELECTOR,
         (card) => {
+            rememberFriendCard(card);
             renderFriendLabel(card);
         },
         {
@@ -433,6 +846,14 @@ function registerObservers() {
             multiple: true,
         },
     );
+
+    observeElement(
+        MODERN_TOOLTIP_ROOT_SELECTOR,
+        attachModernTooltipAction,
+        {
+            multiple: true,
+        },
+    );
 }
 
 function attachActionsToExistingDropdowns() {
@@ -441,6 +862,12 @@ function attachActionsToExistingDropdowns() {
         .forEach((menuList) => {
             attachDropdownAction(menuList);
         });
+
+    document.querySelectorAll(CARD_SELECTOR).forEach((card) => {
+        rememberFriendCard(card);
+    });
+
+    attachActionsToExistingModernTooltips();
 }
 
 function registerStorageListener() {

--- a/src/content/features/home/friendLabels.js
+++ b/src/content/features/home/friendLabels.js
@@ -10,6 +10,8 @@ const SETTING_NAME = 'friendLabelsEnabled';
 const STORAGE_KEY = 'rovalra_friend_labels';
 
 const CARD_SELECTOR = '.friends-carousel-tile';
+const EXCLUDED_CONTAINER_SELECTOR =
+    '.roseal-friends-carousel-container';
 
 /* Legacy Roblox friend dropdown */
 const DROPDOWN_LIST_SELECTOR = '.friend-tile-dropdown ul';
@@ -41,6 +43,12 @@ let observersRegistered = false;
 let storageListenerRegistered = false;
 let friendLabels = {};
 let lastInteractedFriendCard = null;
+
+function isExcludedCarouselPresent() {
+    return Boolean(
+        document.querySelector(EXCLUDED_CONTAINER_SELECTOR),
+    );
+}
 
 function sanitizeLabels(value) {
     if (!value || typeof value !== 'object' || Array.isArray(value)) {
@@ -209,6 +217,11 @@ function removeRenderedLabel(card) {
 function renderFriendLabel(card, suppliedContext = null) {
     if (!(card instanceof HTMLElement)) return;
 
+    if (isExcludedCarouselPresent()) {
+        removeRenderedLabel(card);
+        return;
+    }
+
     const context = suppliedContext || getUserCardContext(card);
     const existingLabel = card.querySelector(`.${LABEL_CLASS}`);
 
@@ -269,6 +282,11 @@ function renderFriendLabel(card, suppliedContext = null) {
 }
 
 function refreshExistingCards() {
+    if (isExcludedCarouselPresent()) {
+        removeFeatureUi();
+        return;
+    }
+
     document.querySelectorAll(CARD_SELECTOR).forEach((card) => {
         renderFriendLabel(card);
     });
@@ -814,7 +832,11 @@ function createModernTooltipButton(sourceControl, labelText) {
 }
 
 async function attachModernTooltipAction(candidate) {
-    if (!enabled || !(candidate instanceof HTMLElement)) {
+    if (
+        !enabled ||
+        isExcludedCarouselPresent() ||
+        !(candidate instanceof HTMLElement)
+    ) {
         return;
     }
 
@@ -985,7 +1007,11 @@ function attachActionsToExistingModernTooltips() {
 }
 
 async function attachDropdownAction(menuList) {
-    if (!enabled || !(menuList instanceof HTMLElement)) {
+    if (
+        !enabled ||
+        isExcludedCarouselPresent() ||
+        !(menuList instanceof HTMLElement)
+    ) {
         return;
     }
 
@@ -1078,6 +1104,14 @@ function registerObservers() {
     observeElement(
         MODERN_TOOLTIP_ROOT_SELECTOR,
         attachModernTooltipAction,
+        {
+            multiple: true,
+        },
+    );
+
+    observeElement(
+        EXCLUDED_CONTAINER_SELECTOR,
+        removeFeatureUi,
         {
             multiple: true,
         },

--- a/src/content/features/home/friendLabels.js
+++ b/src/content/features/home/friendLabels.js
@@ -1,0 +1,498 @@
+import { getUserCardContext } from '../../core/profile/userCardElements.js';
+import { t } from '../../core/locale/i18n.js';
+import { observeElement } from '../../core/observer.js';
+import { settings } from '../../core/settings/getSettings.js';
+import { createButton } from '../../core/ui/buttons.js';
+import { createStyledInput } from '../../core/ui/catalog/input.js';
+import { createOverlay } from '../../core/ui/overlay.js';
+
+const SETTING_NAME = 'friendLabelsEnabled';
+const STORAGE_KEY = 'rovalra_friend_labels';
+
+const CARD_SELECTOR = '.friends-carousel-tile';
+const DROPDOWN_LIST_SELECTOR = '.friend-tile-dropdown ul';
+
+const HOST_CLASS = 'rovalra-friend-label-host';
+const LABEL_CLASS = 'rovalra-friend-label';
+const MENU_ITEM_CLASS = 'rovalra-friend-label-menu-item';
+const MENU_BUTTON_CLASS = 'rovalra-friend-label-menu-button';
+
+const MAX_LABEL_LENGTH = 24;
+
+let enabled = false;
+let observersRegistered = false;
+let storageListenerRegistered = false;
+let friendLabels = {};
+
+function sanitizeLabels(value) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return {};
+    }
+
+    const sanitized = {};
+
+    for (const [userId, label] of Object.entries(value)) {
+        if (!/^\d+$/.test(userId) || typeof label !== 'string') {
+            continue;
+        }
+
+        const cleanedLabel = label.trim().slice(0, MAX_LABEL_LENGTH);
+
+        if (cleanedLabel) {
+            sanitized[userId] = cleanedLabel;
+        }
+    }
+
+    return sanitized;
+}
+
+async function loadFriendLabels() {
+    try {
+        const result = await chrome.storage.local.get(STORAGE_KEY);
+
+        return sanitizeLabels(result[STORAGE_KEY]);
+    } catch (error) {
+        console.warn('RoValra: Failed to load friend labels', error);
+        return {};
+    }
+}
+
+async function saveFriendLabels(nextLabels) {
+    friendLabels = sanitizeLabels(nextLabels);
+
+    try {
+        await chrome.storage.local.set({
+            [STORAGE_KEY]: friendLabels,
+        });
+    } catch (error) {
+        console.warn('RoValra: Failed to save friend labels', error);
+    }
+
+    refreshExistingCards();
+}
+
+function getFriendLabel(userId) {
+    return friendLabels[String(userId)] || '';
+}
+
+function getDisplayNameText(context) {
+    return context.displayName?.textContent?.trim() || '';
+}
+
+function findLabelHost(context) {
+    if (!(context.displayName instanceof HTMLElement)) {
+        return null;
+    }
+
+    const labelContainer = context.displayName.closest(
+        '.user-card-labels, .user-card-labels-no-username',
+    );
+
+    if (labelContainer) {
+        return labelContainer;
+    }
+
+    const nameRow = context.displayName.closest('.user-card-name');
+
+    if (nameRow?.parentElement) {
+        return nameRow.parentElement;
+    }
+
+    return context.displayName.parentElement;
+}
+
+function removeRenderedLabel(card) {
+    if (!(card instanceof HTMLElement)) return;
+
+    const label = card.querySelector(`.${LABEL_CLASS}`);
+    const host = label?.closest(`.${HOST_CLASS}`);
+
+    label?.remove();
+
+    if (host && !host.querySelector(`.${LABEL_CLASS}`)) {
+        host.classList.remove(HOST_CLASS);
+    }
+}
+
+function renderFriendLabel(card, suppliedContext = null) {
+    if (!(card instanceof HTMLElement)) return;
+
+    const context = suppliedContext || getUserCardContext(card);
+    const existingLabel = card.querySelector(`.${LABEL_CLASS}`);
+
+    if (!enabled || !context.userId) {
+        removeRenderedLabel(card);
+        return;
+    }
+
+    const labelText = getFriendLabel(context.userId);
+
+    if (!labelText) {
+        removeRenderedLabel(card);
+        return;
+    }
+
+    const host = findLabelHost(context);
+
+    if (!host) {
+        removeRenderedLabel(card);
+        return;
+    }
+
+    host.classList.add(HOST_CLASS);
+
+    if (existingLabel) {
+        existingLabel.textContent = labelText;
+        existingLabel.title = labelText;
+        existingLabel.dataset.userId = String(context.userId);
+
+        if (existingLabel.parentElement !== host) {
+            host.appendChild(existingLabel);
+        }
+
+        return;
+    }
+
+    const label = document.createElement('div');
+
+    label.className = LABEL_CLASS;
+    label.textContent = labelText;
+    label.title = labelText;
+    label.dataset.userId = String(context.userId);
+    label.setAttribute('aria-label', labelText);
+
+    host.appendChild(label);
+}
+
+function refreshExistingCards() {
+    document.querySelectorAll(CARD_SELECTOR).forEach((card) => {
+        renderFriendLabel(card);
+    });
+}
+
+function removeFeatureUi() {
+    document.querySelectorAll(`.${LABEL_CLASS}`).forEach((label) => {
+        const host = label.closest(`.${HOST_CLASS}`);
+
+        label.remove();
+
+        if (host && !host.querySelector(`.${LABEL_CLASS}`)) {
+            host.classList.remove(HOST_CLASS);
+        }
+    });
+
+    document.querySelectorAll(`.${HOST_CLASS}`).forEach((host) => {
+        host.classList.remove(HOST_CLASS);
+    });
+
+    document.querySelectorAll(`.${MENU_ITEM_CLASS}`).forEach((item) => {
+        item.remove();
+    });
+}
+
+function getExistingLabels() {
+    return [...new Set(Object.values(friendLabels))]
+        .filter(Boolean)
+        .sort((firstLabel, secondLabel) =>
+            firstLabel.localeCompare(secondLabel),
+        );
+}
+
+async function openLabelEditor(card, context) {
+    const userId = String(context.userId);
+    const currentLabel = getFriendLabel(userId);
+
+    const displayName =
+        getDisplayNameText(context) ||
+        (await t('friendLabels.friendFallback'));
+
+    const body = document.createElement('div');
+    body.className = 'rovalra-friend-label-editor';
+
+    const { container: inputContainer, input } = createStyledInput({
+        id: `rovalra-friend-label-input-${userId}`,
+        label: await t('friendLabels.inputLabel'),
+        placeholder: await t('friendLabels.inputPlaceholder'),
+        value: currentLabel,
+    });
+
+    input.maxLength = MAX_LABEL_LENGTH;
+
+    body.appendChild(inputContainer);
+
+    const existingLabels = getExistingLabels();
+
+    if (existingLabels.length > 0) {
+        const suggestionSection = document.createElement('div');
+        suggestionSection.className =
+            'rovalra-friend-label-suggestion-section';
+
+        const suggestionTitle = document.createElement('div');
+        suggestionTitle.className =
+            'rovalra-friend-label-suggestion-title';
+        suggestionTitle.textContent = await t(
+            'friendLabels.existingLabels',
+        );
+
+        const suggestionList = document.createElement('div');
+        suggestionList.className = 'rovalra-friend-label-suggestions';
+
+        for (const existingLabel of existingLabels) {
+            const suggestion = document.createElement('button');
+
+            suggestion.type = 'button';
+            suggestion.className = 'rovalra-friend-label-suggestion';
+            suggestion.textContent = existingLabel;
+            suggestion.title = existingLabel;
+
+            suggestion.addEventListener('click', () => {
+                input.value = existingLabel;
+
+                input.dispatchEvent(
+                    new Event('input', {
+                        bubbles: true,
+                    }),
+                );
+
+                input.focus();
+            });
+
+            suggestionList.appendChild(suggestion);
+        }
+
+        suggestionSection.append(suggestionTitle, suggestionList);
+        body.appendChild(suggestionSection);
+    }
+
+    let closeOverlay = () => {};
+
+    const saveLabel = async () => {
+        const nextLabel = input.value
+            .trim()
+            .slice(0, MAX_LABEL_LENGTH);
+
+        const nextLabels = {
+            ...friendLabels,
+        };
+
+        if (nextLabel) {
+            nextLabels[userId] = nextLabel;
+        } else {
+            delete nextLabels[userId];
+        }
+
+        await saveFriendLabels(nextLabels);
+
+        closeOverlay();
+    };
+
+    const cancelButton = createButton(
+        await t('friendLabels.cancel'),
+        'secondary',
+        {
+            onClick: () => closeOverlay(),
+        },
+    );
+
+    const saveButton = createButton(
+        await t('friendLabels.save'),
+        'primary',
+        {
+            onClick: saveLabel,
+        },
+    );
+
+    const actions = [];
+
+    if (currentLabel) {
+        const removeButton = createButton(
+            await t('friendLabels.remove'),
+            'secondary',
+            {
+                onClick: async () => {
+                    const nextLabels = {
+                        ...friendLabels,
+                    };
+
+                    delete nextLabels[userId];
+
+                    await saveFriendLabels(nextLabels);
+
+                    closeOverlay();
+                },
+            },
+        );
+
+        removeButton.classList.add(
+            'rovalra-friend-label-remove-button',
+        );
+
+        actions.push(removeButton);
+    }
+
+    actions.push(cancelButton, saveButton);
+
+    const overlayResult = createOverlay({
+        title: await t('friendLabels.dialogTitle', {
+            displayName,
+        }),
+        bodyContent: body,
+        actions,
+        maxWidth: '430px',
+        showLogo: true,
+    });
+
+    closeOverlay = overlayResult.close;
+
+    input.addEventListener('keydown', (event) => {
+        if (event.key !== 'Enter') return;
+
+        event.preventDefault();
+        saveButton.click();
+    });
+
+    requestAnimationFrame(() => {
+        input.focus();
+        input.select();
+    });
+}
+
+async function attachDropdownAction(menuList) {
+    if (!enabled || !(menuList instanceof HTMLElement)) {
+        return;
+    }
+
+    if (menuList.querySelector(`.${MENU_ITEM_CLASS}`)) {
+        return;
+    }
+
+    const dropdown = menuList.closest('.friend-tile-dropdown');
+    const card = dropdown?.closest(CARD_SELECTOR);
+
+    if (!card) return;
+
+    const context = getUserCardContext(card);
+
+    if (!context.userId) return;
+
+    const item = document.createElement('li');
+    item.className = MENU_ITEM_CLASS;
+
+    const button = createButton(
+        await t('friendLabels.menuAction'),
+        'secondary',
+        {
+            onClick: async (event) => {
+                event.preventDefault();
+                event.stopPropagation();
+
+                const currentCard =
+                    button.closest(CARD_SELECTOR) || card;
+
+                const currentContext =
+                    getUserCardContext(currentCard);
+
+                if (!currentContext.userId) return;
+
+                await openLabelEditor(
+                    currentCard,
+                    currentContext,
+                );
+            },
+        },
+    );
+
+    button.classList.add(
+        MENU_BUTTON_CLASS,
+        'friend-tile-dropdown-button',
+    );
+
+    item.appendChild(button);
+    menuList.appendChild(item);
+}
+
+function registerObservers() {
+    if (observersRegistered) return;
+
+    observersRegistered = true;
+
+    observeElement(
+        CARD_SELECTOR,
+        (card) => {
+            renderFriendLabel(card);
+        },
+        {
+            multiple: true,
+        },
+    );
+
+    observeElement(
+        DROPDOWN_LIST_SELECTOR,
+        attachDropdownAction,
+        {
+            multiple: true,
+        },
+    );
+}
+
+function attachActionsToExistingDropdowns() {
+    document
+        .querySelectorAll(DROPDOWN_LIST_SELECTOR)
+        .forEach((menuList) => {
+            attachDropdownAction(menuList);
+        });
+}
+
+function registerStorageListener() {
+    if (storageListenerRegistered) return;
+
+    storageListenerRegistered = true;
+
+    chrome.storage.onChanged.addListener(
+        async (changes, namespace) => {
+            if (namespace !== 'local') return;
+
+            if (changes[STORAGE_KEY]) {
+                friendLabels = sanitizeLabels(
+                    changes[STORAGE_KEY].newValue,
+                );
+
+                if (enabled) {
+                    refreshExistingCards();
+                }
+            }
+
+            if (!changes[SETTING_NAME]) return;
+
+            enabled = changes[SETTING_NAME].newValue === true;
+
+            if (!enabled) {
+                removeFeatureUi();
+                return;
+            }
+
+            friendLabels = await loadFriendLabels();
+
+            registerObservers();
+            refreshExistingCards();
+            attachActionsToExistingDropdowns();
+        },
+    );
+}
+
+export async function init() {
+    registerStorageListener();
+
+    enabled = (await settings.friendLabelsEnabled) === true;
+
+    if (!enabled) {
+        removeFeatureUi();
+        return;
+    }
+
+    friendLabels = await loadFriendLabels();
+
+    registerObservers();
+    refreshExistingCards();
+    attachActionsToExistingDropdowns();
+}

--- a/src/content/features/home/friendLabels.js
+++ b/src/content/features/home/friendLabels.js
@@ -118,22 +118,63 @@ function unwrapLabelHost(host) {
     host.remove();
 }
 
+function getNameRow(displayNameEl, context) {
+    const parent = displayNameEl.parentElement;
+
+    if (
+        !parent ||
+        parent.classList.contains(HOST_CLASS)
+    ) {
+        return displayNameEl;
+    }
+
+    /*
+     * Roblox and other extensions can render badges such as Verified or
+     * Roblox Premium next to the display name. In that layout the badge is a
+     * sibling of the name, so wrap the complete name row rather than moving
+     * only the text and leaving the badge behind.
+     */
+    if (context.link && parent.contains(context.link)) {
+        return displayNameEl;
+    }
+
+    if (context.avatar && parent.contains(context.avatar)) {
+        return displayNameEl;
+    }
+
+    if (
+        parent.textContent.trim() !==
+        displayNameEl.textContent.trim()
+    ) {
+        return displayNameEl;
+    }
+
+    return parent;
+}
+
 function findLabelHost(context) {
     if (!(context.displayName instanceof HTMLElement)) {
         return null;
     }
 
-    /*
-     * Wrap only the name row itself. Roblox keeps the current-game/presence
-     * text as a sibling, so this prevents Friend Labels from taking ownership
-     * of and restyling the playing-status layout.
-     */
-    const nameElement =
-        context.displayName.closest(
-            '.user-card-name, .friends-carousel-display-name, .avatar-name',
-        ) || context.displayName;
+    let nameRow = getNameRow(
+        context.displayName,
+        context,
+    );
 
-    const currentParent = nameElement.parentElement;
+    /*
+     * If the newer RoValra username feature has already wrapped this row,
+     * keep that wrapper intact and place the friend label beneath it.
+     */
+    const usernameWrapper = nameRow.closest(
+        '.rovalra-friend-username-wrapper',
+    );
+
+    if (usernameWrapper) {
+        nameRow = usernameWrapper;
+    }
+
+    const currentParent = nameRow.parentElement;
 
     if (!(currentParent instanceof HTMLElement)) {
         return null;
@@ -143,11 +184,11 @@ function findLabelHost(context) {
         return currentParent;
     }
 
-    const host = document.createElement('div');
+    const host = document.createElement('span');
     host.className = HOST_CLASS;
 
-    currentParent.insertBefore(host, nameElement);
-    host.appendChild(nameElement);
+    nameRow.replaceWith(host);
+    host.appendChild(nameRow);
 
     return host;
 }
@@ -465,6 +506,92 @@ function isModernFriendTooltip(root) {
     return hasViewProfile && hasFriendAction;
 }
 
+function getCanonicalModernTooltipRoot(candidate) {
+    if (!(candidate instanceof HTMLElement)) {
+        return null;
+    }
+
+    const controls = getTooltipControls(candidate);
+    const viewProfileControl = controls.find(
+        (element) =>
+            normalizeControlText(element) === 'view profile',
+    );
+
+    if (!viewProfileControl) {
+        return null;
+    }
+
+    /*
+     * Roblox can render nested nodes that all match our broad tooltip
+     * selector. Always collapse them to the nearest matching ancestor that
+     * actually contains the complete friend action set.
+     */
+    let current = viewProfileControl.parentElement;
+
+    while (
+        current instanceof HTMLElement &&
+        current !== document.body
+    ) {
+        if (
+            current.matches(MODERN_TOOLTIP_ROOT_SELECTOR) &&
+            isModernFriendTooltip(current)
+        ) {
+            return current;
+        }
+
+        current = current.parentElement;
+    }
+
+    return isModernFriendTooltip(candidate) ? candidate : null;
+}
+
+function removeModernTooltipAction(button) {
+    if (!(button instanceof HTMLElement)) {
+        return;
+    }
+
+    const wrapper = button.closest(
+        `.${MODERN_TOOLTIP_ITEM_CLASS}`,
+    );
+
+    if (
+        wrapper instanceof HTMLElement &&
+        wrapper !== button &&
+        wrapper.querySelectorAll(
+            `.${MODERN_TOOLTIP_BUTTON_CLASS}`,
+        ).length === 1
+    ) {
+        wrapper.remove();
+        return;
+    }
+
+    button.remove();
+}
+
+function dedupeModernTooltipActions(tooltip) {
+    if (!(tooltip instanceof HTMLElement)) {
+        return null;
+    }
+
+    const buttons = [
+        ...tooltip.querySelectorAll(
+            `.${MODERN_TOOLTIP_BUTTON_CLASS}`,
+        ),
+    ].filter((button) => button instanceof HTMLElement);
+
+    if (buttons.length === 0) {
+        return null;
+    }
+
+    const keep = buttons[0];
+
+    for (const duplicate of buttons.slice(1)) {
+        removeModernTooltipAction(duplicate);
+    }
+
+    return keep;
+}
+
 function getUserIdFromProfileLink(root) {
     if (!(root instanceof HTMLElement)) {
         return null;
@@ -609,58 +736,112 @@ function rememberFriendCard(card) {
 function findModernActionMount(tooltip, viewProfileControl) {
     const controls = getTooltipControls(tooltip);
 
-    const peerControl = controls.find((control) => {
-        const text = normalizeControlText(control);
+    const chatControl =
+        controls.find(
+            (control) =>
+                normalizeControlText(control) === 'chat',
+        ) || null;
 
-        return text === 'chat' || text === 'join';
-    });
+    const styleSource = chatControl || viewProfileControl;
 
     if (
-        peerControl?.parentElement ===
+        styleSource?.parentElement ===
         viewProfileControl.parentElement
     ) {
         return {
             reference: viewProfileControl,
             wrapperSource: null,
+            controlSource: styleSource,
         };
     }
 
     const viewWrapper = viewProfileControl.parentElement;
-    const peerWrapper = peerControl?.parentElement;
+    const styleWrapper = styleSource?.parentElement;
 
     if (
         viewWrapper instanceof HTMLElement &&
-        peerWrapper instanceof HTMLElement &&
-        viewWrapper.parentElement === peerWrapper.parentElement
+        styleWrapper instanceof HTMLElement &&
+        viewWrapper.parentElement === styleWrapper.parentElement
     ) {
         return {
             reference: viewWrapper,
-            wrapperSource: viewWrapper,
+            wrapperSource: styleWrapper,
+            controlSource: styleSource,
         };
     }
 
     return {
         reference: viewProfileControl,
         wrapperSource: null,
+        controlSource: styleSource,
     };
 }
 
-async function attachModernTooltipAction(tooltip) {
-    if (!enabled || !(tooltip instanceof HTMLElement)) {
+function createModernTooltipButton(sourceControl, labelText) {
+    let button;
+
+    if (sourceControl instanceof HTMLElement) {
+        button = sourceControl.cloneNode(false);
+    } else {
+        button = document.createElement('button');
+    }
+
+    if (!(button instanceof HTMLElement)) {
+        return null;
+    }
+
+    button.removeAttribute('id');
+    button.removeAttribute('href');
+    button.removeAttribute('target');
+    button.removeAttribute('rel');
+    button.removeAttribute('aria-controls');
+    button.removeAttribute('aria-expanded');
+
+    if (button instanceof HTMLButtonElement) {
+        button.type = 'button';
+    } else {
+        button.setAttribute('role', 'button');
+        button.tabIndex = 0;
+    }
+
+    button.classList.add(
+        MENU_BUTTON_CLASS,
+        MODERN_TOOLTIP_BUTTON_CLASS,
+    );
+    button.textContent = labelText;
+
+    return button;
+}
+
+async function attachModernTooltipAction(candidate) {
+    if (!enabled || !(candidate instanceof HTMLElement)) {
         return;
     }
 
-    if (!isModernFriendTooltip(tooltip)) {
+    const tooltip = getCanonicalModernTooltipRoot(candidate);
+
+    if (!tooltip) {
+        return;
+    }
+
+    /*
+     * Clean up any duplicate left by a previous Roblox rerender before doing
+     * anything else. One canonical tooltip should own exactly one action.
+     */
+    if (dedupeModernTooltipActions(tooltip)) {
         return;
     }
 
     if (
-        tooltip.querySelector(`.${MODERN_TOOLTIP_BUTTON_CLASS}`) ||
         tooltip.dataset.rovalraFriendLabelPending === 'true'
     ) {
         return;
     }
 
+    /*
+     * Lock the canonical tooltip before awaiting translations. This prevents
+     * two observer callbacks from racing and inserting the same action twice.
+     */
     tooltip.dataset.rovalraFriendLabelPending = 'true';
 
     try {
@@ -681,13 +862,29 @@ async function attachModernTooltipAction(tooltip) {
             return;
         }
 
-        const button = document.createElement('button');
-        button.type = 'button';
-        button.className = [
-            MENU_BUTTON_CLASS,
-            MODERN_TOOLTIP_BUTTON_CLASS,
-        ].join(' ');
-        button.textContent = await t('friendLabels.menuAction');
+        const mount = findModernActionMount(
+            tooltip,
+            viewProfileControl,
+        );
+
+        const labelText = await t('friendLabels.menuAction');
+
+        /*
+         * Re-check after the async translation in case another lifecycle path
+         * already created the action while Roblox was replacing DOM nodes.
+         */
+        if (dedupeModernTooltipActions(tooltip)) {
+            return;
+        }
+
+        const button = createModernTooltipButton(
+            mount.controlSource,
+            labelText,
+        );
+
+        if (!button) {
+            return;
+        }
 
         button.addEventListener('pointerdown', (event) => {
             event.stopPropagation();
@@ -712,10 +909,19 @@ async function attachModernTooltipAction(tooltip) {
             await openLabelEditor(currentCard, currentContext);
         });
 
-        const mount = findModernActionMount(
-            tooltip,
-            viewProfileControl,
-        );
+        if (!(button instanceof HTMLButtonElement)) {
+            button.addEventListener('keydown', (event) => {
+                if (
+                    event.key !== 'Enter' &&
+                    event.key !== ' '
+                ) {
+                    return;
+                }
+
+                event.preventDefault();
+                button.click();
+            });
+        }
 
         if (mount.wrapperSource) {
             const wrapper = document.createElement(
@@ -734,30 +940,48 @@ async function attachModernTooltipAction(tooltip) {
                 'afterend',
                 wrapper,
             );
+        } else {
+            const wrapper = document.createElement('div');
 
-            return;
+            wrapper.className = [
+                MENU_ITEM_CLASS,
+                MODERN_TOOLTIP_ITEM_CLASS,
+            ].join(' ');
+
+            wrapper.appendChild(button);
+            mount.reference.insertAdjacentElement(
+                'afterend',
+                wrapper,
+            );
         }
 
-        const wrapper = document.createElement('div');
-
-        wrapper.className = [
-            MENU_ITEM_CLASS,
-            MODERN_TOOLTIP_ITEM_CLASS,
-        ].join(' ');
-
-        wrapper.appendChild(button);
-        mount.reference.insertAdjacentElement('afterend', wrapper);
+        /*
+         * Final safety net for React/Roblox rerenders that may replay observer
+         * callbacks during insertion.
+         */
+        dedupeModernTooltipActions(tooltip);
     } finally {
         delete tooltip.dataset.rovalraFriendLabelPending;
     }
 }
 
 function attachActionsToExistingModernTooltips() {
+    const canonicalTooltips = new Set();
+
     document
         .querySelectorAll(MODERN_TOOLTIP_ROOT_SELECTOR)
-        .forEach((tooltip) => {
-            attachModernTooltipAction(tooltip);
+        .forEach((candidate) => {
+            const tooltip =
+                getCanonicalModernTooltipRoot(candidate);
+
+            if (tooltip) {
+                canonicalTooltips.add(tooltip);
+            }
         });
+
+    canonicalTooltips.forEach((tooltip) => {
+        attachModernTooltipAction(tooltip);
+    });
 }
 
 async function attachDropdownAction(menuList) {
@@ -815,6 +1039,10 @@ async function attachDropdownAction(menuList) {
             MENU_BUTTON_CLASS,
             'friend-tile-dropdown-button',
         );
+
+        if (menuList.querySelector(`.${MENU_ITEM_CLASS}`)) {
+            return;
+        }
 
         item.appendChild(button);
         menuList.appendChild(item);

--- a/src/content/features/home/friendLabels.js
+++ b/src/content/features/home/friendLabels.js
@@ -10,24 +10,18 @@ const SETTING_NAME = 'friendLabelsEnabled';
 const STORAGE_KEY = 'rovalra_friend_labels';
 
 const CARD_SELECTOR = '.friends-carousel-tile';
-const EXCLUDED_CONTAINER_SELECTOR =
-    '.roseal-friends-carousel-container';
+const EXCLUDED_CONTAINER_SELECTOR = '.roseal-friends-carousel-container';
 
 /* Legacy Roblox friend dropdown */
 const DROPDOWN_LIST_SELECTOR = '.friend-tile-dropdown ul';
 
 /*
- * The modern Roblox friend tooltip is rendered in a document-level portal,
- * rather than inside the friend card. Watch interactive controls and verify
- * that they belong to the friend tooltip before modifying them.
+ * The modern Roblox friend menu is rendered in a document-level portal.
+ * Identify it from its structure rather than translated button text.
  */
-const MODERN_TOOLTIP_ROOT_SELECTOR = [
-    '[role="dialog"]',
-    '[role="menu"]',
-    '[role="tooltip"]',
-    '[class*="popover" i]',
-    '[class*="dropdown" i]',
-].join(', ');
+const MODERN_TOOLTIP_ROOT_SELECTOR = '.friend-tile-dropdown--iarc';
+const MODERN_ACTIONS_SELECTOR = '.in-game-friend-card-actions';
+const MODERN_PROFILE_LINK_SELECTOR = 'a[href*="/users/"][href*="/profile"]';
 
 const HOST_CLASS = 'rovalra-friend-label-host';
 const LABEL_CLASS = 'rovalra-friend-label';
@@ -45,9 +39,7 @@ let friendLabels = {};
 let lastInteractedFriendCard = null;
 
 function isExcludedCarouselPresent() {
-    return Boolean(
-        document.querySelector(EXCLUDED_CONTAINER_SELECTOR),
-    );
+    return Boolean(document.querySelector(EXCLUDED_CONTAINER_SELECTOR));
 }
 
 function sanitizeLabels(value) {
@@ -129,10 +121,7 @@ function unwrapLabelHost(host) {
 function getNameRow(displayNameEl, context) {
     const parent = displayNameEl.parentElement;
 
-    if (
-        !parent ||
-        parent.classList.contains(HOST_CLASS)
-    ) {
+    if (!parent || parent.classList.contains(HOST_CLASS)) {
         return displayNameEl;
     }
 
@@ -150,10 +139,7 @@ function getNameRow(displayNameEl, context) {
         return displayNameEl;
     }
 
-    if (
-        parent.textContent.trim() !==
-        displayNameEl.textContent.trim()
-    ) {
+    if (parent.textContent.trim() !== displayNameEl.textContent.trim()) {
         return displayNameEl;
     }
 
@@ -165,18 +151,13 @@ function findLabelHost(context) {
         return null;
     }
 
-    let nameRow = getNameRow(
-        context.displayName,
-        context,
-    );
+    let nameRow = getNameRow(context.displayName, context);
 
     /*
      * If the newer RoValra username feature has already wrapped this row,
      * keep that wrapper intact and place the friend label beneath it.
      */
-    const usernameWrapper = nameRow.closest(
-        '.rovalra-friend-username-wrapper',
-    );
+    const usernameWrapper = nameRow.closest('.rovalra-friend-username-wrapper');
 
     if (usernameWrapper) {
         nameRow = usernameWrapper;
@@ -252,9 +233,7 @@ function renderFriendLabel(card, suppliedContext = null) {
         existingLabel.dataset.userId = String(context.userId);
 
         if (existingLabel.parentElement !== host) {
-            const previousHost = existingLabel.closest(
-                `.${HOST_CLASS}`,
-            );
+            const previousHost = existingLabel.closest(`.${HOST_CLASS}`);
 
             host.appendChild(existingLabel);
 
@@ -331,8 +310,7 @@ async function openLabelEditor(card, context) {
     const currentLabel = getFriendLabel(userId);
 
     const displayName =
-        getDisplayNameText(context) ||
-        (await t('friendLabels.friendFallback'));
+        getDisplayNameText(context) || (await t('friendLabels.friendFallback'));
 
     const body = document.createElement('div');
     body.className = 'rovalra-friend-label-editor';
@@ -352,15 +330,11 @@ async function openLabelEditor(card, context) {
 
     if (existingLabels.length > 0) {
         const suggestionSection = document.createElement('div');
-        suggestionSection.className =
-            'rovalra-friend-label-suggestion-section';
+        suggestionSection.className = 'rovalra-friend-label-suggestion-section';
 
         const suggestionTitle = document.createElement('div');
-        suggestionTitle.className =
-            'rovalra-friend-label-suggestion-title';
-        suggestionTitle.textContent = await t(
-            'friendLabels.existingLabels',
-        );
+        suggestionTitle.className = 'rovalra-friend-label-suggestion-title';
+        suggestionTitle.textContent = await t('friendLabels.existingLabels');
 
         const suggestionList = document.createElement('div');
         suggestionList.className = 'rovalra-friend-label-suggestions';
@@ -395,9 +369,7 @@ async function openLabelEditor(card, context) {
     let closeOverlay = () => {};
 
     const saveLabel = async () => {
-        const nextLabel = input.value
-            .trim()
-            .slice(0, MAX_LABEL_LENGTH);
+        const nextLabel = input.value.trim().slice(0, MAX_LABEL_LENGTH);
 
         const nextLabels = {
             ...friendLabels,
@@ -422,13 +394,9 @@ async function openLabelEditor(card, context) {
         },
     );
 
-    const saveButton = createButton(
-        await t('friendLabels.save'),
-        'primary',
-        {
-            onClick: saveLabel,
-        },
-    );
+    const saveButton = createButton(await t('friendLabels.save'), 'primary', {
+        onClick: saveLabel,
+    });
 
     const actions = [];
 
@@ -451,9 +419,7 @@ async function openLabelEditor(card, context) {
             },
         );
 
-        removeButton.classList.add(
-            'rovalra-friend-label-remove-button',
-        );
+        removeButton.classList.add('rovalra-friend-label-remove-button');
 
         actions.push(removeButton);
     }
@@ -485,27 +451,14 @@ async function openLabelEditor(card, context) {
     });
 }
 
-function normalizeControlText(element) {
-    return (
-        element?.textContent
-            ?.replace(/\s+/g, ' ')
-            .trim()
-            .toLowerCase() || ''
-    );
-}
-
-function getTooltipControls(root) {
+function getModernActionContainer(root) {
     if (!(root instanceof HTMLElement)) {
-        return [];
+        return null;
     }
 
-    return [
-        ...root.querySelectorAll('button, a, [role="button"]'),
-    ].filter(
-        (element) =>
-            element instanceof HTMLElement &&
-            element.offsetParent !== null,
-    );
+    const actions = root.querySelector(MODERN_ACTIONS_SELECTOR);
+
+    return actions instanceof HTMLElement ? actions : null;
 }
 
 function isModernFriendTooltip(root) {
@@ -513,15 +466,12 @@ function isModernFriendTooltip(root) {
         return false;
     }
 
-    const controlTexts = new Set(
-        getTooltipControls(root).map(normalizeControlText),
+    return Boolean(
+        root.matches(MODERN_TOOLTIP_ROOT_SELECTOR) &&
+        getModernActionContainer(root)?.querySelector(
+            MODERN_PROFILE_LINK_SELECTOR,
+        ),
     );
-
-    const hasViewProfile = controlTexts.has('view profile');
-    const hasFriendAction =
-        controlTexts.has('chat') || controlTexts.has('join');
-
-    return hasViewProfile && hasFriendAction;
 }
 
 function getCanonicalModernTooltipRoot(candidate) {
@@ -529,38 +479,13 @@ function getCanonicalModernTooltipRoot(candidate) {
         return null;
     }
 
-    const controls = getTooltipControls(candidate);
-    const viewProfileControl = controls.find(
-        (element) =>
-            normalizeControlText(element) === 'view profile',
-    );
+    const root = candidate.matches(MODERN_TOOLTIP_ROOT_SELECTOR)
+        ? candidate
+        : candidate.closest(MODERN_TOOLTIP_ROOT_SELECTOR);
 
-    if (!viewProfileControl) {
-        return null;
-    }
-
-    /*
-     * Roblox can render nested nodes that all match our broad tooltip
-     * selector. Always collapse them to the nearest matching ancestor that
-     * actually contains the complete friend action set.
-     */
-    let current = viewProfileControl.parentElement;
-
-    while (
-        current instanceof HTMLElement &&
-        current !== document.body
-    ) {
-        if (
-            current.matches(MODERN_TOOLTIP_ROOT_SELECTOR) &&
-            isModernFriendTooltip(current)
-        ) {
-            return current;
-        }
-
-        current = current.parentElement;
-    }
-
-    return isModernFriendTooltip(candidate) ? candidate : null;
+    return root instanceof HTMLElement && isModernFriendTooltip(root)
+        ? root
+        : null;
 }
 
 function removeModernTooltipAction(button) {
@@ -568,16 +493,12 @@ function removeModernTooltipAction(button) {
         return;
     }
 
-    const wrapper = button.closest(
-        `.${MODERN_TOOLTIP_ITEM_CLASS}`,
-    );
+    const wrapper = button.closest(`.${MODERN_TOOLTIP_ITEM_CLASS}`);
 
     if (
         wrapper instanceof HTMLElement &&
         wrapper !== button &&
-        wrapper.querySelectorAll(
-            `.${MODERN_TOOLTIP_BUTTON_CLASS}`,
-        ).length === 1
+        wrapper.querySelectorAll(`.${MODERN_TOOLTIP_BUTTON_CLASS}`).length === 1
     ) {
         wrapper.remove();
         return;
@@ -592,9 +513,7 @@ function dedupeModernTooltipActions(tooltip) {
     }
 
     const buttons = [
-        ...tooltip.querySelectorAll(
-            `.${MODERN_TOOLTIP_BUTTON_CLASS}`,
-        ),
+        ...tooltip.querySelectorAll(`.${MODERN_TOOLTIP_BUTTON_CLASS}`),
     ].filter((button) => button instanceof HTMLElement);
 
     if (buttons.length === 0) {
@@ -646,49 +565,6 @@ function findHoveredFriendCard() {
     return null;
 }
 
-function findFriendCardByTooltipText(tooltip) {
-    if (!(tooltip instanceof HTMLElement)) {
-        return null;
-    }
-
-    const tooltipText =
-        tooltip.textContent
-            ?.replace(/\s+/g, ' ')
-            .trim()
-            .toLowerCase() || '';
-
-    if (!tooltipText) {
-        return null;
-    }
-
-    const cards = [...document.querySelectorAll(CARD_SELECTOR)];
-
-    cards.sort((firstCard, secondCard) => {
-        const firstName = getDisplayNameText(
-            getUserCardContext(firstCard),
-        );
-        const secondName = getDisplayNameText(
-            getUserCardContext(secondCard),
-        );
-
-        return secondName.length - firstName.length;
-    });
-
-    for (const card of cards) {
-        const context = getUserCardContext(card);
-        const displayName = getDisplayNameText(context)
-            .replace(/\s+/g, ' ')
-            .trim()
-            .toLowerCase();
-
-        if (displayName && tooltipText.includes(displayName)) {
-            return card;
-        }
-    }
-
-    return null;
-}
-
 function resolveModernTooltipCard(tooltip) {
     const linkedUserId = getUserIdFromProfileLink(tooltip);
     const linkedCard = findFriendCardByUserId(linkedUserId);
@@ -705,20 +581,11 @@ function resolveModernTooltipCard(tooltip) {
         return hoveredCard;
     }
 
-    const activeCard = document.activeElement?.closest?.(
-        CARD_SELECTOR,
-    );
+    const activeCard = document.activeElement?.closest?.(CARD_SELECTOR);
 
     if (activeCard instanceof HTMLElement) {
         lastInteractedFriendCard = activeCard;
         return activeCard;
-    }
-
-    const textMatchedCard = findFriendCardByTooltipText(tooltip);
-
-    if (textMatchedCard) {
-        lastInteractedFriendCard = textMatchedCard;
-        return textMatchedCard;
     }
 
     if (
@@ -751,21 +618,14 @@ function rememberFriendCard(card) {
     card.addEventListener('focusin', remember);
 }
 
-function findModernActionMount(tooltip, viewProfileControl) {
-    const controls = getTooltipControls(tooltip);
-
+function findModernActionMount(viewProfileControl) {
+    const previousControl = viewProfileControl.previousElementSibling;
     const chatControl =
-        controls.find(
-            (control) =>
-                normalizeControlText(control) === 'chat',
-        ) || null;
+        previousControl instanceof HTMLButtonElement ? previousControl : null;
 
     const styleSource = chatControl || viewProfileControl;
 
-    if (
-        styleSource?.parentElement ===
-        viewProfileControl.parentElement
-    ) {
+    if (styleSource?.parentElement === viewProfileControl.parentElement) {
         return {
             reference: viewProfileControl,
             wrapperSource: null,
@@ -822,10 +682,7 @@ function createModernTooltipButton(sourceControl, labelText) {
         button.tabIndex = 0;
     }
 
-    button.classList.add(
-        MENU_BUTTON_CLASS,
-        MODERN_TOOLTIP_BUTTON_CLASS,
-    );
+    button.classList.add(MENU_BUTTON_CLASS, MODERN_TOOLTIP_BUTTON_CLASS);
     button.textContent = labelText;
 
     return button;
@@ -854,9 +711,7 @@ async function attachModernTooltipAction(candidate) {
         return;
     }
 
-    if (
-        tooltip.dataset.rovalraFriendLabelPending === 'true'
-    ) {
+    if (tooltip.dataset.rovalraFriendLabelPending === 'true') {
         return;
     }
 
@@ -867,10 +722,9 @@ async function attachModernTooltipAction(candidate) {
     tooltip.dataset.rovalraFriendLabelPending = 'true';
 
     try {
-        const controls = getTooltipControls(tooltip);
-        const viewProfileControl = controls.find(
-            (element) =>
-                normalizeControlText(element) === 'view profile',
+        const actions = getModernActionContainer(tooltip);
+        const viewProfileControl = actions?.querySelector(
+            MODERN_PROFILE_LINK_SELECTOR,
         );
 
         if (!viewProfileControl) {
@@ -884,10 +738,7 @@ async function attachModernTooltipAction(candidate) {
             return;
         }
 
-        const mount = findModernActionMount(
-            tooltip,
-            viewProfileControl,
-        );
+        const mount = findModernActionMount(viewProfileControl);
 
         const labelText = await t('friendLabels.menuAction');
 
@@ -933,10 +784,7 @@ async function attachModernTooltipAction(candidate) {
 
         if (!(button instanceof HTMLButtonElement)) {
             button.addEventListener('keydown', (event) => {
-                if (
-                    event.key !== 'Enter' &&
-                    event.key !== ' '
-                ) {
+                if (event.key !== 'Enter' && event.key !== ' ') {
                     return;
                 }
 
@@ -951,17 +799,11 @@ async function attachModernTooltipAction(candidate) {
             );
 
             wrapper.className = mount.wrapperSource.className;
-            wrapper.classList.add(
-                MENU_ITEM_CLASS,
-                MODERN_TOOLTIP_ITEM_CLASS,
-            );
+            wrapper.classList.add(MENU_ITEM_CLASS, MODERN_TOOLTIP_ITEM_CLASS);
 
             wrapper.appendChild(button);
 
-            mount.reference.insertAdjacentElement(
-                'afterend',
-                wrapper,
-            );
+            mount.reference.insertAdjacentElement('afterend', wrapper);
         } else {
             const wrapper = document.createElement('div');
 
@@ -971,10 +813,7 @@ async function attachModernTooltipAction(candidate) {
             ].join(' ');
 
             wrapper.appendChild(button);
-            mount.reference.insertAdjacentElement(
-                'afterend',
-                wrapper,
-            );
+            mount.reference.insertAdjacentElement('afterend', wrapper);
         }
 
         /*
@@ -993,8 +832,7 @@ function attachActionsToExistingModernTooltips() {
     document
         .querySelectorAll(MODERN_TOOLTIP_ROOT_SELECTOR)
         .forEach((candidate) => {
-            const tooltip =
-                getCanonicalModernTooltipRoot(candidate);
+            const tooltip = getCanonicalModernTooltipRoot(candidate);
 
             if (tooltip) {
                 canonicalTooltips.add(tooltip);
@@ -1045,26 +883,18 @@ async function attachDropdownAction(menuList) {
                     event.preventDefault();
                     event.stopPropagation();
 
-                    const currentCard =
-                        button.closest(CARD_SELECTOR) || card;
+                    const currentCard = button.closest(CARD_SELECTOR) || card;
 
-                    const currentContext =
-                        getUserCardContext(currentCard);
+                    const currentContext = getUserCardContext(currentCard);
 
                     if (!currentContext.userId) return;
 
-                    await openLabelEditor(
-                        currentCard,
-                        currentContext,
-                    );
+                    await openLabelEditor(currentCard, currentContext);
                 },
             },
         );
 
-        button.classList.add(
-            MENU_BUTTON_CLASS,
-            'friend-tile-dropdown-button',
-        );
+        button.classList.add(MENU_BUTTON_CLASS, 'friend-tile-dropdown-button');
 
         if (menuList.querySelector(`.${MENU_ITEM_CLASS}`)) {
             return;
@@ -1093,37 +923,23 @@ function registerObservers() {
         },
     );
 
-    observeElement(
-        DROPDOWN_LIST_SELECTOR,
-        attachDropdownAction,
-        {
-            multiple: true,
-        },
-    );
+    observeElement(DROPDOWN_LIST_SELECTOR, attachDropdownAction, {
+        multiple: true,
+    });
 
-    observeElement(
-        MODERN_TOOLTIP_ROOT_SELECTOR,
-        attachModernTooltipAction,
-        {
-            multiple: true,
-        },
-    );
+    observeElement(MODERN_TOOLTIP_ROOT_SELECTOR, attachModernTooltipAction, {
+        multiple: true,
+    });
 
-    observeElement(
-        EXCLUDED_CONTAINER_SELECTOR,
-        removeFeatureUi,
-        {
-            multiple: true,
-        },
-    );
+    observeElement(EXCLUDED_CONTAINER_SELECTOR, removeFeatureUi, {
+        multiple: true,
+    });
 }
 
 function attachActionsToExistingDropdowns() {
-    document
-        .querySelectorAll(DROPDOWN_LIST_SELECTOR)
-        .forEach((menuList) => {
-            attachDropdownAction(menuList);
-        });
+    document.querySelectorAll(DROPDOWN_LIST_SELECTOR).forEach((menuList) => {
+        attachDropdownAction(menuList);
+    });
 
     document.querySelectorAll(CARD_SELECTOR).forEach((card) => {
         rememberFriendCard(card);
@@ -1137,36 +953,32 @@ function registerStorageListener() {
 
     storageListenerRegistered = true;
 
-    chrome.storage.onChanged.addListener(
-        async (changes, namespace) => {
-            if (namespace !== 'local') return;
+    chrome.storage.onChanged.addListener(async (changes, namespace) => {
+        if (namespace !== 'local') return;
 
-            if (changes[STORAGE_KEY]) {
-                friendLabels = sanitizeLabels(
-                    changes[STORAGE_KEY].newValue,
-                );
+        if (changes[STORAGE_KEY]) {
+            friendLabels = sanitizeLabels(changes[STORAGE_KEY].newValue);
 
-                if (enabled) {
-                    refreshExistingCards();
-                }
+            if (enabled) {
+                refreshExistingCards();
             }
+        }
 
-            if (!changes[SETTING_NAME]) return;
+        if (!changes[SETTING_NAME]) return;
 
-            enabled = changes[SETTING_NAME].newValue === true;
+        enabled = changes[SETTING_NAME].newValue === true;
 
-            if (!enabled) {
-                removeFeatureUi();
-                return;
-            }
+        if (!enabled) {
+            removeFeatureUi();
+            return;
+        }
 
-            friendLabels = await loadFriendLabels();
+        friendLabels = await loadFriendLabels();
 
-            registerObservers();
-            refreshExistingCards();
-            attachActionsToExistingDropdowns();
-        },
-    );
+        registerObservers();
+        refreshExistingCards();
+        attachActionsToExistingDropdowns();
+    });
 }
 
 export async function init() {

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -163,6 +163,7 @@ import { init as initLegacyThemeSwitcher } from './features/settings/roblox/lega
 import { init as initAccurateContinue } from './features/home/accurateContinue.js';
 import { init as initHomeLayout } from './features/home/homeLayout.js';
 import { init as initCustomThemeEditor } from './features/home/customThemeEditor.js';
+import { init as initFriendLabels } from './features/home/friendLabels.js';
 import { init as initUnderratedGamesHome } from './features/home/underratedGames.js';
 import { init as initHideAddFriendsButton } from './features/home/hideAddFriendsButton.js';
 // create
@@ -431,6 +432,7 @@ const featureRoutes = [
             initUnderratedGamesHome,
             initAccurateContinue,
             initHideAddFriendsButton,
+            initFriendLabels,
         ],
     },
     {

--- a/src/css/features/home/friendLabels.scss
+++ b/src/css/features/home/friendLabels.scss
@@ -1,44 +1,21 @@
 .rovalra-friend-label-host {
-    display: flex;
+    display: inline-flex;
     flex-direction: column;
     align-items: center;
-    gap: 2px;
 
-    width: 100%;
-    min-width: 0;
     max-width: 100%;
+    min-width: 0;
 
     box-sizing: border-box;
 }
 
-.rovalra-friend-label-host > .user-card-name,
-.rovalra-friend-label-host > .friends-carousel-display-name,
-.rovalra-friend-label-host > .avatar-name {
-    display: block;
-
-    width: 100%;
-    min-width: 0;
+/*
+ * Keep Roblox's existing name row intact. That row can include Verified,
+ * Premium, RoValra Plus, or other badges next to the display name.
+ */
+.rovalra-friend-label-host > :not(.rovalra-friend-label) {
     max-width: 100%;
-
-    overflow: hidden;
-
-    text-align: center;
-}
-
-.rovalra-friend-label-host .user-card-name > span,
-.rovalra-friend-label-host > .friends-carousel-display-name,
-.rovalra-friend-label-host > .avatar-name {
-    display: block;
-
-    width: 100%;
     min-width: 0;
-    max-width: 100%;
-
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-
-    text-align: center;
 }
 
 .rovalra-friend-label {
@@ -51,7 +28,7 @@
     max-width: calc(100% - 4px);
     min-height: 16px;
 
-    margin: 0 auto;
+    margin: 2px auto 0;
     padding: 1px 6px;
 
     box-sizing: border-box;
@@ -231,57 +208,17 @@
 
 /* Modern Roblox friend tooltip */
 
+/*
+ * The control clones Roblox's Chat control classes at runtime, so its visual
+ * styling follows the native friend tooltip automatically. These rules only
+ * keep the injected row sized correctly and avoid overriding Roblox's theme.
+ */
 .rovalra-friend-label-modern-item {
     width: 100%;
     box-sizing: border-box;
 }
 
 .rovalra-friend-label-modern-button {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-
     width: 100%;
-    min-width: 0;
-    min-height: 40px;
-
-    margin-top: 8px;
-    padding: 0 14px;
-
     box-sizing: border-box;
-
-    appearance: none;
-    border: 1px solid rgba(255, 255, 255, 0.16);
-    border-radius: 8px;
-
-    background: rgba(255, 255, 255, 0.08);
-    color: #fff;
-
-    font: inherit;
-    font-size: 14px;
-    font-weight: 600;
-    line-height: 1;
-    text-align: center;
-    text-decoration: none;
-
-    cursor: pointer;
-
-    transition:
-        background 120ms ease,
-        border-color 120ms ease,
-        transform 120ms ease;
-}
-
-.rovalra-friend-label-modern-button:hover {
-    background: rgba(255, 255, 255, 0.12);
-    border-color: rgba(255, 255, 255, 0.22);
-}
-
-.rovalra-friend-label-modern-button:active {
-    transform: scale(0.985);
-}
-
-.rovalra-friend-label-modern-button:focus-visible {
-    outline: 2px solid rgba(255, 255, 255, 0.4);
-    outline-offset: 2px;
 }

--- a/src/css/features/home/friendLabels.scss
+++ b/src/css/features/home/friendLabels.scss
@@ -1,0 +1,228 @@
+.rovalra-friend-label-host {
+    display: flex !important;
+    flex-direction: column !important;
+    align-items: center !important;
+
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+
+    box-sizing: border-box;
+}
+
+.rovalra-friend-label-host > .user-card-name,
+.rovalra-friend-label-host > .friends-carousel-display-name {
+    display: block;
+
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+
+    overflow: hidden;
+
+    text-align: center;
+}
+
+.rovalra-friend-label-host .user-card-name > span,
+.rovalra-friend-label-host .friends-carousel-display-name,
+.rovalra-friend-label-host .avatar-name {
+    display: block;
+
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    text-align: center;
+}
+
+.rovalra-friend-label {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    width: fit-content;
+    min-width: 0;
+    max-width: calc(100% - 4px);
+    min-height: 16px;
+
+    margin: 4px auto 0;
+    padding: 1px 6px;
+
+    box-sizing: border-box;
+
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    border: 0;
+    border-radius: 999px;
+
+    background: var(--rovalra-button-background-color);
+    color: var(--rovalra-secondary-text-color);
+
+    font-size: 9px;
+    font-weight: 600;
+    line-height: 14px;
+    text-align: center;
+
+    cursor: default;
+    user-select: none;
+}
+
+.rovalra-friend-label-menu-item {
+    width: 100%;
+}
+
+.rovalra-friend-label-menu-button {
+    display: flex;
+    align-items: center;
+
+    width: 100%;
+
+    box-sizing: border-box;
+
+    text-align: left;
+}
+
+/* Label editor dialog */
+
+.rovalra-friend-label-editor {
+    display: flex;
+    flex-direction: column;
+
+    width: 100%;
+    min-width: 0;
+
+    /*
+     * The shared RoValra input moves its label upward when focused.
+     * This spacing prevents the floating label from being clipped.
+     */
+    padding-top: 14px;
+
+    box-sizing: border-box;
+    gap: 16px;
+}
+
+.rovalra-friend-label-editor
+    .rovalra-catalog-input-wrapper {
+    position: relative;
+
+    width: 100%;
+    min-width: 0;
+
+    overflow: visible !important;
+}
+
+.rovalra-friend-label-editor
+    .rovalra-catalog-input-base {
+    width: 100%;
+    min-width: 0;
+}
+
+.rovalra-friend-label-editor
+    .rovalra-catalog-input-field {
+    width: 100%;
+    min-width: 0;
+
+    box-sizing: border-box;
+}
+
+.rovalra-friend-label-editor
+    .rovalra-catalog-input-label {
+    z-index: 2;
+}
+
+.rovalra-friend-label-editor
+    .rovalra-catalog-input-label.MuiInputLabel-shrink {
+    transform: translate(0, -15px) scale(0.75);
+    transform-origin: top left;
+}
+
+/* Existing-label suggestions */
+
+.rovalra-friend-label-suggestion-section {
+    display: flex;
+    flex-direction: column;
+
+    width: 100%;
+    min-width: 0;
+
+    gap: 8px;
+}
+
+.rovalra-friend-label-suggestion-title {
+    color: var(--rovalra-secondary-text-color);
+
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 16px;
+}
+
+.rovalra-friend-label-suggestions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+
+    width: 100%;
+    min-width: 0;
+
+    gap: 6px;
+}
+
+.rovalra-friend-label-suggestion {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    min-width: 0;
+    max-width: 160px;
+    min-height: 28px;
+
+    padding: 5px 9px;
+
+    box-sizing: border-box;
+
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    border: 0;
+    border-radius: 999px;
+
+    background: var(--rovalra-button-background-color);
+    color: var(--rovalra-main-text-color);
+
+    cursor: pointer;
+
+    font: inherit;
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 16px;
+
+    transition:
+        filter 120ms ease,
+        transform 120ms ease;
+}
+
+.rovalra-friend-label-suggestion:hover {
+    filter: brightness(0.92);
+}
+
+.rovalra-friend-label-suggestion:active {
+    transform: scale(0.97);
+}
+
+.rovalra-friend-label-suggestion:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: 2px;
+}
+
+/* Dialog buttons */
+
+.rovalra-friend-label-remove-button {
+    margin-right: auto;
+}

--- a/src/css/features/home/friendLabels.scss
+++ b/src/css/features/home/friendLabels.scss
@@ -1,7 +1,8 @@
 .rovalra-friend-label-host {
-    display: flex !important;
-    flex-direction: column !important;
-    align-items: center !important;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
 
     width: 100%;
     min-width: 0;
@@ -11,7 +12,8 @@
 }
 
 .rovalra-friend-label-host > .user-card-name,
-.rovalra-friend-label-host > .friends-carousel-display-name {
+.rovalra-friend-label-host > .friends-carousel-display-name,
+.rovalra-friend-label-host > .avatar-name {
     display: block;
 
     width: 100%;
@@ -24,8 +26,8 @@
 }
 
 .rovalra-friend-label-host .user-card-name > span,
-.rovalra-friend-label-host .friends-carousel-display-name,
-.rovalra-friend-label-host .avatar-name {
+.rovalra-friend-label-host > .friends-carousel-display-name,
+.rovalra-friend-label-host > .avatar-name {
     display: block;
 
     width: 100%;
@@ -49,7 +51,7 @@
     max-width: calc(100% - 4px);
     min-height: 16px;
 
-    margin: 4px auto 0;
+    margin: 0 auto;
     padding: 1px 6px;
 
     box-sizing: border-box;
@@ -225,4 +227,61 @@
 
 .rovalra-friend-label-remove-button {
     margin-right: auto;
+}
+
+/* Modern Roblox friend tooltip */
+
+.rovalra-friend-label-modern-item {
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.rovalra-friend-label-modern-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    width: 100%;
+    min-width: 0;
+    min-height: 40px;
+
+    margin-top: 8px;
+    padding: 0 14px;
+
+    box-sizing: border-box;
+
+    appearance: none;
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    border-radius: 8px;
+
+    background: rgba(255, 255, 255, 0.08);
+    color: #fff;
+
+    font: inherit;
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 1;
+    text-align: center;
+    text-decoration: none;
+
+    cursor: pointer;
+
+    transition:
+        background 120ms ease,
+        border-color 120ms ease,
+        transform 120ms ease;
+}
+
+.rovalra-friend-label-modern-button:hover {
+    background: rgba(255, 255, 255, 0.12);
+    border-color: rgba(255, 255, 255, 0.22);
+}
+
+.rovalra-friend-label-modern-button:active {
+    transform: scale(0.985);
+}
+
+.rovalra-friend-label-modern-button:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.4);
+    outline-offset: 2px;
 }

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -30,6 +30,7 @@
 @use 'features/games/badgeLayoutToggle.scss';
 @use 'features/groups/antibots.scss';
 @use 'features/home/homeLayout.scss';
+@use 'features/home/friendLabels.scss';
 @use 'features/home/customThemeEditor.scss';
 @use 'features/sitewide/backgroundImage.scss';
 @use 'features/home/hideAddFriendsButton.scss';


### PR DESCRIPTION
## What is it?

Heya, This adds a new **Friend Labels** feature to the Roblox Home page.

It lets users assign private labels to friends directly from the friend card dropdown when you hover over friends. For example, friends can be labelled as **Close Friends**, **School** or anything else the user chooses.

## How does it work

The feature reuses RoValra’s existing user card detection.

Friend labels are stored locally so they stay. Users can create, replace, reuse, or remove labels at any time.

This feature does not reorder any of the friends btw.

## Testing

I tested:

- Creating labels for multiple friends
- Reusing existing labels
- Editing and removing labels
- Label persistence after refreshing
- Enabling and disabling the setting
- Long friend names and long labels

<img width="2230" height="304" alt="image" src="https://github.com/user-attachments/assets/4feed2bb-cdb1-413a-9cee-3046032530df" />

Area to add or change labels of a friend
<img width="418" height="260" alt="image" src="https://github.com/user-attachments/assets/b9070c2a-f573-4adb-a707-26b3df9b5b4c" />

