### PR TITLE
add view option for groups on user profile

### DIFF
--- a/src/content/core/settings/settingConfig.js
+++ b/src/content/core/settings/settingConfig.js
@@ -778,8 +778,9 @@ export const SETTINGS_CONFIG = {
             groupFiltersEnabled: {
                 label: 'Community Filters',
                 description: [
-                    'Adds filters to the community section on profiles allowing you to sort by A-Z, Z-A, Newest and Oldest.',
+                    'Adds filters to the community section on profiles allowing you to sort by A-Z, Z-A, Newest and Oldest, also allows you to view groups in a row format or grid format.',
                 ],
+                contributors: ['447170745', '3602693727'],
                 type: 'checkbox',
                 default: true,
             },

--- a/src/content/features/profile/groupFilters.js
+++ b/src/content/features/profile/groupFilters.js
@@ -7,6 +7,17 @@ import { ts } from '../../core/locale/i18n.js';
 
 const joinDateCache = new Map();
 const joinDatePromises = new Map();
+const VIEW_PREFERENCE_KEY = 'rovalra_group_filters_view';
+const DEFAULT_VIEW = 'default';
+
+function getStoredViewPreference() {
+    return chrome.storage.local
+        .get({ [VIEW_PREFERENCE_KEY]: DEFAULT_VIEW })
+        .then((settings) =>
+            settings[VIEW_PREFERENCE_KEY] === 'grid' ? 'grid' : DEFAULT_VIEW,
+        )
+        .catch(() => DEFAULT_VIEW);
+}
 
 export async function getJoinDate(groupId, userId) {
     if (!groupId || !userId) return new Date(0);
@@ -107,7 +118,7 @@ export function init() {
                     );
                 };
 
-                const setup = () => {
+                const setup = async () => {
                     const carousel = getCarousel();
                     if (!carousel || container.dataset.rovalraFiltersAdded)
                         return;
@@ -135,12 +146,15 @@ export function init() {
                     const header = container.querySelector('h2');
                     if (!header) return;
 
+                    const storedView = await getStoredViewPreference();
+
                     const headerWrapper = document.createElement('div');
                     headerWrapper.style.display = 'flex';
                     headerWrapper.style.alignItems = 'center';
                     headerWrapper.style.justifyContent = 'space-between';
                     headerWrapper.style.width = '100%';
                     headerWrapper.style.marginBottom = '12px';
+                    headerWrapper.style.gap = '12px';
 
                     header.parentNode.insertBefore(headerWrapper, header);
                     headerWrapper.appendChild(header);
@@ -148,38 +162,48 @@ export function init() {
                     const originalOrder = [...items];
 
                     // view options
-                    let currentView = 'default';
+                    let currentView = storedView;
                     const viewOptions = [
-                        { text: 'Row', value: 'default' },
+                        { text: 'Row', value: DEFAULT_VIEW },
                         { text: 'Grid', value: 'grid' },
                     ];
 
+                    const applyView = (value, activeCarousel = getCarousel()) => {
+                        if (!activeCarousel) return;
+
+                        currentView = value === 'grid' ? 'grid' : DEFAULT_VIEW;
+                        const rowButtons =
+                            activeCarousel.parentElement?.querySelector(
+                                '.scroll-arrow.next',
+                            );
+
+                        if (currentView === DEFAULT_VIEW) {
+                            activeCarousel.style.display = 'flex';
+                            activeCarousel.style.flexWrap = 'nowrap';
+                            activeCarousel.style.gridTemplateColumns = '';
+
+                            if (rowButtons) rowButtons.style.display = '';
+                        } else {
+                            activeCarousel.style.display = 'grid';
+                            activeCarousel.style.gridTemplateColumns =
+                                'repeat(6, 1fr)';
+                            activeCarousel.style.flexWrap = '';
+
+                            if (rowButtons) rowButtons.style.display = 'none';
+                        }
+                    };
+
                     const viewToggle = createPillToggle({
                         options: viewOptions,
-                        initialValue: 'default',
-                        onChange: async (value) => {
-                            const activeCarousel = getCarousel();
-                            const rowButtons = activeCarousel?.parentElement?.querySelector('.scroll-arrow.next',);
-                            if (!activeCarousel) return;
-
-                            currentView = value;
-
-                            if (currentView === 'default') {
-                                activeCarousel.style.display = 'flex';
-                                activeCarousel.style.flexWrap = 'nowrap';
-                                activeCarousel.style.gridTemplateColumns = '';
-
-                                if (rowButtons) rowButtons.style.display = '';
-                            } else {
-                                activeCarousel.style.display = 'grid';
-                                activeCarousel.style.gridTemplateColumns = 'repeat(6, 1fr)'; // 6 items per row, Roblox's default
-                                activeCarousel.style.flexWrap = '';
-
-                                if (rowButtons) rowButtons.style.display = 'none';
-                            }
+                        initialValue: storedView,
+                        onChange: (value) => {
+                            applyView(value);
+                            chrome.storage.local
+                                .set({ [VIEW_PREFERENCE_KEY]: value })
+                                .catch(() => {});
                         },
                     });
-                    
+
                     // filters
                     const sortOptions = [
                         {
@@ -317,10 +341,13 @@ export function init() {
                     filterToggles.style.flexDirection = 'row';
                     filterToggles.style.gap = '12px';
 
+                    headerWrapper.appendChild(viewToggle);
+                    filterToggles.style.marginLeft = 'auto';
                     headerWrapper.appendChild(filterToggles);
 
-                    filterToggles.appendChild(viewToggle);
                     filterToggles.appendChild(toggle);
+
+                    applyView(storedView);
                 };
 
                 setup();

--- a/src/content/features/profile/groupFilters.js
+++ b/src/content/features/profile/groupFilters.js
@@ -147,6 +147,40 @@ export function init() {
 
                     const originalOrder = [...items];
 
+                    // view options
+                    let currentView = 'default';
+                    const viewOptions = [
+                        { text: 'Row', value: 'default' },
+                        { text: 'Grid', value: 'grid' },
+                    ];
+
+                    const viewToggle = createPillToggle({
+                        options: viewOptions,
+                        initialValue: 'default',
+                        onChange: async (value) => {
+                            const activeCarousel = getCarousel();
+                            const rowButtons = activeCarousel?.parentElement?.querySelector('.scroll-arrow.next',);
+                            if (!activeCarousel) return;
+
+                            currentView = value;
+
+                            if (currentView === 'default') {
+                                activeCarousel.style.display = 'flex';
+                                activeCarousel.style.flexWrap = 'nowrap';
+                                activeCarousel.style.gridTemplateColumns = '';
+
+                                if (rowButtons) rowButtons.style.display = '';
+                            } else {
+                                activeCarousel.style.display = 'grid';
+                                activeCarousel.style.gridTemplateColumns = 'repeat(6, 1fr)'; // 6 items per row, Roblox's default
+                                activeCarousel.style.flexWrap = '';
+
+                                if (rowButtons) rowButtons.style.display = 'none';
+                            }
+                        },
+                    });
+                    
+                    // filters
                     const sortOptions = [
                         {
                             text: ts('groupFilters.sort.default'),
@@ -171,6 +205,7 @@ export function init() {
                         initialValue: 'default',
                         onChange: async (value) => {
                             const activeCarousel = getCarousel();
+                            const rowButtons = document.querySelector('.scroll-arrow.next');
                             if (!activeCarousel) return;
 
                             const currentItems = Array.from(
@@ -256,8 +291,19 @@ export function init() {
                                 }
                             });
 
-                            activeCarousel.style.display = 'flex';
-                            activeCarousel.style.flexWrap = 'nowrap';
+                            if (currentView === 'default') {
+                                activeCarousel.style.display = 'flex';
+                                activeCarousel.style.flexWrap = 'nowrap';
+                                activeCarousel.style.gridTemplateColumns = '';
+
+                                if (rowButtons) rowButtons.style.display = 'block';
+                            } else {
+                                activeCarousel.style.display = 'grid';
+                                activeCarousel.style.gridTemplateColumns = 'repeat(6, 1fr)'; // 6 items per row, Roblox's default
+                                activeCarousel.style.flexWrap = '';
+
+                                if (rowButtons) rowButtons.style.display = 'none';
+                            }
 
                             currentItems.forEach((item) =>
                                 activeCarousel.appendChild(item),
@@ -265,7 +311,16 @@ export function init() {
                         },
                     });
 
-                    headerWrapper.appendChild(toggle);
+                    const filterToggles = document.createElement('div');
+                    filterToggles.style.display = 'flex';
+                    filterToggles.style.alignItems = 'center';
+                    filterToggles.style.flexDirection = 'row';
+                    filterToggles.style.gap = '12px';
+
+                    headerWrapper.appendChild(filterToggles);
+
+                    filterToggles.appendChild(viewToggle);
+                    filterToggles.appendChild(toggle);
                 };
 
                 setup();


### PR DESCRIPTION
basically allows you to view groups a user is is with roblox's default row view, or a grid view. having the grid view option is useful if you are looking through all of the groups a user is in without needing to click the buttons to view all of them.
 
## examples:
### row view:
<img width="852" height="306" alt="image" src="https://github.com/user-attachments/assets/644f4bb6-be1a-4899-961b-6e5638353cf2" />

### grid view:
<img width="831" height="557" alt="image" src="https://github.com/user-attachments/assets/ca07d55a-2f3c-42d7-9522-719a7538fbc7" />