### PR TITLE
chore(profileNotes): move storage to indexedDB

### DIFF
--- a/src/content/core/debug.ts
+++ b/src/content/core/debug.ts
@@ -3,15 +3,12 @@
 let verbose = false;
 
 async function init() {
-    verbose = (await chrome.storage.local.get({verboseDebug: false})).verboseDebug;  // believe me, I would *love* to use the new settings API here, but that deadlocks
+    verbose = (await chrome.storage.local.get({verboseDebug: false})).verboseDebug as boolean;  // believe me, I would *love* to use the new settings API here, but that deadlocks
 }
 
 init();
 
 export function debugVerbose(fmt: string, ...args: any[]) {
-    if (toFlush.length >= 500) {
-        flush();
-    }
     if (verbose) {
         console.debug(fmt, ...args);
     }

--- a/src/content/core/debug.ts
+++ b/src/content/core/debug.ts
@@ -8,22 +8,16 @@ async function init() {
 
 init();
 
-let toFlush: string = "";
-
 export function debugVerbose(fmt: string, ...args: any[]) {
     if (toFlush.length >= 500) {
         flush();
     }
     if (verbose) {
         console.debug(fmt, ...args);
-    } else {
-        toFlush += fmt;
-        toFlush += (args?.length || 0) >= 1 ? ` (${args.length} suppressed Objects)` : ``;
-        toFlush += "\n";
     }
 }
 
-export function flush() {
-    console.debug(toFlush);
-    toFlush = "";
-}
+/**
+ * @deprecated Does nothing.
+ */
+export function flush() {}

--- a/src/content/core/indexeddb/getdb.ts
+++ b/src/content/core/indexeddb/getdb.ts
@@ -2,15 +2,25 @@
 
 import { debugVerbose } from "../debug";
 import { isCallable } from "../utils/js/type";
+import { UUID } from "../utils/js/typing";
+import { getKey, setKey } from "./utils";
 
 
 /* ===================== TYPES ===================== */
 
-export type DatabaseName = string;
+export namespace GetDB {
+    export type DatabaseName = `RoValra:${string}`;
 
-export type RowMeta = {
-    id: unknown
-};
+    export type RowIdentifier = UUID | IDBValidKey | IDBKeyRange;
+    /** @deprecated */
+    export type RowMeta = {
+        id: RowIdentifier
+    };
+
+    export type CreateObjectStoreOptions = {
+        primaryKey: string
+    }
+}
 
 
 /* ===================== INTERNAL VARIABLES ===================== */
@@ -39,7 +49,7 @@ export function _loadDatabase(name: string, version?: number): Promise<IDBDataba
  * Check data about a database.
  * @param {DatabaseName} name The database name 
  */
-export async function CheckIndexedDB(name: DatabaseName): Promise<{ exists: boolean, version: number | undefined }> {
+export async function CheckIndexedDB(name: GetDB.DatabaseName): Promise<{ exists: boolean, version: number | undefined }> {
     const databases = await _indexedDB.databases();
 
     const data = {
@@ -57,14 +67,14 @@ export async function CheckIndexedDB(name: DatabaseName): Promise<{ exists: bool
  * @param {DatabaseName} name The database name 
  * @param {number} version The database's schema version. Increase this when you change its structure 
  */
-export function CreateIndexedDB(name: DatabaseName, version: number, options: {
-    onUpgrade: (request: IDBOpenDBRequest) => void
+export function CreateIndexedDB(name: GetDB.DatabaseName, version: number, options: {
+    onUpgrade: (request: IDBOpenDBRequest, ev: IDBVersionChangeEvent) => void
 }): Promise<true> {
     const request = _indexedDB.open(name, version);
 
-    request.onupgradeneeded = () => {
+    request.onupgradeneeded = (ev: IDBVersionChangeEvent) => {
         if (isCallable(options.onUpgrade)) {
-            options.onUpgrade(request);
+            options.onUpgrade(request, ev);
         }
     };
 
@@ -87,7 +97,7 @@ export function CreateIndexedDB(name: DatabaseName, version: number, options: {
  * @param name The database's name 
  * @returns The database instance
  */
-export async function LoadIndexDB(name: DatabaseName): Promise<IDBDatabase> {
+export async function LoadIndexDB(name: GetDB.DatabaseName): Promise<IDBDatabase> {
     if (!(await CheckIndexedDB(name)).exists) {
         throw new Error(`Failed to load IndexedDB database: ${name}. Please create it with CreateIndexedDB first.`);
     }
@@ -105,7 +115,7 @@ export async function LoadIndexDB(name: DatabaseName): Promise<IDBDatabase> {
  * @param fn An async function taking the database object as the first argument, and returning any data
  * @returns The data returned by the function
  */
-export async function WithIndexDB(name: DatabaseName, fn: (arg0: IDBDatabase) => Promise<any>): Promise<any> {
+export async function WithIndexDB(name: GetDB.DatabaseName, fn: (arg0: IDBDatabase) => Promise<any>): Promise<any> {
     if (!isCallable(fn))
         throw new Error(`WithIndexDB received non-function variable "fn".`);
     const db = await LoadIndexDB(name);
@@ -126,10 +136,10 @@ export async function WithIndexDB(name: DatabaseName, fn: (arg0: IDBDatabase) =>
  * @param {IDBDatabase} db The database object 
  * @param {string} name The object store name (case-insensitive) 
  */
-export function CreateObjectStore(db: IDBDatabase, name: string): IDBObjectStore {
+export function CreateObjectStore(db: IDBDatabase, name: string, options?: GetDB.CreateObjectStoreOptions): IDBObjectStore {
     debugVerbose(`IndexedDB(${db.name}): Creating object store "${name}"`);
     return db.createObjectStore(name.toLowerCase(), {
-        keyPath: "meta.id"
+        keyPath: options?.primaryKey ?? "meta.id"
     });
 }
 
@@ -150,24 +160,32 @@ export function LoadObjectStore(db: IDBDatabase, name: string): ObjectStore {
 class ObjectStore {
     private db: IDBDatabase;
     private name: string;
-    private persistence: IDBTransactionDurability;
+    private config: {
+        persistence: IDBTransactionDurability,
+        primaryKey: string
+    }
 
     constructor (db: IDBDatabase, name: string) {
         this.db = db
         this.name = name;
-        this.persistence = "default";
+        this.config = {
+            persistence: "default",
+            primaryKey: "meta.id"
+        }
     }
 
     /**
-     * Configure the ObjectStore instance
+     * Configure the ObjectStore instance.
      */
     Configure(options: {
-        persistence?: IDBTransactionDurability
+        persistence?: IDBTransactionDurability,
+        primaryKey?: string
     }) {
-        this.persistence = options.persistence ?? this.persistence;
+        this.config.persistence = options.persistence ?? this.config.persistence;
+        this.config.primaryKey = options.primaryKey ?? this.config.primaryKey;
     }
 
-    private getStore(perms: IDBTransactionMode = "readwrite", persistence: IDBTransactionDurability = this.persistence): [IDBObjectStore, IDBTransaction] {
+    private getStore(perms: IDBTransactionMode = "readwrite", persistence: IDBTransactionDurability = this.config.persistence): [IDBObjectStore, IDBTransaction] {
         const tr = this.db.transaction(
             this.name,
             perms,
@@ -181,44 +199,49 @@ class ObjectStore {
 
     /**
      * Insert a row of data, and wait until it's fully inserted.
+     * This will automatically insert a meta.id key (the default primary key) with a UUIDv4 value. If you change the primary key, you will need to provide the primary key yourself.
      * @param data The row of data to insert.
-     * @returns The metadata of the created row, usable to select the row later.
+     * @returns The value of the primary key.
      */
-    async AddData(data: Record<any, unknown>): Promise<RowMeta> {
+    async AddData(data: Record<any, unknown>): Promise<GetDB.RowIdentifier> {
         const targetMeta = {
             id: crypto.randomUUID()
         }
         const [str, tr] = this.getStore('readwrite');
-        const result = str.add({
+        const targetData = {
             ...data,
             meta: targetMeta
-        });
+        }
+        const result = str.add(targetData);
 
         return new Promise((r, f) => {
-            tr.oncomplete = () => r(targetMeta);
+            tr.oncomplete = () => r(getKey<GetDB.RowIdentifier>(targetData, this.config.primaryKey) as GetDB.RowIdentifier);
             tr.onabort = () => f(result.error ?? tr.error ?? new DOMException("Unknown error (?) in RoValra indexeddb:getdb", "AbortError"))
         });
     }
 
     /**
      * Insert a row of data, and return immediately.
+     * This will automatically insert a meta.id key (the default primary key) with a UUIDv4 value. If you change the primary key, you will need to provide the primary key yourself.
      * @param data The row of data to insert.
-     * @returns The metadata of the created row, usable to select the row later.
+     * @returns The value of the primary key.
      */
-    AddDataSync(data: Record<any, unknown>): RowMeta {
+    AddDataSync(data: Record<any, unknown>): GetDB.RowIdentifier {
         const targetMeta = {
             id: crypto.randomUUID()
         }
         const [str, tr] = this.getStore('readwrite', 'strict');
-        str.add({
+        const targetData = {
             ...data,
             meta: targetMeta
-        });
-        return targetMeta;
+        };
+        str.add(targetData);
+        return getKey<GetDB.RowIdentifier>(targetData, this.config.primaryKey) as GetDB.RowIdentifier;
     }
 
     /**
      * Insert a row of data without preprocessing, and wait until it's fully inserted.
+     * This will not insert a primary key. That is up to the caller to do.
      * @param data The row of data to insert.
      */
     async AddDataRaw(data: Record<any, unknown>): Promise<void> {
@@ -236,12 +259,11 @@ class ObjectStore {
      * @param data The new version of the row of data.
      * @param meta The metadata used to select the row (returned by AddData and AddDataSync)
      */
-    MutateRow(data: Record<any, unknown>, meta: RowMeta): Promise<void> {
+    MutateRow(data: Record<any, unknown>, identifier: GetDB.RowIdentifier): Promise<void> {
         const [str, tr] = this.getStore('readwrite');
-        const result = str.put({
-            ...data,
-            meta: meta
-        });
+        let targetData = structuredClone(data);
+        setKey(targetData, this.config.primaryKey, identifier);
+        const result = str.put(targetData);
 
         return new Promise((r, f) => {
             tr.oncomplete = () => r(undefined);
@@ -254,8 +276,8 @@ class ObjectStore {
      * @param meta The metadata used to select the row (returned by AddData and AddDataSync)
      * @returns 
      */
-    ReadRow(meta: RowMeta): Promise<unknown> {
-        const request = this.getStore("readonly")[0].get(meta.id as any);
+    ReadRow(identifier: GetDB.RowIdentifier): Promise<unknown> {
+        const request = this.getStore("readonly")[0].get(identifier);
 
         return new Promise((r, f) => {
             request.onsuccess = () => {
@@ -273,7 +295,7 @@ class ObjectStore {
      * @param count The number of rows to read. 
      * @returns An array of the rows of data returned by the query.
      */
-    ReadStore(count?: number, queryOrOptions?: IDBValidKey | IDBKeyRange | null | undefined): Promise<unknown[]> {
+    ReadStore(count?: number, queryOrOptions?: GetDB.RowIdentifier | null | undefined): Promise<unknown[]> {
         const request = this.getStore("readonly")[0].getAll(queryOrOptions, count);
 
         return new Promise((r, f) => {
@@ -290,13 +312,13 @@ class ObjectStore {
      * @param meta The metadata used to select the row (returned by AddData and AddDataSync)
      * @returns 
      */
-    DeleteRow(meta: RowMeta): Promise<void> {
+    DeleteRow(identifier: GetDB.RowIdentifier): Promise<void> {
         const [str, tr] = this.getStore('readwrite', "strict");
-        const req = str.delete(meta.id);
+        const req = str.delete(identifier);
 
         return new Promise((r, f) => {
             tr.oncomplete = () => r();
-            tr.onabort = () => f(new DOMException(`Failed to delete row (id=${meta.id}).`, "AbortError"));
+            tr.onabort = () => f(new DOMException(`Failed to delete row (id=${identifier}).`, "AbortError"));
         })
     }
 }

--- a/src/content/core/indexeddb/getdb.ts
+++ b/src/content/core/indexeddb/getdb.ts
@@ -1,7 +1,7 @@
 /* ===================== IMPORTS ===================== */
 
 import { debugVerbose } from "../debug";
-import { isCallable } from "../utils/async";
+import { isCallable } from "../utils/js/type";
 
 
 /* ===================== TYPES ===================== */
@@ -9,7 +9,7 @@ import { isCallable } from "../utils/async";
 export type DatabaseName = string;
 
 export type RowMeta = {
-    id: string
+    id: unknown
 };
 
 
@@ -39,11 +39,12 @@ export function _loadDatabase(name: string, version?: number): Promise<IDBDataba
  * Check data about a database.
  * @param {DatabaseName} name The database name 
  */
-export async function CheckIndexedDB(name: DatabaseName): Promise<{ exists: boolean }> {
+export async function CheckIndexedDB(name: DatabaseName): Promise<{ exists: boolean, version: number | undefined }> {
     const databases = await indexedDB.databases();
 
     const data = {
-        exists: databases.some((db) => db.name === name)
+        exists: databases.some((db) => db.name === name),
+        version: databases.find((db) => db.name === name)?.version
     };
 
     debugVerbose(`Obtained data about IndexedDB database: ${name}`, data);
@@ -217,6 +218,20 @@ class ObjectStore {
     }
 
     /**
+     * Insert a row of data without preprocessing, and wait until it's fully inserted.
+     * @param data The row of data to insert.
+     */
+    async AddDataRaw(data: Record<any, unknown>): Promise<void> {
+        const [str, tr] = this.getStore('readwrite');
+        const result = str.add(data);
+
+        return new Promise((r, f) => {
+            tr.oncomplete = () => r(void 0);
+            tr.onabort = () => f(result.error ?? tr.error ?? new DOMException("Unknown error (?) in RoValra indexeddb:getdb", "AbortError"));
+        });
+    }
+
+    /**
      * Mutate/Replace a row of data
      * @param data The new version of the row of data.
      * @param meta The metadata used to select the row (returned by AddData and AddDataSync)
@@ -240,7 +255,7 @@ class ObjectStore {
      * @returns 
      */
     ReadRow(meta: RowMeta): Promise<unknown> {
-        const request = this.getStore("readonly")[0].get(meta.id);
+        const request = this.getStore("readonly")[0].get(meta.id as any);
 
         return new Promise((r, f) => {
             request.onsuccess = () => {

--- a/src/content/core/indexeddb/getdb.ts
+++ b/src/content/core/indexeddb/getdb.ts
@@ -40,7 +40,7 @@ export function _loadDatabase(name: string, version?: number): Promise<IDBDataba
  * @param {DatabaseName} name The database name 
  */
 export async function CheckIndexedDB(name: DatabaseName): Promise<{ exists: boolean, version: number | undefined }> {
-    const databases = await indexedDB.databases();
+    const databases = await _indexedDB.databases();
 
     const data = {
         exists: databases.some((db) => db.name === name),
@@ -226,7 +226,7 @@ class ObjectStore {
         const result = str.add(data);
 
         return new Promise((r, f) => {
-            tr.oncomplete = () => r(void 0);
+            tr.oncomplete = () => r(undefined);
             tr.onabort = () => f(result.error ?? tr.error ?? new DOMException("Unknown error (?) in RoValra indexeddb:getdb", "AbortError"));
         });
     }

--- a/src/content/core/indexeddb/getdb.ts
+++ b/src/content/core/indexeddb/getdb.ts
@@ -1,0 +1,287 @@
+/* ===================== IMPORTS ===================== */
+
+import { debugVerbose } from "../debug";
+import { isCallable } from "../utils/async";
+
+
+/* ===================== TYPES ===================== */
+
+export type DatabaseName = string;
+
+export type RowMeta = {
+    id: string
+};
+
+
+/* ===================== INTERNAL VARIABLES ===================== */
+
+const _indexedDB = typeof window !== "undefined" ? window.indexedDB : globalThis.indexedDB;
+
+export function _loadDatabase(name: string, version?: number): Promise<IDBDatabase> {
+    const request = _indexedDB.open(name, version);
+
+    return new Promise((r, f) => {
+        request.onsuccess = () => {
+            r(request.result);
+        }
+        request.onerror = () => {
+            f(request.error);
+        }
+    })
+}
+
+
+/* ===================== PUBLIC API ===================== */
+
+// ---- Database ----
+
+/**
+ * Check data about a database.
+ * @param {DatabaseName} name The database name 
+ */
+export async function CheckIndexedDB(name: DatabaseName): Promise<{ exists: boolean }> {
+    const databases = await indexedDB.databases();
+
+    const data = {
+        exists: databases.some((db) => db.name === name)
+    };
+
+    debugVerbose(`Obtained data about IndexedDB database: ${name}`, data);
+
+    return data;
+}
+
+/**
+ * Creates an IndexedDB database
+ * @param {DatabaseName} name The database name 
+ * @param {number} version The database's schema version. Increase this when you change its structure 
+ */
+export function CreateIndexedDB(name: DatabaseName, version: number, options: {
+    onUpgrade: (request: IDBOpenDBRequest) => void
+}): Promise<true> {
+    const request = _indexedDB.open(name, version);
+
+    request.onupgradeneeded = () => {
+        if (isCallable(options.onUpgrade)) {
+            options.onUpgrade(request);
+        }
+    };
+
+    return new Promise((r, f) => {
+        request.onsuccess = () => {
+            request.result.close();
+            r(true);
+        };
+        request.onerror = () => {
+            f(request.error);
+        };
+        request.onblocked = (event) => {
+            console.error(`CreateIndexedDB: Upgrade Blocked. Waiting...`, {currentVersion: event.oldVersion, requestedVersion: event.newVersion});
+        };
+    });
+}
+
+/**
+ * Load a database. Prefer WithIndexDB where appropriate for automatic cleanup.
+ * @param name The database's name 
+ * @returns The database instance
+ */
+export async function LoadIndexDB(name: DatabaseName): Promise<IDBDatabase> {
+    if (!(await CheckIndexedDB(name)).exists) {
+        throw new Error(`Failed to load IndexedDB database: ${name}. Please create it with CreateIndexedDB first.`);
+    }
+
+    debugVerbose(`Loading IndexedDB: ${name}`);
+
+    const db = await _loadDatabase(name);
+    db.onversionchange = () => db.close();
+    return db;
+}
+
+/**
+ * Run a function with an instance of a database
+ * @param name The database's name
+ * @param fn An async function taking the database object as the first argument, and returning any data
+ * @returns The data returned by the function
+ */
+export async function WithIndexDB(name: DatabaseName, fn: (arg0: IDBDatabase) => Promise<any>): Promise<any> {
+    if (!isCallable(fn))
+        throw new Error(`WithIndexDB received non-function variable "fn".`);
+    const db = await LoadIndexDB(name);
+    let result;
+    try {
+        result = await fn(db);
+    } catch (e) {
+        db.close();
+        throw e;
+    };
+
+    db.close();
+    return result;
+}
+
+/**
+ * Creates an object store. Only callable within CreateIndexedDB.
+ * @param {IDBDatabase} db The database object 
+ * @param {string} name The object store name (case-insensitive) 
+ */
+export function CreateObjectStore(db: IDBDatabase, name: string): IDBObjectStore {
+    debugVerbose(`IndexedDB(${db.name}): Creating object store "${name}"`);
+    return db.createObjectStore(name.toLowerCase(), {
+        keyPath: "meta.id"
+    });
+}
+
+
+
+// ---- Object Store ----
+
+export function LoadObjectStore(db: IDBDatabase, name: string): ObjectStore {
+    if (!db.objectStoreNames.contains(name.toLowerCase())) {
+        throw new Error(`Object store "${name}" does not exist.`);
+    }
+
+    debugVerbose(`IndexedDB(${db.name}): Loading object store "${name}"`);
+    const o = new ObjectStore(db, name.toLowerCase());
+    return o;
+}
+
+class ObjectStore {
+    private db: IDBDatabase;
+    private name: string;
+    private persistence: IDBTransactionDurability;
+
+    constructor (db: IDBDatabase, name: string) {
+        this.db = db
+        this.name = name;
+        this.persistence = "default";
+    }
+
+    /**
+     * Configure the ObjectStore instance
+     */
+    Configure(options: {
+        persistence?: IDBTransactionDurability
+    }) {
+        this.persistence = options.persistence ?? this.persistence;
+    }
+
+    private getStore(perms: IDBTransactionMode = "readwrite", persistence: IDBTransactionDurability = this.persistence): [IDBObjectStore, IDBTransaction] {
+        const tr = this.db.transaction(
+            this.name,
+            perms,
+            {
+                durability: persistence
+            }
+        );
+        
+        return [tr.objectStore(this.name), tr];
+    }
+
+    /**
+     * Insert a row of data, and wait until it's fully inserted.
+     * @param data The row of data to insert.
+     * @returns The metadata of the created row, usable to select the row later.
+     */
+    async AddData(data: Record<any, unknown>): Promise<RowMeta> {
+        const targetMeta = {
+            id: crypto.randomUUID()
+        }
+        const [str, tr] = this.getStore('readwrite');
+        const result = str.add({
+            ...data,
+            meta: targetMeta
+        });
+
+        return new Promise((r, f) => {
+            tr.oncomplete = () => r(targetMeta);
+            tr.onabort = () => f(result.error ?? tr.error ?? new DOMException("Unknown error (?) in RoValra indexeddb:getdb", "AbortError"))
+        });
+    }
+
+    /**
+     * Insert a row of data, and return immediately.
+     * @param data The row of data to insert.
+     * @returns The metadata of the created row, usable to select the row later.
+     */
+    AddDataSync(data: Record<any, unknown>): RowMeta {
+        const targetMeta = {
+            id: crypto.randomUUID()
+        }
+        const [str, tr] = this.getStore('readwrite', 'strict');
+        str.add({
+            ...data,
+            meta: targetMeta
+        });
+        return targetMeta;
+    }
+
+    /**
+     * Mutate/Replace a row of data
+     * @param data The new version of the row of data.
+     * @param meta The metadata used to select the row (returned by AddData and AddDataSync)
+     */
+    MutateRow(data: Record<any, unknown>, meta: RowMeta): Promise<void> {
+        const [str, tr] = this.getStore('readwrite');
+        const result = str.put({
+            ...data,
+            meta: meta
+        });
+
+        return new Promise((r, f) => {
+            tr.oncomplete = () => r(undefined);
+            tr.onabort = () => f(result.error ?? tr.error ?? new DOMException("Unknown error (?) in RoValra indexeddb:getdb", "AbortError"))
+        })
+    }
+
+    /**
+     * Read a row of data.
+     * @param meta The metadata used to select the row (returned by AddData and AddDataSync)
+     * @returns 
+     */
+    ReadRow(meta: RowMeta): Promise<unknown> {
+        const request = this.getStore("readonly")[0].get(meta.id);
+
+        return new Promise((r, f) => {
+            request.onsuccess = () => {
+                const row = request.result;
+                r(row);
+            }
+            request.onerror = () => {
+                f(request.error);
+            }
+        })
+    }
+
+    /**
+     * Read multiple rows of data.
+     * @param count The number of rows to read. 
+     * @returns An array of the rows of data returned by the query.
+     */
+    ReadStore(count?: number, queryOrOptions?: IDBValidKey | IDBKeyRange | null | undefined): Promise<unknown[]> {
+        const request = this.getStore("readonly")[0].getAll(queryOrOptions, count);
+
+        return new Promise((r, f) => {
+            request.onsuccess = () => {
+                const data = request.result;
+                r(data);
+            }
+            request.onerror = () => f(request.error);
+        })
+    }
+
+    /**
+     * Delete a row of data.
+     * @param meta The metadata used to select the row (returned by AddData and AddDataSync)
+     * @returns 
+     */
+    DeleteRow(meta: RowMeta): Promise<void> {
+        const [str, tr] = this.getStore('readwrite', "strict");
+        const req = str.delete(meta.id);
+
+        return new Promise((r, f) => {
+            tr.oncomplete = () => r();
+            tr.onabort = () => f(new DOMException(`Failed to delete row (id=${meta.id}).`, "AbortError"));
+        })
+    }
+}

--- a/src/content/core/indexeddb/utils.ts
+++ b/src/content/core/indexeddb/utils.ts
@@ -1,0 +1,45 @@
+export const KeyNotFound = Symbol("KeyNotFound");
+
+/**
+ * Get an item from a Record by period-separated key.
+ * Example: "test.abc" will return data['test']['abc']
+ * @param data The data to retrieve a value from
+ * @param key The period-separated key.
+ */
+export function getKey<T = any>(data: Record<string, any>, key: string): Record<string, any> | T {
+    let value: any = data;
+    for (const subString of key.split(".")) {
+        if (typeof value === 'object' && value !== null) {
+            if (Object.keys(value).includes(subString))
+                value = value[subString];
+            else {
+                value = KeyNotFound;
+                return value;
+            }
+        } else {
+            return value;
+        }
+    }
+    return value;
+}
+
+/**
+ * Set an item from a Record by period-separated key.
+ * @param data The data to set a value for
+ * @param key The period-separated key.
+ * @param v The value to set
+ */
+export function setKey(data: Record<string, any>, key: string, v: any) {  // I apologise for this code
+    let value: any = data;
+    const split = key.split(".");
+
+    for (const subString of split.slice(0, split.length - 1)) {
+        let value2 = value[subString];
+        if (typeof value2 !== 'object' || value2 === null)
+            value[subString] = {};
+        
+        value = value2;
+    }
+
+    value[split[split.length - 1]] = v;
+}

--- a/src/content/core/settings/settingConfig.js
+++ b/src/content/core/settings/settingConfig.js
@@ -2755,8 +2755,6 @@ export const SETTINGS_CONFIG = {
                 type: 'checkbox',
                 default: false,
                 contributors: ['1564574922'],
-                experimental:
-                    'This feature is not yet widely used within RoValra.',
             },
         },
     },

--- a/src/content/core/utils/async.ts
+++ b/src/content/core/utils/async.ts
@@ -12,3 +12,13 @@ export async function awaitSafe<T>(fn: (...args: any[]) => Promise<T>, ...args: 
         return undefined;
     }
 }
+
+export function isCallable(fn: unknown): boolean {
+    if (typeof fn === "undefined")
+        return false;
+    if ([undefined, null].includes(fn))
+        return false;
+    if (typeof fn !== 'function')
+        return false;
+    return true;
+}

--- a/src/content/core/utils/js/async.ts
+++ b/src/content/core/utils/js/async.ts
@@ -12,13 +12,3 @@ export async function awaitSafe<T>(fn: (...args: any[]) => Promise<T>, ...args: 
         return undefined;
     }
 }
-
-export function isCallable(fn: unknown): boolean {
-    if (typeof fn === "undefined")
-        return false;
-    if ([undefined, null].includes(fn))
-        return false;
-    if (typeof fn !== 'function')
-        return false;
-    return true;
-}

--- a/src/content/core/utils/js/type.ts
+++ b/src/content/core/utils/js/type.ts
@@ -1,0 +1,9 @@
+export function isCallable(fn: unknown): boolean {
+    if (typeof fn === "undefined")
+        return false;
+    if (fn === null)
+        return false;
+    if (typeof fn !== 'function')
+        return false;
+    return true;
+}

--- a/src/content/core/utils/js/typing.ts
+++ b/src/content/core/utils/js/typing.ts
@@ -1,0 +1,1 @@
+export type UUID = `${string}-${string}-${string}-${string}-${string}`;

--- a/src/content/features/profile/header/profileNotes.ts
+++ b/src/content/features/profile/header/profileNotes.ts
@@ -3,9 +3,13 @@ import { observeElement } from '../../../core/observer.js';
 import { getAuthenticatedUserId } from '../../../core/user.js';
 import { createStyledInput } from '../../../core/ui/catalog/input.js';
 import { ts } from '../../../core/locale/i18n.js';
+import { CreateIndexedDB, CreateObjectStore, LoadObjectStore, WithIndexDB } from '../../../core/indexeddb/getdb.js';
+
+type Notes = Map<bigint, string>;
 
 const PROFILE_NOTES_SETTING_NAME = 'profileNotesEnabled';
-const PROFILE_NOTES_STORAGE_KEY = 'rovalra_profile_notes';
+const PROFILE_NOTES_STORAGE_KEY = 'RoValra:ProfileNotes';
+const IDB_OBJECT_STORE = 'pf-notes';
 const PROFILE_ACTION_BUTTON_SELECTOR =
     '#user-profile-header-contextual-menu-button';
 const MAX_NOTE_LENGTH = 256;
@@ -13,7 +17,7 @@ const MAX_NOTE_ROWS = 2;
 
 let actionButtonObserver = null;
 let activeController = null;
-let activeProfileUserId = null;
+let activeProfileUserId: bigint = 0n;
 let initGeneration = 0;
 let storageListenerStarted = false;
 
@@ -22,38 +26,60 @@ function normalizeNote(value) {
     return value.replace(/\r\n?/g, '\n').trim().slice(0, MAX_NOTE_LENGTH);
 }
 
-function normalizeNotesMap(value) {
-    return value && typeof value === 'object' && !Array.isArray(value)
+function normalizeNotesMap(value: unknown): Notes {
+    return value instanceof Map
         ? value
-        : {};
+        : new Map<bigint, string>();
 }
 
-async function getStoredNotes() {
-    const stored = await chrome.storage.local.get({
-        [PROFILE_NOTES_STORAGE_KEY]: {},
+async function loadNotesFromStorage(): Promise<Notes> {
+    type RawStored = Array<{note: string, meta: {id: string}}>;
+    const rows: RawStored = await WithIndexDB(PROFILE_NOTES_STORAGE_KEY, async (db) => {
+        const objstore = LoadObjectStore(db, IDB_OBJECT_STORE);
+        return await objstore.ReadStore();
     });
-    return normalizeNotesMap(stored[PROFILE_NOTES_STORAGE_KEY]);
+    let map = new Map();
+    for (let i = 0; i < rows.length; i++) {
+        const row = rows[i];
+        map.set(BigInt(row.meta.id), String(row.note ?? ""));
+    }
+    return map;
 }
 
-async function getStoredNote(userId) {
+async function getStoredNotes(): Promise<Notes> {
+    const stored = await loadNotesFromStorage();
+    return normalizeNotesMap(stored);
+}
+
+async function getStoredNote(userId: bigint | string) {
+    userId = BigInt(userId);
     const notes = await getStoredNotes();
-    return normalizeNote(notes[String(userId)]);
+    return normalizeNote(notes.get(userId));
 }
 
-async function saveStoredNote(userId, note) {
-    const notes = { ...(await getStoredNotes()) };
+async function saveStoredNote(userId: bigint | string, note: string) {
     const key = String(userId);
     const normalizedNote = normalizeNote(note);
 
-    if (normalizedNote) {
-        notes[key] = normalizedNote;
-    } else {
-        delete notes[key];
-    }
-
-    await chrome.storage.local.set({
-        [PROFILE_NOTES_STORAGE_KEY]: notes,
+    await WithIndexDB(PROFILE_NOTES_STORAGE_KEY, async (db) => {
+        const objstore = LoadObjectStore(db, IDB_OBJECT_STORE);
+        if (normalizedNote) {
+            if (await objstore.ReadRow({ id: key })) {
+                await objstore.MutateRow({ note: normalizedNote }, { id: key });
+            } else {
+                await objstore.AddDataRaw(
+                    {
+                        note: normalizedNote,
+                        meta: { id: key }
+                    }
+                );
+            }
+        } else {
+            await objstore.DeleteRow({ id: key });
+        }
     });
+
+    onEdit();  // let this run in the background
 
     return normalizedNote;
 }
@@ -326,7 +352,7 @@ async function mountProfileNote(actionButton, userId, generation) {
     const note = await getStoredNote(userId);
     if (
         generation !== initGeneration ||
-        activeProfileUserId !== String(userId) ||
+        activeProfileUserId !== BigInt(userId) ||
         String(getUserIdFromUrl()) !== String(userId) ||
         !host.isConnected
     ) {
@@ -352,7 +378,7 @@ async function initProfileNotes() {
     removeActiveNote();
 
     const userId = Number(getUserIdFromUrl());
-    activeProfileUserId = userId ? String(userId) : null;
+    activeProfileUserId = userId ? BigInt(userId) : 0n;
     if (!userId) return;
 
     const [settings, authenticatedUserId] = await Promise.all([
@@ -375,27 +401,41 @@ async function initProfileNotes() {
     );
 }
 
+async function onEdit() {
+    const notes = await getStoredNotes();
+    activeController?.setNote(notes.get(activeProfileUserId));
+}
+
 function startStorageListener() {
     if (storageListenerStarted) return;
     storageListenerStarted = true;
 
     chrome.storage.onChanged.addListener((changes, areaName) => {
-        if (areaName !== 'local') return;
+        (async () => {
+            if (areaName !== 'local') return;
 
-        if (changes[PROFILE_NOTES_SETTING_NAME]) {
-            initProfileNotes();
-            return;
-        }
-
-        if (!changes[PROFILE_NOTES_STORAGE_KEY] || !activeProfileUserId) return;
-        const notes = normalizeNotesMap(
-            changes[PROFILE_NOTES_STORAGE_KEY].newValue,
-        );
-        activeController?.setNote(notes[activeProfileUserId]);
+            if (changes[PROFILE_NOTES_SETTING_NAME]) {
+                initProfileNotes();
+                return;
+            }
+        })();
     });
 }
 
-export function init() {
+async function initdb() {
+    await CreateIndexedDB(PROFILE_NOTES_STORAGE_KEY, 1, {
+        onUpgrade: (request: IDBOpenDBRequest) => {
+            const db = request.result;
+
+            if (!db.objectStoreNames.contains(IDB_OBJECT_STORE)) {
+                const str = CreateObjectStore(db, IDB_OBJECT_STORE);
+            }
+        }
+    })
+}
+
+export async function init() {
+    await initdb();
     startStorageListener();
     initProfileNotes();
 }

--- a/src/content/features/profile/header/profileNotes.ts
+++ b/src/content/features/profile/header/profileNotes.ts
@@ -10,6 +10,10 @@ type Notes = Map<bigint, string>;
 const PROFILE_NOTES_SETTING_NAME = 'profileNotesEnabled';
 const PROFILE_NOTES_STORAGE_KEY = 'RoValra:ProfileNotes';
 const IDB_OBJECT_STORE = 'pf-notes';
+const OBJSTORE_CONFIG = {
+    persistence: "relaxed" as IDBTransactionDurability ,
+    primaryKey: "uid"
+}
 const PROFILE_ACTION_BUTTON_SELECTOR =
     '#user-profile-header-contextual-menu-button';
 const MAX_NOTE_LENGTH = 256;
@@ -33,7 +37,7 @@ function normalizeNotesMap(value: unknown): Notes {
 }
 
 async function loadNotesFromStorage(): Promise<Notes> {
-    type RawStored = Array<{note: string, meta: {id: string}}>;
+    type RawStored = Array<{note: string, uid: string}>;
     const rows: RawStored = await WithIndexDB(PROFILE_NOTES_STORAGE_KEY, async (db) => {
         const objstore = LoadObjectStore(db, IDB_OBJECT_STORE);
         return await objstore.ReadStore();
@@ -41,7 +45,7 @@ async function loadNotesFromStorage(): Promise<Notes> {
     let map = new Map();
     for (let i = 0; i < rows.length; i++) {
         const row = rows[i];
-        map.set(BigInt(row.meta.id), String(row.note ?? ""));
+        map.set(BigInt(row.uid), String(row.note ?? ""));
     }
     return map;
 }
@@ -63,19 +67,20 @@ async function saveStoredNote(userId: bigint | string, note: string) {
 
     await WithIndexDB(PROFILE_NOTES_STORAGE_KEY, async (db) => {
         const objstore = LoadObjectStore(db, IDB_OBJECT_STORE);
+        objstore.Configure(OBJSTORE_CONFIG);
         if (normalizedNote) {
-            if (await objstore.ReadRow({ id: key })) {
-                await objstore.MutateRow({ note: normalizedNote }, { id: key });
+            if (await objstore.ReadRow(key)) {
+                await objstore.MutateRow({ note: normalizedNote }, key);
             } else {
                 await objstore.AddDataRaw(
                     {
                         note: normalizedNote,
-                        meta: { id: key }
+                        uid: key
                     }
                 );
             }
         } else {
-            await objstore.DeleteRow({ id: key });
+            await objstore.DeleteRow(key);
         }
     });
 
@@ -423,14 +428,8 @@ function startStorageListener() {
 }
 
 async function initdb() {
-    await CreateIndexedDB(PROFILE_NOTES_STORAGE_KEY, 1, {
-        onUpgrade: (request: IDBOpenDBRequest) => {
-            const db = request.result;
-
-            if (!db.objectStoreNames.contains(IDB_OBJECT_STORE)) {
-                const str = CreateObjectStore(db, IDB_OBJECT_STORE);
-            }
-        }
+    await CreateIndexedDB(PROFILE_NOTES_STORAGE_KEY, 2, {
+        onUpgrade: (request: IDBOpenDBRequest, event) => { }
     })
 }
 

--- a/src/content/features/sitewide/viewid.ts
+++ b/src/content/features/sitewide/viewid.ts
@@ -3,7 +3,7 @@ import { getAssetIdFromUrl } from '../../core/idExtractor.js';
 import { t } from '../../core/locale/i18n.js';
 import { createButton } from '../../core/ui/buttons.js';
 import { createOverlay } from '../../core/ui/overlay.js';
-import { awaitSafe, sleep } from '../../core/utils/async.js';
+import { awaitSafe, sleep } from '../../core/utils/js/async';
 import { parseMarkdown } from '../../core/utils/markdown.js';
 
 type RequestType = {

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -2,6 +2,7 @@ import { initializeObserver, startObserving } from './core/observer.js';
 import { getValidAccessToken } from './core/oauth/oauth.js';
 import { startAuthFavoriteCleanupMonitor } from './core/oauth/fallback.js';
 import { t } from './core/locale/i18n.js';
+import { isCallable } from './core/utils/js/type.js';
 // Site wide
 import { init as initOnboarding } from './features/onboarding/onboarding.js';
 import { init as initWhatAmIJoining } from './features/games/revertlogo.js';
@@ -508,6 +509,7 @@ function runFeaturesForPage() {
     const path = window.location.pathname.toLowerCase();
     const normalizedPath = path.replace(/^\/[a-z]{2}(?:-[a-z]{2})?\//, '/');
     const featuresRunThisPass = new Set();
+    const promisesLeft = [];
 
     featureRoutes.forEach((route) => {
         if (
@@ -531,7 +533,9 @@ function runFeaturesForPage() {
                     if (route.once) initializedPersistentFeatures.add(init);
 
                     try {
-                        init();
+                        const r = init();
+                        if (r && typeof r === 'object' && r.then && isCallable(r.then))
+                            promisesLeft.push(r);
                     } catch (error) {
                         console.error('RoValra: Feature init failed', error);
                     }
@@ -539,6 +543,8 @@ function runFeaturesForPage() {
             }
         }
     });
+
+    return promisesLeft;
 }
 
 async function initializePage() {
@@ -584,8 +590,17 @@ async function initializePage() {
         const featureStartTime = performance.now();
 
         await t('__i18n_ready__').catch(() => {});
-        runFeaturesForPage();
+        const promisesLeft = runFeaturesForPage();
         scheduleSettingsMaintenance();
+        const syncEndTime = performance.now();
+
+        const results = await Promise.allSettled(promisesLeft);
+
+        for (const result of results) {
+            if (result.status === 'rejected') {
+                console.error('RoValra: Feature init failed', result.reason);
+            }
+        }
 
         const endTime = performance.now();
 
@@ -593,7 +608,8 @@ async function initializePage() {
             `%cRoValra Initialized`,
             'font-size: 1.5em; color: #FF4500;',
             `\n(Observer: ${observerStatus})` +
-                `\nFeature Load Time: ${(endTime - featureStartTime).toFixed(2)}ms` +
+                `\nSynchronous Feature Load Time: ${(syncEndTime - featureStartTime).toFixed(2)}ms` +
+                `\nTotal Feature Load Time: ${(endTime - featureStartTime).toFixed(2)}ms` +
                 `\nTotal Load Time: ${(endTime - startTime).toFixed(2)}ms`,
         );
     };


### PR DESCRIPTION
## Overview
The PR implements a wrapper over IndexedDB (I could've used Dexie but I didn't know about it when I wrote this, and now I already have an entire wrapper made), and makes profile notes use IndexedDB to store notes.

## Changes
* I added `getdb` which is just a wrapper over IndexedDB (a62afa259240fb991e7bc845ba023fc1bc602a9d)
* I moved profile notes onto IndexedDB (dd28916945beaac6fe1ba64ed87400003bcb7b92)
* Profile notes now use a hashmap to map a userid to a note for performance, and userIDs are kept in variables as `BigInt` rather than strings (dd28916945beaac6fe1ba64ed87400003bcb7b92)
* I changed the profile notes filetype to `.ts` just to use type hints in some places. No major typescript-related changes beyond this (dd28916945beaac6fe1ba64ed87400003bcb7b92)
* `getdb` uses `debugVerbose` heavily, so I modified `debugVerbose` to not print/log anything unless the "Verbose Debugging" setting is active (this was originally intended behaviour, idk why my original pr made debugVerbose print anyways) (dd28916945beaac6fe1ba64ed87400003bcb7b92, 139592dff9fc887cb4e3417b4a88018a4aa1a5e5)
* `index.js` now also counts load time for asynchronous features. I can very easily revert this if you'd want me to (7368a66ea1096d771a8b0f300747e17052366f57)

## Notes
> [!TIP]
> IndexedDB is very useful for large storage, because unlike chrome.storage.local, **it is effectively unlimited**. There is no 10MB cap.