### PR TITLE
fix: border-radius for 3d avatar renderer

### DIFF
--- a/src/content/core/configs/userIds.js
+++ b/src/content/core/configs/userIds.js
@@ -29,7 +29,7 @@ export const CONTRIBUTOR_USER_IDS = [
     '2830488781', //idhglua
     '390309731', // AxnxDev 
     '477516666', //return_request :3
-    '2605032407', // RoPrime dev
+    '2605032407', // walway
 ];
 
 export const TESTER_USER_IDS = [

--- a/src/content/core/configs/userIds.js
+++ b/src/content/core/configs/userIds.js
@@ -29,6 +29,7 @@ export const CONTRIBUTOR_USER_IDS = [
     '2830488781', //idhglua
     '390309731', // AxnxDev 
     '477516666', //return_request :3
+    '2605032407', // RoPrime dev
 ];
 
 export const TESTER_USER_IDS = [

--- a/src/css/sitewide.scss
+++ b/src/css/sitewide.scss
@@ -69,3 +69,7 @@ body:where(.dark-theme),
 .rovalra-markdown span a {
     color: inherit;
 }
+
+.rovalra-canvas > canvas {
+    border-radius: var(--radius-medium, 8px) !important;
+}


### PR DESCRIPTION
It is made sitewide cuz canvas just eats this css unless i add it there



| before | after |
| :---: | :---: |
| <img width="157" alt="before image" src="https://github.com/user-attachments/assets/71674547-4ae3-4a97-8992-310034292df6" /> | <img width="234" alt="after image" src="https://github.com/user-attachments/assets/364f58dd-90d4-443d-a528-cdcd0d04980c" /> |