### PR TITLE
Contributor Credits Improvements

### DIFF
--- a/public/Assets/locales/en.json
+++ b/public/Assets/locales/en.json
@@ -408,7 +408,35 @@
             "contributionCount_other": "Contributed to {{count}} features",
             "backendContributorsNote": "These people helped with non feature related things.",
             "loadingContributors": "Loading...",
-            "failedToLoadContributors": "Failed to load contributors."
+            "failedToLoadContributors": "Failed to load contributors.",
+            "otherContributions": {
+                "badges": {
+                    "translatorAndNate": "Added translator badge and WoozyNate badge",
+                    "nateGilbertFix": "Fix nates badge to be gilbert again"
+                },
+                "caching": {
+                    "hashmap": "Added hashmap to the cache handler"
+                },
+                "sidebar": {
+                    "rblxUpdateFix": "Fixed the sidebar for a Roblox update"
+                },
+                "rbxm": {
+                    "fixDesyncCframe": "Fixed RBXM parser desync and CFRAME format"
+                },
+                "markdown": {
+                    "untrustedMd": "Added limited markdown parser for untrusted users"
+                },
+                "settingsHandler": {
+                    "unifiedApi": "Added unified settings API"
+                },
+                "contributorList": {
+                    "creditsImprovement": "Improved credits in the contributor list",
+                    "nonSettingCredits": "Add credits for features and improvements that don't have their own settings"
+                },
+                "donatorTierPage": {
+                    "newIndicators": "Added new indicators for donator tiers"
+                }
+            }
         },
         "donatorPerks": {
             "title": "Donator Perks!",

--- a/public/Assets/locales/en.json
+++ b/public/Assets/locales/en.json
@@ -436,6 +436,14 @@
                 "donatorTierPage": {
                     "newIndicators": "Added new indicators for donator tiers"
                 }
+            },
+            "ui": {
+                "popup": {
+                    "title": "{{user}}'s Contributions",
+                    "contributor": "Contributor",
+                    "featureName": "Feature",
+                    "featureKey": "(Dev) Feature Key"
+                }
             }
         },
         "donatorPerks": {

--- a/src/content/core/configs/otherContributions.ts
+++ b/src/content/core/configs/otherContributions.ts
@@ -12,49 +12,58 @@ class Contribution {
 
 type ContributionsType = {
     [featureName: string]: {
+        label: string,
         contributors: Contribution[]
     }
 };
 
 export const OTHER_CONTRIBUTIONS: ContributionsType = {
     Badges: {
+        label: "Badges",
         contributors: [
             new Contribution(1564574922, "badges.translatorAndNate", "https://github.com/NotValra/RoValra/pull/48"),  // @BossBoss2021
             new Contribution(650766686, "badges.nateGilbertFix", "https://github.com/NotValra/RoValra/pull/126")  // @auggeeo
         ]
     },
     Caching: {
+        label: "Caching System",
         contributors: [
             new Contribution(1564574922, "caching.hashmap", "https://github.com/NotValra/RoValra/pull/52")  // @BossBoss2021
         ]
     },
     Sidebar: {
+        label: "Roblox Sidebar",
         contributors: [
             new Contribution(48255812, "sidebar.rblxUpdateFix", "https://github.com/NotValra/RoValra/pull/55")  // @aliceeenight
         ]
     },
     RbxmParser: {
+        label: "RoValra .rbxm Parser",
         contributors: [
             new Contribution(48255812, "rbxm.fixDesyncCframe", "https://github.com/NotValra/RoValra/pull/69")  // @aliceeenight
         ]
     },
     Markdown: {
+        label: "Markdown Parser",
         contributors: [
             new Contribution(1564574922, "markdown.untrustedMd", "https://github.com/NotValra/RoValra/pull/75") // @BossBoss2021
         ]
     },
     SettingsHandler: {
+        label: "RoValra Settings Handler",
         contributors: [
             new Contribution(1564574922, "settingsHandler.unifiedApi", "https://github.com/NotValra/RoValra/pull/85") // @BossBoss2021
         ]
     },
     ContributorList: {
+        label: "RoValra Contributor List",
         contributors: [
             new Contribution(546872490, "contributorList.creditsImprovement", "https://github.com/NotValra/RoValra/pull/117"),  // @kanibal_dev
             new Contribution(1564574922, "contributorList.nonSettingCredits")  // @BossBoss2021
         ]
     },
     DonatorTierPage: {
+        label: "RoValra Donator Tier Page",
         contributors: [
             new Contribution(650766686, "donatorTierPage.newIndicators", "https://github.com/NotValra/RoValra/pull/123")  // @auggeeo
         ]

--- a/src/content/core/configs/otherContributions.ts
+++ b/src/content/core/configs/otherContributions.ts
@@ -1,0 +1,62 @@
+class Contribution {
+    userId: string;
+    contributionDescription: string;
+    relevantPR?: string;
+
+    constructor(userId: BigInt | number | string, contributionDescription: string, relevantPR?: string) {
+        this.userId = String(userId);
+        this.contributionDescription = "settings.credits.otherContributions." + contributionDescription;
+        this.relevantPR = relevantPR;
+    }
+}
+
+type ContributionsType = {
+    [featureName: string]: {
+        contributors: Contribution[]
+    }
+};
+
+export const OTHER_CONTRIBUTIONS: ContributionsType = {
+    Badges: {
+        contributors: [
+            new Contribution(1564574922, "badges.translatorAndNate", "https://github.com/NotValra/RoValra/pull/48"),  // @BossBoss2021
+            new Contribution(650766686, "badges.nateGilbertFix", "https://github.com/NotValra/RoValra/pull/126")  // @auggeeo
+        ]
+    },
+    Caching: {
+        contributors: [
+            new Contribution(1564574922, "caching.hashmap", "https://github.com/NotValra/RoValra/pull/52")  // @BossBoss2021
+        ]
+    },
+    Sidebar: {
+        contributors: [
+            new Contribution(48255812, "sidebar.rblxUpdateFix", "https://github.com/NotValra/RoValra/pull/55")  // @aliceeenight
+        ]
+    },
+    RbxmParser: {
+        contributors: [
+            new Contribution(48255812, "rbxm.fixDesyncCframe", "https://github.com/NotValra/RoValra/pull/69")  // @aliceeenight
+        ]
+    },
+    Markdown: {
+        contributors: [
+            new Contribution(1564574922, "markdown.untrustedMd", "https://github.com/NotValra/RoValra/pull/75") // @BossBoss2021
+        ]
+    },
+    SettingsHandler: {
+        contributors: [
+            new Contribution(1564574922, "settingsHandler.unifiedApi", "https://github.com/NotValra/RoValra/pull/85") // @BossBoss2021
+        ]
+    },
+    ContributorList: {
+        contributors: [
+            new Contribution(546872490, "contributorList.creditsImprovement", "https://github.com/NotValra/RoValra/pull/117"),  // @kanibal_dev
+            new Contribution(1564574922, "contributorList.nonSettingCredits")  // @BossBoss2021
+        ]
+    },
+    DonatorTierPage: {
+        contributors: [
+            new Contribution(650766686, "donatorTierPage.newIndicators", "https://github.com/NotValra/RoValra/pull/123")  // @auggeeo
+        ]
+    }
+};

--- a/src/content/core/settings/settingConfig.js
+++ b/src/content/core/settings/settingConfig.js
@@ -2263,6 +2263,7 @@ export const SETTINGS_CONFIG = {
                 default: false,
                 experimental:
                     "This may cause some issues since it tricks Roblox into thinking your private info is something it isn't.",
+                contributors: ['447170745', '48255812'],
                 childSettings: {
                     settingsPageInfo: {
                         label: 'Hide Private Information on the settings page',

--- a/src/content/features/settings/index.js
+++ b/src/content/features/settings/index.js
@@ -32,7 +32,7 @@ import { callRobloxApi, callRobloxApiJson } from '../../core/api.js';
 import { safeHtml } from '../../core/packages/dompurify';
 import DOMPurify from 'dompurify';
 import { BADGE_CONFIG } from '../../core/configs/badges.js';
-import { ts } from '../../core/locale/i18n.js';
+import { t, ts } from '../../core/locale/i18n.js';
 import { CONTRIBUTOR_USER_IDS } from '../../core/configs/userIds.js';
 import { createOverlay } from '../../core/ui/overlay.js';
 import { createInteractiveTimestamp } from '../../core/ui/time/time.js';
@@ -1123,6 +1123,59 @@ function getContributorContributionCounts() {
     return counts;
 }
 
+/**
+ * @returns {Record<string, Array<{key: string, feature: string, contributionDescription?: string, prLink?: string}>>}
+ */
+function getContributions() {
+    /**
+     * @type {Record<string, Array<{key: string, feature: string, contributionDescription?: string, prLink?: string}>>}
+     */
+    const contributions = {};
+    for (const contributor of CONTRIBUTOR_USER_IDS) {
+        contributions[String(contributor)] = [];
+    }
+    for (const category of Object.values(SETTINGS_CONFIG)) {
+        for (const [settingName, settingData] of Object.entries(category.settings)) {
+            if (settingData.contributors !== undefined) {
+                for (const contributor of settingData.contributors) {
+                    if (contributions[String(contributor)] === undefined)
+                        contributions[String(contributor)] = [];
+                    contributions[String(contributor)].push({
+                        feature: settingData.label,
+                        key: settingName
+                    });
+                }
+            }
+            if (settingData.childSettings) {
+                for (const [subSettingName, subSettingData] of Object.entries(settingData.childSettings)) {
+                    if (subSettingData.contributors !== undefined) {
+                        for (const contributor of subSettingData.contributors) {
+                            if (contributions[String(contributor)] === undefined)
+                                contributions[String(contributor)] = [];
+                            contributions[String(contributor)].push({
+                                feature: subSettingData.label,
+                                key: subSettingName
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    }
+    for (const [contKey, contData] of Object.entries(OTHER_CONTRIBUTIONS)) {
+        for (const contribution of contData.contributors) {
+            contributions[String(contribution.userId)].push({
+                feature: contData.label,
+                key: contKey,
+                contributionDescription: contribution.contributionDescription,
+                prLink: contribution.relevantPR
+            });
+        }
+    }
+
+    return contributions;
+}
+
 const contributorContributionCounts = getContributorContributionCounts();
 
 function addContributorTooltip(link, id) {
@@ -1245,11 +1298,44 @@ function renderContributors(container, users, thumbMap) {
             count: contributionCount,
         });
 
-        link.append(
-            createContributorProfile(user, thumbMap.get(String(id))),
-            count,
-        );
+        count.addEventListener("click", async (ev) => {
+            const contributions = getContributions()[String(id)];
+            
+            let markdown = `
+| ${await t("settings.credits.ui.popup.contributor")} | ${await t("settings.credits.ui.popup.featureName")} | ${await t("settings.credits.ui.popup.featureKey")} |
+|              -                                 |                   -                            |                       -                       |
+`;
+
+            for (const contribution of contributions) {
+                markdown += `| [${user.displayName}](${link.href}) | `;
+                const featureNameText = contribution.contributionDescription ? `${contribution.feature} (${await t(contribution.contributionDescription)})` : contribution.feature;
+                markdown += `${contribution.prLink ? `[${featureNameText}](${contribution.prLink})` : featureNameText} | `;
+                markdown += `${contribution.prLink ? `[${contribution.key}](${contribution.prLink})` : contribution.key} |\n`;
+            }
+
+            const html = parseMarkdown(markdown);
+
+            const bodyContent = document.createElement('div');
+            bodyContent.innerHTML = html;
+
+            const okayBtn = createButton("Okay", 'primary', {
+                onClick: async () => {
+                    overlay.close();
+                }
+            });
+
+            const overlay = createOverlay({
+                title: await t('settings.credits.ui.popup.title', {user: user.displayName}),
+                bodyContent: bodyContent,
+                actions: [okayBtn],
+                showLogo: true,
+                maxWidth: '50%'
+            });
+        })
+
+        link.appendChild(createContributorProfile(user, thumbMap.get(String(id))));
         item.appendChild(link);
+        item.appendChild(count,);
         listContainer.appendChild(item);
     });
 

--- a/src/content/features/settings/index.js
+++ b/src/content/features/settings/index.js
@@ -74,6 +74,7 @@ import {
 import { showConfirmationPrompt } from '../../core/ui/confirmationPrompt.js';
 import { createSpinner } from '../../core/ui/spinner.js';
 import { createButton } from '../../core/ui/buttons.js';
+import { OTHER_CONTRIBUTIONS } from '../../core/configs/otherContributions.js';
 
 const assets = getAssets();
 let REGIONS = {};
@@ -1110,6 +1111,14 @@ function getContributorContributionCounts() {
     Object.values(SETTINGS_CONFIG).forEach((category) => {
         Object.values(category.settings || {}).forEach(countSetting);
     });
+
+    Object.values(OTHER_CONTRIBUTIONS).forEach((category) => {
+        const contributors = category.contributors;
+        for (const contributor of contributors) {
+            const id = contributor.userId;
+            if (counts.has(id)) counts.set(id, counts.get(id) + 1);
+        }
+    })
 
     return counts;
 }

--- a/src/css/features/settings/settings.scss
+++ b/src/css/features/settings/settings.scss
@@ -230,14 +230,18 @@ body.rovalra-settings-page {
 
     .rovalra-contributors-item {
         padding-left: 4px;
-    }
-
-    .rovalra-contributor-row {
         display: flex;
         align-items: center;
         justify-content: space-between;
-        gap: 12px;
         width: 100%;
+    }
+
+    .rovalra-contributor-row {
+        //display: flex;
+        //align-items: center;
+        //justify-content: space-between;
+        gap: 12px;
+        //width: 100%;
         padding: 8px 12px;
         border-radius: 8px;
         background-color: var(
@@ -263,9 +267,15 @@ body.rovalra-settings-page {
     }
 
     .rovalra-contributor-count {
+        display: inline;
         flex-shrink: 0;
         color: var(--rovalra-secondary-text-color);
         font-size: 13px;
+        transition: color 0.4s ease;
+    }
+    
+    .rovalra-contributor-count:hover {
+        color: rgb(194, 223, 250);
     }
 
     .rovalra-contributor-loading-row {

--- a/src/css/features/settings/settings.scss
+++ b/src/css/features/settings/settings.scss
@@ -272,6 +272,7 @@ body.rovalra-settings-page {
         color: var(--rovalra-secondary-text-color);
         font-size: 13px;
         transition: color 0.4s ease;
+        cursor: pointer;
     }
     
     .rovalra-contributor-count:hover {


### PR DESCRIPTION
## Overview
This PR includes two primary changes:
* The per-contributor feature count now also counts features and improvements that don't have a corresponding setting (ex. the donator tier page, updated by #123)
* By clicking on the feature count of a user, you can now see exactly what features they contributed to (this was suggested in the PR description of #117)

## Notes
I used locales for everything. For a lot of the contributions that this PR now takes into consideration, I also included PR links.

The popup showing a person's contributions is rendered using Markdown.

This was *not* generated automatically. I went through past PRs by hand.

The `streamermode` setting also didn't have its contributors listed, and since that fit the scope of the PR well enough, I added the contributors to the setting myself. The contributors in question are @NotValra (of course), and @aliceenight (#90).