### PR TITLE
Add second friends row option for Home page carousel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rovalra",
-  "version": "2.6.1",
+  "version": "2.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rovalra",
-      "version": "2.6.1",
+      "version": "2.6.4",
       "dependencies": {
         "dompurify": "^3.4.11",
         "fflate": "^0.8.3",

--- a/src/content/core/configs/userIds.js
+++ b/src/content/core/configs/userIds.js
@@ -26,6 +26,7 @@ export const CONTRIBUTOR_USER_IDS = [
     '2333236354', // AandA510
     '170038374', // syra (concept artist)
     '760897332', // ceyexm
+    '2830488781' // idhglua
 ];
 
 export const TESTER_USER_IDS = [

--- a/src/content/core/settings/settingConfig.js
+++ b/src/content/core/settings/settingConfig.js
@@ -1160,6 +1160,15 @@ export const SETTINGS_CONFIG = {
                 type: 'checkbox',
                 default: true,
             },
+            friendsSecondRowEnabled: {
+                label: 'Second Friends Row',
+                description: [
+                    'Shows a second row of friends in the Home page friends carousel instead of only one row.',
+                ],
+                type: 'checkbox',
+                default: false,
+                contributors: ['2830488781'],
+            },
             HideAddFriendsButton: {
                 label: 'Hide Add Friends Button',
                 description: [

--- a/src/content/features/home/friendsSecondRow.js
+++ b/src/content/features/home/friendsSecondRow.js
@@ -1,0 +1,198 @@
+import { observeElement } from '../../core/observer.js';
+import { settings } from '../../core/settings/getSettings.js';
+import { getCachedFriendsList } from '../../core/utils/trackers/friendslist.js';
+import {
+    getBatchThumbnails,
+    createThumbnailElement,
+} from '../../core/thumbnail/thumbnails.js';
+
+const SETTING_NAME = 'friendsSecondRowEnabled';
+const ROW_CLASS = 'rovalra-friends-second-row';
+const EXTRA_TILE_CLASS = 'rovalra-friends-extra-tile';
+const TILE_CLASS = 'friends-carousel-tile';
+const TILE_SELECTOR = `.${TILE_CLASS}`;
+const LIST_CONTAINER_SELECTOR =
+    '#HomeContainer .friends-carousel-list-container';
+const CAROUSEL_CONTAINER_SELECTOR = '.friends-carousel-container';
+const PROFILE_LINK_SELECTOR = 'a[href*="/users/"]';
+
+let observerRegistered = false;
+let storageListenerRegistered = false;
+let enabled = false;
+
+function isHomePage() {
+    const path = window.location.pathname
+        .toLowerCase()
+        .replace(/^\/[a-z]{2}(?:-[a-z]{2})?\//, '/');
+    return path.startsWith('/home');
+}
+
+function getProfileUserId(href) {
+    const match = href?.match(/\/users\/(\d+)\//);
+    return match ? match[1] : null;
+}
+
+function getRenderedFriendIds(listContainer) {
+    const ids = new Set();
+    listContainer
+        .querySelectorAll(
+            `${TILE_SELECTOR}:not(.${EXTRA_TILE_CLASS}) ${PROFILE_LINK_SELECTOR}`,
+        )
+        .forEach((link) => {
+            const id = getProfileUserId(link.getAttribute('href') || '');
+            if (id) ids.add(id);
+        });
+    return ids;
+}
+
+// Extra tiles use a trimmed-down version of Roblox's own friend-tile markup
+// (no dropdown/options button) since we're not wired into Roblox's popover
+// system for synthetic tiles that Roblox never rendered itself.
+function createExtraFriendTile(friend, thumbnailData) {
+    const profileUrl = `/users/${friend.id}/profile`;
+
+    const tile = document.createElement('div');
+    tile.className = `${TILE_CLASS} ${EXTRA_TILE_CLASS}`;
+
+    const content = document.createElement('div');
+    content.className = 'friend-tile-content';
+
+    const avatar = document.createElement('div');
+    avatar.className = 'avatar avatar-card-fullbody';
+
+    const avatarLink = document.createElement('a');
+    avatarLink.className = 'avatar-card-link';
+    avatarLink.href = profileUrl;
+
+    const thumbContainer = document.createElement('span');
+    thumbContainer.className = 'thumbnail-2d-container avatar-card-image';
+    thumbContainer.appendChild(
+        createThumbnailElement(
+            thumbnailData,
+            friend.displayName || friend.username,
+            'rovalra-friends-extra-tile-thumb',
+            { width: '100%', height: '100%', borderRadius: '50%' },
+        ),
+    );
+
+    avatarLink.appendChild(thumbContainer);
+    avatar.appendChild(avatarLink);
+
+    const labels = document.createElement('a');
+    labels.className = 'friends-carousel-tile-labels';
+    labels.href = profileUrl;
+
+    const labelWrap = document.createElement('div');
+    labelWrap.className = 'friends-carousel-tile-label';
+
+    const nameWrap = document.createElement('div');
+    nameWrap.className = 'friends-carousel-tile-name';
+
+    const nameSpan = document.createElement('span');
+    nameSpan.className = 'friends-carousel-display-name';
+    nameSpan.textContent = friend.displayName || friend.username;
+
+    nameWrap.appendChild(nameSpan);
+    labelWrap.appendChild(nameWrap);
+    labels.appendChild(labelWrap);
+
+    content.append(avatar, labels);
+    tile.appendChild(content);
+
+    return tile;
+}
+
+async function fillMissingFriends(listContainer) {
+    if (listContainer.dataset.rovalraSecondRowFilled === 'true') return;
+    listContainer.dataset.rovalraSecondRowFilled = 'true';
+
+    const renderedIds = getRenderedFriendIds(listContainer);
+    const friends = await getCachedFriendsList();
+    const missingFriends = friends.filter(
+        (friend) => !renderedIds.has(String(friend.id)),
+    );
+
+    if (!missingFriends.length) return;
+
+    const thumbnails = await getBatchThumbnails(
+        missingFriends.map((friend) => friend.id),
+        'AvatarHeadshot',
+        '150x150',
+    );
+    const thumbnailById = new Map(
+        thumbnails.map((thumb) => [thumb.targetId, thumb]),
+    );
+
+    const fragment = document.createDocumentFragment();
+    for (const friend of missingFriends) {
+        fragment.appendChild(
+            createExtraFriendTile(friend, thumbnailById.get(Number(friend.id))),
+        );
+    }
+    listContainer.appendChild(fragment);
+}
+
+async function handleListContainer(listContainer) {
+    if (!enabled || !isHomePage()) return;
+
+    const carouselContainer = listContainer.closest(
+        CAROUSEL_CONTAINER_SELECTOR,
+    );
+    carouselContainer?.classList.add(ROW_CLASS);
+
+    fillMissingFriends(listContainer).catch((error) =>
+        console.error('RoValra: Failed to fill friends second row.', error),
+    );
+}
+
+function removeSecondRow() {
+    document
+        .querySelectorAll(`.${ROW_CLASS}`)
+        .forEach((element) => element.classList.remove(ROW_CLASS));
+    document
+        .querySelectorAll(`.${EXTRA_TILE_CLASS}`)
+        .forEach((element) => element.remove());
+    document
+        .querySelectorAll(LIST_CONTAINER_SELECTOR)
+        .forEach((element) => delete element.dataset.rovalraSecondRowFilled);
+}
+
+function registerObserver() {
+    if (observerRegistered) return;
+
+    observerRegistered = true;
+    observeElement(LIST_CONTAINER_SELECTOR, handleListContainer, {
+        multiple: true,
+    });
+}
+
+function registerStorageListener() {
+    if (storageListenerRegistered) return;
+
+    storageListenerRegistered = true;
+    chrome.storage.onChanged.addListener((changes, namespace) => {
+        if (namespace !== 'local' || !changes[SETTING_NAME]) return;
+
+        enabled = changes[SETTING_NAME].newValue === true;
+        if (enabled) {
+            registerObserver();
+            document
+                .querySelectorAll(LIST_CONTAINER_SELECTOR)
+                .forEach(handleListContainer);
+        } else {
+            removeSecondRow();
+        }
+    });
+}
+
+export async function init() {
+    registerStorageListener();
+
+    enabled = (await settings.friendsSecondRowEnabled) === true;
+    if (!enabled) {
+        removeSecondRow();
+        return;
+    }
+
+    registerObserver();
+}

--- a/src/content/features/home/friendsSecondRow.js
+++ b/src/content/features/home/friendsSecondRow.js
@@ -1,6 +1,9 @@
 import { observeElement } from '../../core/observer.js';
 import { settings } from '../../core/settings/getSettings.js';
-import { getCachedFriendsList } from '../../core/utils/trackers/friendslist.js';
+import {
+    getCachedFriendsList,
+    getFriendsList,
+} from '../../core/utils/trackers/friendslist.js';
 import {
     getBatchThumbnails,
     createThumbnailElement,
@@ -102,6 +105,8 @@ function createExtraFriendTile(friend, thumbnailData) {
 async function fillMissingFriends(listContainer) {
     if (listContainer.dataset.rovalraSecondRowFilled === 'true') return;
     listContainer.dataset.rovalraSecondRowFilled = 'true';
+    
+    getFriendsList();
 
     const renderedIds = getRenderedFriendIds(listContainer);
     const friends = await getCachedFriendsList();

--- a/src/content/features/home/friendsSecondRow.js
+++ b/src/content/features/home/friendsSecondRow.js
@@ -45,9 +45,6 @@ function getRenderedFriendIds(listContainer) {
     return ids;
 }
 
-// Extra tiles use a trimmed-down version of Roblox's own friend-tile markup
-// (no dropdown/options button) since we're not wired into Roblox's popover
-// system for synthetic tiles that Roblox never rendered itself.
 function createExtraFriendTile(friend, thumbnailData) {
     const profileUrl = `/users/${friend.id}/profile`;
 

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -166,6 +166,7 @@ import { init as initHomeLayout } from './features/home/homeLayout.js';
 import { init as initCustomThemeEditor } from './features/home/customThemeEditor.js';
 import { init as initUnderratedGamesHome } from './features/home/underratedGames.js';
 import { init as initHideAddFriendsButton } from './features/home/hideAddFriendsButton.js';
+import { init as initFriendsSecondRow } from './features/home/friendsSecondRow.js';
 // create
 import { init as initCreateDownload } from './features/create.roblox.com/download.js';
 import { init as initCatalogExplorer } from './features/catalog/explorer.js';
@@ -433,6 +434,7 @@ const featureRoutes = [
             initUnderratedGamesHome,
             initAccurateContinue,
             initHideAddFriendsButton,
+            initFriendsSecondRow,
         ],
     },
     {

--- a/src/css/features/home/friendsSecondRow.scss
+++ b/src/css/features/home/friendsSecondRow.scss
@@ -1,0 +1,46 @@
+html .react-friends-carousel-container:has(.rovalra-friends-second-row) {
+    min-height: 187px;
+    height: auto;
+}
+
+html .rovalra-friends-second-row .friends-carousel-container {
+    padding-left: 0;
+    padding-right: 0;
+}
+
+html .rovalra-friends-second-row .friends-carousel-list-container {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+    grid-template-rows: repeat(2, auto) repeat(100, 0);
+}
+
+html .rovalra-friends-second-row .friends-carousel-tile {
+    #friend-tile-button {
+        width: 100%;
+        padding: 0;
+    }
+
+    .avatar,
+    .add-friends-icon-container {
+        margin-left: auto;
+        margin-right: auto;
+    }
+
+    .friends-carousel-tile-name {
+        width: 100%;
+        justify-content: center;
+    }
+
+    .friends-carousel-display-name {
+        max-width: 100%;
+        width: auto;
+    }
+}
+
+.rovalra-friends-extra-tile {
+    .friend-tile-content {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
+}

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -30,6 +30,7 @@
 @use 'features/games/badgeLayoutToggle.scss';
 @use 'features/groups/antibots.scss';
 @use 'features/home/homeLayout.scss';
+@use 'features/home/friendsSecondRow.scss';
 @use 'features/home/customThemeEditor.scss';
 @use 'features/sitewide/backgroundImage.scss';
 @use 'features/home/hideAddFriendsButton.scss';


### PR DESCRIPTION
## What this does

Adds an opt-in setting (`friendsSecondRowEnabled`, off by default) that shows a **second row of friends** in the Home page friends carousel instead of the single row.

## How it works

- A new feature module (`src/content/features/home/friendsSecondRow.js`) observes the native friends carousel on `/home` via `observer.js` and, when the setting is enabled, adds a `rovalra-friends-second-row` class to the carousel container.
- The accompanying SCSS switches the carousel's list container from Roblox's native `display: flex; flex-wrap: nowrap` to a CSS grid (2 rows, auto-fill columns), and expands the carousel's outer wrapper height so the second row isn't clipped.
- Roblox doesn't always render every friend into the DOM for this carousel. To avoid an empty/sparse second row, the feature compares the tiles Roblox actually rendered against the full friends list (already fetched/cached by RoValra's existing `friendslist.js` tracker) and appends synthetic tiles — built from Roblox's own markup/classes — for any friends missing, fetching their avatar via the existing batched thumbnail utility (`thumbnails.js`).

## Setting

Added under the **Home** category in `settingConfig.js`:
- `friendsSecondRowEnabled` — "Second Friends Row" (default: `false`)

## Testing

- Built and loaded as an unpacked extension, tested on `/home` with the setting on/off.
- Verified with both a small friends list and a larger one that the second row fills in correctly.
- No console errors.