### PR TITLE
Reveal hidden Robux balance on mouse hover

### DIFF
--- a/public/Assets/locales/en.json
+++ b/public/Assets/locales/en.json
@@ -56,6 +56,9 @@
             "settings": "Settings"
         }
     },
+    "streamerMode": {
+        "hiddenRobux": "Hidden"
+    },
     "underratedGames": {
         "topic": "Underrated Games",
         "subtitle": "Underrated games hand picked by the RoValra community.",

--- a/src/content/core/settings/settingConfig.js
+++ b/src/content/core/settings/settingConfig.js
@@ -2270,6 +2270,7 @@ export const SETTINGS_CONFIG = {
                 ],
                 type: 'checkbox',
                 default: false,
+                contributors: ['196966673', '447170745'],
                 experimental:
                     "This may cause some issues since it tricks Roblox into thinking your private info is something it isn't.",
                 childSettings: {
@@ -2287,6 +2288,14 @@ export const SETTINGS_CONFIG = {
                         description: [
                             "Simply hides your Robux by changing it to 'Hidden'",
                             'This does not hide your Robux on purchase prompts.',
+                        ],
+                        type: 'checkbox',
+                        default: false,
+                    },
+                    showRobuxOnHover: {
+                        label: 'Show Robux on Hover',
+                        description: [
+                            'Temporarily shows your Robux while you hover over it.',
                         ],
                         type: 'checkbox',
                         default: false,

--- a/src/content/core/ui/robuxIcon.js
+++ b/src/content/core/ui/robuxIcon.js
@@ -38,6 +38,8 @@ const IGNORE_USD_SELECTOR =
 const INLINE_FIAT_LOCATIONS = '#navbar-robux, #buy-robux-popover';
 const TOOLTIP_FIAT_LOCATIONS = '#rovalra-stat-robux';
 const NAVBAR_BALANCE_UPDATED_EVENT = 'rovalra:navbar-balance-updated';
+const NAVBAR_FIAT_ESTIMATE_UPDATED_EVENT =
+    'rovalra:navbar-fiat-estimate-updated';
 
 let robuxPricingPromise = null;
 let robuxIconInitialized = false;
@@ -49,12 +51,25 @@ function scheduleUsdRefresh(delay = 0) {
 }
 
 function removeAllEstimates() {
+    let navbarEstimateChanged = false;
+
     document
         .querySelectorAll('.rovalra-usd-estimate')
-        .forEach((el) => el.remove());
+        .forEach((el) => {
+            if (el.closest('#navbar-robux')) {
+                navbarEstimateChanged = true;
+            }
+            el.remove();
+        });
     document.querySelectorAll('[data-rovalra-usd-amount]').forEach((el) => {
         delete el.dataset.rovalraUsdAmount;
     });
+
+    if (navbarEstimateChanged) {
+        document.dispatchEvent(
+            new CustomEvent(NAVBAR_FIAT_ESTIMATE_UPDATED_EVENT),
+        );
+    }
 }
 
 function isTransactionsPage() {
@@ -465,6 +480,12 @@ function upsertEstimate(anchorElement, estimate, options = {}) {
         const nextText = ` (${text})`;
         if (estimateEl.textContent !== nextText) {
             estimateEl.textContent = nextText;
+        }
+
+        if (anchor.closest('#navbar-robux')) {
+            document.dispatchEvent(
+                new CustomEvent(NAVBAR_FIAT_ESTIMATE_UPDATED_EVENT),
+            );
         }
 
         return estimateEl;
@@ -908,6 +929,16 @@ export function init() {
                 document
                     .querySelectorAll('.rovalra-usd-estimate')
                     .forEach((el) => applyEstimateStyle(el, style));
+
+                if (
+                    document.querySelector(
+                        '#navbar-robux .rovalra-usd-estimate',
+                    )
+                ) {
+                    document.dispatchEvent(
+                        new CustomEvent(NAVBAR_FIAT_ESTIMATE_UPDATED_EVENT),
+                    );
+                }
             });
             return;
         }

--- a/src/content/features/sitewide/customFont.js
+++ b/src/content/features/sitewide/customFont.js
@@ -1,3 +1,5 @@
+const CUSTOM_FONT_UPDATED_EVENT = 'rovalra:custom-font-updated';
+
 export function init() {
     chrome.storage.local.get(['Customfont', 'Customfontlink'], (result) => {
         if (!result.Customfont) return;
@@ -57,11 +59,12 @@ function resolveGoogleFont(input) {
 }
 
 function applyCustomFont(input) {
-    removeCustomFont();
+    removeCustomFont(false);
 
     const resolved = resolveGoogleFont(input);
     if (!resolved) {
         console.warn('[RoValra] customFont: Could not parse font input:', input);
+        document.dispatchEvent(new CustomEvent(CUSTOM_FONT_UPDATED_EVENT));
         return;
     }
 
@@ -78,9 +81,13 @@ function applyCustomFont(input) {
     `;
 
     document.head.appendChild(style);
+    document.dispatchEvent(new CustomEvent(CUSTOM_FONT_UPDATED_EVENT));
 }
 
-function removeCustomFont() {
+function removeCustomFont(notify = true) {
     const existing = document.getElementById('rovalra-custom-font');
     if (existing) existing.remove();
+    if (notify) {
+        document.dispatchEvent(new CustomEvent(CUSTOM_FONT_UPDATED_EVENT));
+    }
 }

--- a/src/content/features/sitewide/streamermode.js
+++ b/src/content/features/sitewide/streamermode.js
@@ -1,13 +1,104 @@
 import { observeElement } from '../../core/observer.js';
+import { ts } from '../../core/locale/i18n.js';
+import { settings } from '../../core/settings/getSettings.js';
+
+const NAVBAR_BALANCE_UPDATED_EVENT = 'rovalra:navbar-balance-updated';
+const NAVBAR_FIAT_ESTIMATE_UPDATED_EVENT =
+    'rovalra:navbar-fiat-estimate-updated';
 
 export function init() {
     let isHideRobuxEnabled = false;
+    let isShowRobuxOnHoverEnabled = false;
     let isSettingsPageInfoEnabled = false;
 
-    function updateRobuxText(element) {
-        if (isHideRobuxEnabled && element.textContent !== 'Hidden') {
-            element.textContent = 'Hidden';
+    function updateAllRobuxMasks() {
+        document
+            .querySelectorAll('#nav-robux-amount, #nav-robux-balance')
+            .forEach(updateRobuxMask);
+    }
+
+    function measureRobuxWidth(element, text = null) {
+        const measure = document.createElement('span');
+        const computedStyle = getComputedStyle(element);
+
+        Object.assign(measure.style, {
+            position: 'absolute',
+            visibility: 'hidden',
+            whiteSpace: 'nowrap',
+            font: computedStyle.font,
+            letterSpacing: computedStyle.letterSpacing,
+        });
+        measure.textContent = text ?? element.textContent;
+        document.body.appendChild(measure);
+        const width = Math.ceil(measure.getBoundingClientRect().width);
+        measure.remove();
+
+        return width;
+    }
+
+    function measureFullRobuxWidth(element) {
+        const measure = element.cloneNode(true);
+        const computedStyle = getComputedStyle(element);
+
+        measure.dataset.rovalraObserverIgnore = 'true';
+        delete measure.dataset.rovalraHideRobux;
+        delete measure.dataset.rovalraRevealRobuxOnHover;
+        delete measure.dataset.rovalraHiddenRobuxLabel;
+        measure.style.removeProperty('--rovalra-hidden-robux-width');
+        measure.style.removeProperty('--rovalra-visible-robux-width');
+        Object.assign(measure.style, {
+            position: 'absolute',
+            visibility: 'hidden',
+            display: 'inline-block',
+            width: 'auto',
+            minWidth: '0',
+            maxWidth: 'none',
+            whiteSpace: 'nowrap',
+            font: computedStyle.font,
+            letterSpacing: computedStyle.letterSpacing,
+        });
+        document.body.appendChild(measure);
+        const width = Math.ceil(measure.getBoundingClientRect().width);
+        measure.remove();
+
+        return width;
+    }
+
+    function setRobuxMaskWidths(element, hiddenRobuxText) {
+        const hiddenWidth = measureRobuxWidth(element, hiddenRobuxText);
+        const fullWidth = measureFullRobuxWidth(element);
+
+        element.style.setProperty(
+            '--rovalra-hidden-robux-width',
+            `${hiddenWidth}px`,
+        );
+        element.style.setProperty(
+            '--rovalra-visible-robux-width',
+            `${Math.max(hiddenWidth, fullWidth)}px`,
+        );
+    }
+
+    function updateRobuxMask(element) {
+        if (!isHideRobuxEnabled) {
+            delete element.dataset.rovalraHideRobux;
+            delete element.dataset.rovalraRevealRobuxOnHover;
+            delete element.dataset.rovalraHiddenRobuxLabel;
+            element.style.removeProperty('--rovalra-hidden-robux-width');
+            element.style.removeProperty('--rovalra-visible-robux-width');
+            return;
         }
+
+        const hiddenRobuxText = ts('streamerMode.hiddenRobux', {
+            defaultValue: 'Hidden',
+        });
+
+        setRobuxMaskWidths(element, hiddenRobuxText);
+
+        element.dataset.rovalraHideRobux = 'true';
+        element.dataset.rovalraRevealRobuxOnHover = String(
+            isShowRobuxOnHoverEnabled,
+        );
+        element.dataset.rovalraHiddenRobuxLabel = hiddenRobuxText;
     }
 
     function applyStreamerModeToSettingsField(element) {
@@ -55,48 +146,49 @@ export function init() {
             });
     }
 
-    function updateStreamerMode() {
-        chrome.storage.local.get(
-            ['streamermode', 'settingsPageInfo', 'hideRobux'],
-            (data) => {
-                try {
-                    if (data.streamermode) {
-                        sessionStorage.setItem('rovalra_streamermode', 'true');
-                        sessionStorage.setItem(
-                            'rovalra_settingsPageInfo',
-                            data.settingsPageInfo !== false ? 'true' : 'false',
-                        );
-                        sessionStorage.setItem(
-                            'rovalra_hideRobux',
-                            data.hideRobux === true ? 'true' : 'false',
-                        );
-                    } else {
-                        sessionStorage.removeItem('rovalra_streamermode');
-                    }
-                } catch (e) {}
+    async function updateStreamerMode() {
+        const [streamermode, settingsPageInfo, hideRobux, showRobuxOnHover] =
+            await Promise.all([
+                settings.streamermode,
+                settings.settingsPageInfo,
+                settings.hideRobux,
+                settings.showRobuxOnHover,
+            ]);
 
-                isHideRobuxEnabled =
-                    data.streamermode && data.hideRobux === true;
-                isSettingsPageInfoEnabled =
-                    data.streamermode && data.settingsPageInfo !== false;
-
-                const robuxElements = document.querySelectorAll(
-                    '#nav-robux-amount, #nav-robux-balance',
+        try {
+            if (streamermode) {
+                sessionStorage.setItem('rovalra_streamermode', 'true');
+                sessionStorage.setItem(
+                    'rovalra_settingsPageInfo',
+                    settingsPageInfo !== false ? 'true' : 'false',
                 );
-                robuxElements.forEach(updateRobuxText);
-
-                updateSettingsPage();
-
-                document.dispatchEvent(
-                    new CustomEvent('rovalra-streamer-mode', {
-                        detail: {
-                            enabled: data.streamermode,
-                            settingsPageInfo: data.settingsPageInfo !== false,
-                            hideRobux: data.hideRobux === true,
-                        },
-                    }),
+                sessionStorage.setItem(
+                    'rovalra_hideRobux',
+                    hideRobux === true ? 'true' : 'false',
                 );
-            },
+            } else {
+                sessionStorage.removeItem('rovalra_streamermode');
+            }
+        } catch (e) {}
+
+        isHideRobuxEnabled = streamermode && hideRobux === true;
+        isShowRobuxOnHoverEnabled =
+            isHideRobuxEnabled && showRobuxOnHover === true;
+        isSettingsPageInfoEnabled =
+            streamermode && settingsPageInfo !== false;
+
+        updateAllRobuxMasks();
+
+        updateSettingsPage();
+
+        document.dispatchEvent(
+            new CustomEvent('rovalra-streamer-mode', {
+                detail: {
+                    enabled: streamermode,
+                    settingsPageInfo: settingsPageInfo !== false,
+                    hideRobux: hideRobux === true,
+                },
+            }),
         );
     }
 
@@ -107,16 +199,40 @@ export function init() {
             namespace === 'local' &&
             (changes.streamermode ||
                 changes.settingsPageInfo ||
-                changes.hideRobux)
+                changes.hideRobux ||
+                changes.showRobuxOnHover)
         ) {
             updateStreamerMode();
         }
     });
 
+    document.addEventListener('rovalra:custom-font-updated', () => {
+        if (isHideRobuxEnabled) updateAllRobuxMasks();
+    });
+
+    document.addEventListener(NAVBAR_BALANCE_UPDATED_EVENT, () => {
+        if (isHideRobuxEnabled) updateAllRobuxMasks();
+    });
+
+    document.addEventListener(NAVBAR_FIAT_ESTIMATE_UPDATED_EVENT, () => {
+        if (isHideRobuxEnabled) updateAllRobuxMasks();
+    });
+
+    if (document.fonts) {
+        document.fonts.ready
+            .then(() => {
+                if (isHideRobuxEnabled) updateAllRobuxMasks();
+            })
+            .catch(() => {});
+        document.fonts.addEventListener('loadingdone', () => {
+            if (isHideRobuxEnabled) updateAllRobuxMasks();
+        });
+    }
+
     observeElement(
         '#nav-robux-amount, #nav-robux-balance',
         (element) => {
-            updateRobuxText(element);
+            updateRobuxMask(element);
         },
         { multiple: true },
     );

--- a/src/css/features/sitewide/streamerMode.scss
+++ b/src/css/features/sitewide/streamerMode.scss
@@ -1,0 +1,38 @@
+#nav-robux-amount[data-rovalra-hide-robux='true'],
+#nav-robux-balance[data-rovalra-hide-robux='true'] {
+    position: relative;
+    display: inline-block;
+    width: var(--rovalra-hidden-robux-width, auto);
+    -webkit-text-fill-color: transparent;
+
+    .rovalra-usd-estimate {
+        visibility: hidden;
+    }
+
+    &::after {
+        content: attr(data-rovalra-hidden-robux-label);
+        position: absolute;
+        top: 50%;
+        left: 0;
+        display: inline-flex;
+        align-items: center;
+        color: currentcolor;
+        -webkit-text-fill-color: currentcolor;
+        pointer-events: none;
+        transform: translateY(-50%);
+        white-space: nowrap;
+    }
+
+    &[data-rovalra-reveal-robux-on-hover='true']:hover {
+        width: var(--rovalra-visible-robux-width, auto);
+        -webkit-text-fill-color: currentcolor;
+
+        .rovalra-usd-estimate {
+            visibility: visible;
+        }
+
+        &::after {
+            display: none;
+        }
+    }
+}

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -42,4 +42,5 @@
 @use 'features/sitewide/sidebar_layout.scss';
 @use 'features/sitewide/less_plus.scss';
 @use 'features/sitewide/kids_theme_text.scss';
+@use 'features/sitewide/streamerMode.scss';
 @use 'features/plus/sendRobux.scss';


### PR DESCRIPTION
## Summary

Adds a `Show Robux on Hover` option under `Settings` > `Privacy` > `Streamer Mode`, alongside `Hide Robux`.

When both options are enabled, the navbar displays `Hidden` normally, then reveals the full Robux balance while the user hovers.

## Changes

- Adds a `Show Robux on Hover` option alongside `Hide Robux` in Streamer Mode.
- Keeps the original Robux amount and optional Fiat estimate intact rather than replacing the navbar text.
- Hides both values normally and reveals them together while hovered.
- Migrates all Streamer Mode settings from direct Chrome storage reads to the shared settings API, due to what `CONTRIBUTING.md` specifies.

## Purpose

People who frequently screenshare to public audiences may prefer to keep their Robux balance hidden by default to prevent accidental leaks. Previously, checking the balance required briefly disabling Streamer Mode (or the `Hide Robux` suboption) and enabling it again. This option keeps the balance hidden generally while allowing it to be viewed on hover. This feature makes it ideal for frequent streamers if they're willing to make a convenience tradeoff for a slight risk of leaking.