### PR TITLE
feat: friend relationship changed notifications

### DIFF
--- a/public/Assets/locales/en.json
+++ b/public/Assets/locales/en.json
@@ -2,6 +2,13 @@
     "freeRobloxPlusThemes": {
         "notice": "Select and use any theme without Roblox Plus."
     },
+    "friendRelationshipNotifier": {
+        "userFallback": "User {{id}}",
+        "friendAdded": "You are now friends with {{user}}.",
+        "friendRemoved": "You are no longer friends with {{user}}.",
+        "dismiss": "Dismiss",
+        "viewProfile": "View Profile"
+    },
     "items": {
         "hiddenFromMarketplace": "This item is hidden from the marketplace"
     },

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -1,4 +1,13 @@
 import { SETTINGS_CONFIG } from '../content/core/settings/settingConfig.js';
+import {
+    FRIEND_LIST_KEY,
+    FRIEND_UPDATES_KEY,
+    FRIEND_UPDATE_INTERVAL,
+    normalizeFriendLists,
+    normalizeUpdates,
+    normalizeUserId,
+    normalizeUserIds,
+} from '../content/features/sitewide/friendRelationshipNotifier/contract.js';
 import init from './settingsCompat.ts';
 
 // --- Constants & State ---
@@ -22,6 +31,184 @@ const state = {
     badgeFullScanInterval: null,
     avatarInventoryInterval: null,
 };
+
+const friendUpdates = {
+    queue: Promise.resolve(),
+    sequence: 0,
+    lastPoll: 0,
+    polling: false,
+    userId: null,
+};
+
+function createFriendUpdate(userId, change) {
+    friendUpdates.sequence += 1;
+    return {
+        id: `${Date.now()}-${friendUpdates.sequence}`,
+        userId,
+        change,
+    };
+}
+
+function queueFriendUpdate(operation) {
+    // Keep storage writes ordered when more than one tab polls at once.
+    const task = friendUpdates.queue.then(operation, operation);
+    friendUpdates.queue = task.catch(() => {});
+    return task;
+}
+
+async function saveFriendUpdates(userId, friendIds) {
+    const storage = await chrome.storage.local.get([
+        'friendRelationshipNotifierEnabled',
+        FRIEND_LIST_KEY,
+        FRIEND_UPDATES_KEY,
+    ]);
+    if (storage.friendRelationshipNotifierEnabled !== true) {
+        return { status: 'disabled' };
+    }
+
+    const snapshots = normalizeFriendLists(storage[FRIEND_LIST_KEY]);
+    const pending = normalizeUpdates(storage[FRIEND_UPDATES_KEY]);
+    if (!Object.hasOwn(snapshots, userId)) {
+        snapshots[userId] = friendIds;
+        await chrome.storage.local.set({
+            [FRIEND_LIST_KEY]: snapshots,
+            [FRIEND_UPDATES_KEY]: pending,
+        });
+        return { status: 'baseline', pending: pending[userId] ?? [] };
+    }
+
+    const previousIds = normalizeUserIds(snapshots[userId]);
+    const previousSet = new Set(previousIds);
+    const currentSet = new Set(friendIds);
+    const added = friendIds.filter((id) => !previousSet.has(id));
+    const removed = previousIds.filter((id) => !currentSet.has(id));
+    const updates = [
+        ...added.map((id) => createFriendUpdate(id, 'added')),
+        ...removed.map((id) => createFriendUpdate(id, 'removed')),
+    ];
+
+    snapshots[userId] = friendIds;
+    if (updates.length)
+        pending[userId] = [...(pending[userId] ?? []), ...updates];
+    await chrome.storage.local.set({
+        [FRIEND_LIST_KEY]: snapshots,
+        [FRIEND_UPDATES_KEY]: pending,
+    });
+    return {
+        status: updates.length ? 'changed' : 'unchanged',
+        pending: pending[userId] ?? [],
+    };
+}
+
+async function friendUpdatesEnabled() {
+    const storage = await chrome.storage.local.get({
+        friendRelationshipNotifierEnabled: false,
+    });
+    return storage.friendRelationshipNotifierEnabled === true;
+}
+
+async function fetchFriendUpdateUserId() {
+    const response = await callRobloxApiBackground({
+        subdomain: 'users',
+        endpoint: '/v1/users/authenticated',
+        credentials: 'include',
+        noCache: true,
+    });
+    if (response.status === 401 || response.status === 403) {
+        return null;
+    }
+    if (!response.ok) {
+        throw new Error('Could not fetch the authenticated user');
+    }
+
+    return normalizeUserId((await response.json())?.id);
+}
+
+async function fetchFriendIds(userId) {
+    const response = await callRobloxApiBackground({
+        subdomain: 'friends',
+        endpoint: `/v1/users/${userId}/friends`,
+        credentials: 'include',
+        noCache: true,
+    });
+    if (!response.ok) throw new Error('Could not fetch the friend list');
+
+    const data = await response.json();
+    if (!Array.isArray(data?.data)) {
+        throw new Error('Friend relationship response was malformed');
+    }
+    return normalizeUserIds(data.data.map((friend) => friend?.id));
+}
+
+async function pollFriendUpdates() {
+    const now = Date.now();
+    if (friendUpdates.polling) return { status: 'busy' };
+    if (now - friendUpdates.lastPoll < FRIEND_UPDATE_INTERVAL) {
+        // Recheck the account before returning cached notifications.
+        const userId = await fetchFriendUpdateUserId();
+        friendUpdates.userId = userId;
+        return userId
+            ? { status: 'throttled', userId }
+            : { status: 'signedOut' };
+    }
+
+    friendUpdates.lastPoll = now;
+    friendUpdates.polling = true;
+    try {
+        if (!(await friendUpdatesEnabled())) {
+            return { status: 'disabled' };
+        }
+
+        const userId = await fetchFriendUpdateUserId();
+        if (!userId) return { status: 'signedOut' };
+        friendUpdates.userId = userId;
+        const friendIds = await fetchFriendIds(userId);
+        const result = await queueFriendUpdate(() =>
+            saveFriendUpdates(userId, friendIds),
+        );
+        return { ...result, userId };
+    } finally {
+        friendUpdates.polling = false;
+    }
+}
+
+async function dismissFriendUpdate(userId, notificationId) {
+    const storage = await chrome.storage.local.get(FRIEND_UPDATES_KEY);
+
+    const pending = normalizeUpdates(storage[FRIEND_UPDATES_KEY]);
+    const notifications = pending[userId] ?? [];
+    pending[userId] = notifications.filter(
+        (notification) => notification.id !== notificationId,
+    );
+    await chrome.storage.local.set({
+        [FRIEND_UPDATES_KEY]: pending,
+    });
+    return { status: 'ok', pending: pending[userId] };
+}
+
+function isRobloxTabSender(sender) {
+    try {
+        return new URL(sender.tab?.url || sender.url).hostname.endsWith(
+            '.roblox.com',
+        );
+    } catch {
+        return false;
+    }
+}
+
+chrome.storage.onChanged.addListener((changes, areaName) => {
+    if (areaName !== 'local' || !changes.friendRelationshipNotifierEnabled) {
+        return;
+    }
+
+    friendUpdates.lastPoll = 0;
+    friendUpdates.userId = null;
+    if (changes.friendRelationshipNotifierEnabled.newValue !== true) {
+        queueFriendUpdate(() =>
+            chrome.storage.local.remove([FRIEND_LIST_KEY, FRIEND_UPDATES_KEY]),
+        );
+    }
+});
 
 // --- Session Storage Configuration ---
 if (chrome.storage.session && chrome.storage.session.setAccessLevel) {
@@ -345,9 +532,9 @@ const contextMenuClickListener = async (info, tab) => {
             chrome.tabs.sendMessage(tab.id, {
                 action: 'view-ids',
                 data: {
-                    targetId: id
-                }
-            })
+                    targetId: id,
+                },
+            });
         }
     } else if (info.menuItemId.startsWith('rovalra-copy-') && tab?.id) {
         const textToCopy = info.menuItemId.replace('rovalra-copy-', '');
@@ -399,6 +586,8 @@ async function callRobloxApiBackground(options) {
         body = null,
         headers = {},
         fullUrl = null,
+        credentials,
+        noCache = false,
     } = options;
 
     let url;
@@ -418,7 +607,12 @@ async function callRobloxApiBackground(options) {
         url += `${separator}_RoValraRequest=`;
     }
 
-    const fetchOptions = { method, headers: { ...headers } };
+    const fetchOptions = {
+        method,
+        headers: { ...headers },
+        credentials,
+        cache: noCache ? 'no-store' : 'default',
+    };
 
     if (body) {
         if (typeof body === 'object') {
@@ -2072,6 +2266,38 @@ chrome.permissions.onRemoved.addListener((permissions) => {
 
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     switch (request.action) {
+        case 'pollFriendRelationshipNotifier': {
+            if (!isRobloxTabSender(sender)) {
+                sendResponse({ status: 'stale' });
+                return false;
+            }
+
+            pollFriendUpdates()
+                .then(sendResponse)
+                .catch((error) => {
+                    console.warn(
+                        'RoValra: Friend relationship polling failed',
+                        error,
+                    );
+                    sendResponse({ status: 'failed' });
+                });
+            return true;
+        }
+
+        case 'dismissFriendRelationshipNotifierNotification': {
+            const userId = normalizeUserId(request.userId);
+            const notificationId = String(request.notificationId ?? '');
+            if (!userId || !notificationId || !isRobloxTabSender(sender)) {
+                sendResponse({ status: 'stale' });
+                return false;
+            }
+
+            queueFriendUpdate(() => dismissFriendUpdate(userId, notificationId))
+                .then(sendResponse)
+                .catch(() => sendResponse({ status: 'failed' }));
+            return true;
+        }
+
         case 'fetchJson':
             fetch(request.url)
                 .then((res) => {
@@ -2336,7 +2562,9 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
                                 ) {
                                     request.ids.forEach((item) => {
                                         if (item.type === 'Universe') {
-                                            if (settings.copyUniverseIdEnabled) {
+                                            if (
+                                                settings.copyUniverseIdEnabled
+                                            ) {
                                                 chrome.contextMenus.create({
                                                     id: `rovalra-copy-universe-${item.id}`,
                                                     title: item.title,
@@ -2378,8 +2606,9 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
                                         ],
                                     });
                                 }
-                        });
-                    })
+                            },
+                        );
+                    });
                 }
             }
             return false;

--- a/src/content/core/api.js
+++ b/src/content/core/api.js
@@ -490,21 +490,23 @@ export async function callRobloxApi(options) {
 
         if (useBackground) {
             return new Promise((resolve) => {
+                const backgroundOptions = {
+                    endpoint,
+                    subdomain,
+                    fullUrl: customFullUrl,
+                    method,
+                    body,
+                    headers: Object.fromEntries(normalizedHeaders.entries()),
+                    noCache,
+                    responseType,
+                };
+                if (options.credentials !== undefined) {
+                    backgroundOptions.credentials = options.credentials;
+                }
                 chrome.runtime.sendMessage(
                     {
                         action: 'fetchRobloxApi',
-                        options: {
-                            endpoint,
-                            subdomain,
-                            fullUrl: customFullUrl,
-                            method,
-                            body,
-                            headers: Object.fromEntries(
-                                normalizedHeaders.entries(),
-                            ),
-                            noCache,
-                            responseType,
-                        },
+                        options: backgroundOptions,
                     },
                     (response) => {
                         if (chrome.runtime.lastError || !response) {

--- a/src/content/core/settings/settingConfig.js
+++ b/src/content/core/settings/settingConfig.js
@@ -2005,6 +2005,19 @@ export const SETTINGS_CONFIG = {
     Miscellaneous: {
         title: 'Miscellaneous',
         settings: {
+            friendRelationshipNotifierEnabled: {
+                label: 'Friend Relationship Notifier',
+                description: [
+                    'Shows an on-site alert when your Roblox friend list changes.',
+                ],
+                type: 'checkbox',
+                default: false,
+                storageKey: [
+                    'rovalra_friend_relationship_ids_v1',
+                    'rovalra_friend_relationship_notifications_v1',
+                ],
+                contributors: ['196966673'],
+            },
             CustomThemeBackgroundEnabled: {
                 label: 'Customizable Background Image',
                 description:

--- a/src/content/features/sitewide/friendRelationshipNotifier.js
+++ b/src/content/features/sitewide/friendRelationshipNotifier.js
@@ -88,9 +88,6 @@ function showNotifications(userId, notifications, dismissLabel, profileLabel) {
         profileLink.target = '_blank';
         profileLink.rel = 'noopener noreferrer';
         profileLink.textContent = profileLabel;
-        profileLink.addEventListener('click', () =>
-            dismissNotification(userId, notification.id),
-        );
 
         actions.append(dismissButton, profileLink);
         card.append(message, actions);

--- a/src/content/features/sitewide/friendRelationshipNotifier.js
+++ b/src/content/features/sitewide/friendRelationshipNotifier.js
@@ -1,0 +1,273 @@
+import { callRobloxApiJson } from '../../core/api.js';
+import { t } from '../../core/locale/i18n.js';
+import { settings } from '../../core/settings/getSettings.js';
+import {
+    FRIEND_UPDATES_KEY,
+    FRIEND_UPDATE_INTERVAL,
+    normalizeUpdate,
+    normalizeUpdates,
+    normalizeUserId,
+} from './friendRelationshipNotifier/contract.js';
+
+const RETRY_DELAY = 500;
+const userLabels = new Map();
+const state = {
+    enabled: false,
+    userId: null,
+    pollTimer: null,
+    retryTimer: null,
+    version: 0,
+};
+
+let initialized = false;
+let renderVersion = 0;
+let notificationRoot = null;
+
+function sendMessage(message) {
+    return new Promise((resolve) => {
+        try {
+            chrome.runtime.sendMessage(message, (response) => {
+                resolve(
+                    chrome.runtime.lastError
+                        ? { status: 'failed' }
+                        : (response ?? { status: 'failed' }),
+                );
+            });
+        } catch {
+            resolve({ status: 'failed' });
+        }
+    });
+}
+
+function isActive(userId, version) {
+    return (
+        state.enabled && state.userId === userId && state.version === version
+    );
+}
+
+function clearNotifications() {
+    renderVersion += 1;
+    notificationRoot?.remove();
+    notificationRoot = null;
+}
+
+function getNotificationRoot() {
+    if (notificationRoot?.isConnected) return notificationRoot;
+
+    notificationRoot = document.createElement('section');
+    notificationRoot.className = 'rovalra-friend-relationship-notifications';
+    notificationRoot.setAttribute('aria-live', 'polite');
+    document.body.append(notificationRoot);
+    return notificationRoot;
+}
+
+function showNotifications(userId, notifications, dismissLabel, profileLabel) {
+    const root = getNotificationRoot();
+    root.replaceChildren();
+
+    for (const notification of notifications) {
+        const card = document.createElement('article');
+        card.className = `rovalra-friend-relationship-notification rovalra-friend-relationship-notification-${notification.change}`;
+
+        const message = document.createElement('p');
+        message.className = 'rovalra-friend-relationship-notification-message';
+        message.textContent = notification.message;
+
+        const actions = document.createElement('div');
+        actions.className = 'rovalra-friend-relationship-notification-actions';
+
+        const dismissButton = document.createElement('button');
+        dismissButton.type = 'button';
+        dismissButton.textContent = dismissLabel;
+        dismissButton.addEventListener('click', () =>
+            dismissNotification(userId, notification.id),
+        );
+
+        const profileLink = document.createElement('a');
+        profileLink.href = `https://www.roblox.com/users/${notification.userId}/profile`;
+        profileLink.target = '_blank';
+        profileLink.rel = 'noopener noreferrer';
+        profileLink.textContent = profileLabel;
+        profileLink.addEventListener('click', () =>
+            dismissNotification(userId, notification.id),
+        );
+
+        actions.append(dismissButton, profileLink);
+        card.append(message, actions);
+        root.append(card);
+    }
+}
+
+function getUserLabel(userId) {
+    if (userLabels.has(userId)) return userLabels.get(userId);
+
+    const label = callRobloxApiJson({
+        subdomain: 'users',
+        endpoint: `/v1/users/${userId}`,
+        method: 'GET',
+        credentials: 'include',
+        useBackground: true,
+        noCache: true,
+    })
+        .then((user) => {
+            const displayName = String(user?.displayName || '').trim();
+            const username = String(user?.name || '').trim();
+            return displayName && username
+                ? `${displayName} (@${username})`
+                : t('friendRelationshipNotifier.userFallback', { id: userId });
+        })
+        .catch(async (error) => {
+            console.warn('RoValra: Failed to resolve changed friend', error);
+            return t('friendRelationshipNotifier.userFallback', { id: userId });
+        });
+    userLabels.set(userId, label);
+    return label;
+}
+
+async function renderNotifications(userId, updates, version) {
+    const currentRender = ++renderVersion;
+    const notifications = (Array.isArray(updates) ? updates : [])
+        .map(normalizeUpdate)
+        .filter(Boolean);
+
+    if (notifications.length === 0) {
+        if (isActive(userId, version)) clearNotifications();
+        return;
+    }
+
+    const [dismissLabel, profileLabel, messages] = await Promise.all([
+        t('friendRelationshipNotifier.dismiss'),
+        t('friendRelationshipNotifier.viewProfile'),
+        Promise.all(
+            notifications.map(async (notification) => ({
+                ...notification,
+                message: await t(
+                    notification.change === 'added'
+                        ? 'friendRelationshipNotifier.friendAdded'
+                        : 'friendRelationshipNotifier.friendRemoved',
+                    { user: await getUserLabel(notification.userId) },
+                ),
+            })),
+        ),
+    ]);
+
+    // Ignore delayed work from an older page session or render.
+    if (currentRender !== renderVersion || !isActive(userId, version)) return;
+    showNotifications(userId, messages, dismissLabel, profileLabel);
+}
+
+async function getStoredUpdates(userId) {
+    const storage = await chrome.storage.local.get(FRIEND_UPDATES_KEY);
+    return normalizeUpdates(storage[FRIEND_UPDATES_KEY])[userId] ?? [];
+}
+
+function scheduleRetry(version) {
+    if (state.retryTimer) return;
+
+    state.retryTimer = setTimeout(() => {
+        state.retryTimer = null;
+        pollSafely(version);
+    }, RETRY_DELAY);
+}
+
+async function poll(version = state.version) {
+    const response = await sendMessage({
+        action: 'pollFriendRelationshipNotifier',
+    });
+    const userId = normalizeUserId(response?.userId);
+
+    if (!userId || !state.enabled || state.version !== version) {
+        if (response?.status === 'signedOut' && state.version === version) {
+            state.userId = null;
+            clearNotifications();
+        }
+        if (response?.status === 'busy' && state.enabled) {
+            scheduleRetry(version);
+        }
+        return;
+    }
+
+    if (state.userId !== userId) {
+        state.userId = userId;
+        clearNotifications();
+    }
+
+    const updates = Array.isArray(response.pending)
+        ? response.pending
+        : await getStoredUpdates(userId);
+    if (isActive(userId, version)) {
+        await renderNotifications(userId, updates, version);
+    }
+}
+
+function pollSafely(version) {
+    poll(version).catch((error) =>
+        console.warn('RoValra: Friend relationship polling failed', error),
+    );
+}
+
+async function dismissNotification(userId, notificationId) {
+    const version = state.version;
+    if (!isActive(userId, version)) return;
+
+    const response = await sendMessage({
+        action: 'dismissFriendRelationshipNotifierNotification',
+        userId,
+        notificationId,
+    });
+    if (response.status === 'ok' && isActive(userId, version)) {
+        await renderNotifications(userId, response.pending, version);
+    }
+}
+
+function setEnabled(enabled) {
+    state.version += 1;
+    const version = state.version;
+    state.enabled = enabled;
+    clearInterval(state.pollTimer);
+    clearTimeout(state.retryTimer);
+    state.pollTimer = null;
+    state.retryTimer = null;
+
+    if (!enabled) {
+        state.userId = null;
+        clearNotifications();
+        return;
+    }
+
+    pollSafely(version);
+    state.pollTimer = setInterval(
+        () => pollSafely(version),
+        FRIEND_UPDATE_INTERVAL,
+    );
+}
+
+export async function init() {
+    if (initialized) return;
+    initialized = true;
+
+    chrome.storage.onChanged.addListener((changes, areaName) => {
+        if (areaName !== 'local') return;
+
+        if (changes[FRIEND_UPDATES_KEY] && state.enabled && state.userId) {
+            const updates = normalizeUpdates(
+                changes[FRIEND_UPDATES_KEY].newValue,
+            )[state.userId];
+            renderNotifications(state.userId, updates, state.version).catch(
+                (error) =>
+                    console.warn(
+                        'RoValra: Failed to refresh friend notifications',
+                        error,
+                    ),
+            );
+        }
+
+        if (changes.friendRelationshipNotifierEnabled) {
+            setEnabled(
+                changes.friendRelationshipNotifierEnabled.newValue === true,
+            );
+        }
+    });
+
+    setEnabled((await settings.friendRelationshipNotifierEnabled) === true);
+}

--- a/src/content/features/sitewide/friendRelationshipNotifier/contract.js
+++ b/src/content/features/sitewide/friendRelationshipNotifier/contract.js
@@ -1,0 +1,63 @@
+export const FRIEND_LIST_KEY = 'rovalra_friend_relationship_ids_v1';
+export const FRIEND_UPDATES_KEY =
+    'rovalra_friend_relationship_notifications_v1';
+export const FRIEND_UPDATE_INTERVAL = 60_000;
+
+export function normalizeUserId(value) {
+    const userId = String(value ?? '');
+    return /^[1-9]\d*$/.test(userId) ? userId : null;
+}
+
+export function normalizeUserIds(value) {
+    // Friend IDs are only stored as arrays.
+    if (!Array.isArray(value)) return [];
+    return [...new Set(value.map(normalizeUserId).filter(Boolean))];
+}
+
+export function normalizeUpdate(value) {
+    const id = typeof value?.id === 'string' ? value.id : '';
+    const userId = normalizeUserId(value?.userId);
+    const change = value?.change;
+    if (!id || !userId || !['added', 'removed'].includes(change)) return null;
+
+    return { id, userId, change };
+}
+
+export function normalizeUpdates(value) {
+    const pending = {};
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return pending;
+    }
+
+    for (const [userId, notifications] of Object.entries(value)) {
+        const normalizedUserId = normalizeUserId(userId);
+        if (!normalizedUserId || !Array.isArray(notifications)) continue;
+
+        const notificationIds = new Set();
+        pending[normalizedUserId] = notifications.flatMap((notification) => {
+            const normalized = normalizeUpdate(notification);
+            if (!normalized || notificationIds.has(normalized.id)) return [];
+
+            notificationIds.add(normalized.id);
+            return [normalized];
+        });
+    }
+
+    return pending;
+}
+
+export function normalizeFriendLists(value) {
+    const snapshots = {};
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return snapshots;
+    }
+
+    for (const [userId, ids] of Object.entries(value)) {
+        const normalizedUserId = normalizeUserId(userId);
+        if (!normalizedUserId || !Array.isArray(ids)) continue;
+
+        snapshots[normalizedUserId] = normalizeUserIds(ids);
+    }
+
+    return snapshots;
+}

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -48,6 +48,7 @@ import { init as initWideTilePlayerCounts } from './features/sitewide/wideTilePl
 import { init as initPaymentMethodBonusItems } from './features/paymentmethods/bonusItems.js';
 import { init as initBackgroundImage } from './features/sitewide/backgroundImage.js';
 import { init as initFreeRobloxPlusThemes } from './features/sitewide/freeRobloxPlusThemes.js';
+import { init as initFriendRelationshipNotifier } from './features/sitewide/friendRelationshipNotifier.js';
 import { initNotificationCenter as initReceiveRobuxNotificationCenter } from './features/plus/sendRobux.js';
 
 // Avatar
@@ -233,6 +234,7 @@ const featureRoutes = [
             initWideTilePlayerCounts,
             initBackgroundImage,
             initFreeRobloxPlusThemes,
+            initFriendRelationshipNotifier,
             initCustomThemeEditor,
             initReceiveRobuxNotificationCenter,
         ],

--- a/src/css/features/sitewide/friendRelationshipNotifier.scss
+++ b/src/css/features/sitewide/friendRelationshipNotifier.scss
@@ -1,0 +1,65 @@
+.rovalra-friend-relationship-notifications {
+    position: fixed;
+    z-index: 2147483647;
+    top: 16px;
+    right: 16px;
+    display: grid;
+    width: min(360px, calc(100vw - 32px));
+    max-height: calc(100vh - 32px);
+    gap: 10px;
+    overflow-y: auto;
+    pointer-events: none;
+}
+
+.rovalra-friend-relationship-notification {
+    padding: 14px;
+    color: var(--rovalra-main-text-color);
+    background: var(--rovalra-container-background-color);
+    border: 1px solid var(--rovalra-border-color);
+    border-radius: 8px;
+    box-shadow: 0 8px 24px rgb(0 0 0 / 28%);
+    pointer-events: auto;
+}
+
+.rovalra-friend-relationship-notification-added {
+    border-left: 4px solid #43b581;
+}
+
+.rovalra-friend-relationship-notification-removed {
+    border-left: 4px solid #f0ad4e;
+}
+
+.rovalra-friend-relationship-notification-message {
+    margin: 0;
+    font-size: 14px;
+    line-height: 1.4;
+}
+
+.rovalra-friend-relationship-notification-actions {
+    display: flex;
+    gap: 8px;
+    margin-top: 12px;
+}
+
+.rovalra-friend-relationship-notification-actions button,
+.rovalra-friend-relationship-notification-actions a {
+    padding: 6px 10px;
+    color: var(--rovalra-main-text-color);
+    font: inherit;
+    font-size: 13px;
+    line-height: 1.2;
+    text-decoration: none;
+    cursor: pointer;
+    background: var(--rovalra-button-background-color);
+    border: 0;
+    border-radius: 4px;
+}
+
+.rovalra-friend-relationship-notification-actions a {
+    background: #1976d2;
+}
+
+.rovalra-friend-relationship-notification-actions button:hover,
+.rovalra-friend-relationship-notification-actions a:hover {
+    filter: brightness(1.12);
+}

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -33,6 +33,7 @@
 @use 'features/sitewide/backgroundImage.scss';
 @use 'features/home/hideAddFriendsButton.scss';
 @use 'features/sitewide/friendGameLink.scss';
+@use 'features/sitewide/friendRelationshipNotifier.scss';
 @use 'features/sitewide/wideGameTileStats.scss';
 @use 'components/region_filters.scss';
 @use 'features/catalog/depenencies.scss';


### PR DESCRIPTION
## Overview
Adds a friend relationship notifier option under the Miscellaneous settings category. It defaults to off and shows on-site notifications when someone is added to or removed from your Roblox friend list. This feature provides a simpler and more private alternative than friend checker games which many players use.

## Changes
* Added the Friend Relationship Notifier setting, disabled by default
* Polls the authenticated user’s friend list once per minute in the background
  * The first poll stores a baseline and does not create notifications
  * Later polls detect added and removed friends
* Shows persistent on-site notification cards with:
  * A message identifying the changed friend
  * A **View Profile** link
  * A separate **Dismiss** button
* Notifications remain visible after opening a profile and are only removed when dismissed
* Stores pending notifications locally so they can still appear after navigation
* Clears stored notifier data when the feature is disabled
* Added dedicated styling for the on-site notification cards since the existing components I found weren't fully suitable for the behavior I intended to implement