### PR TITLE
feat: Added Custom Body Colors

### DIFF
--- a/public/Assets/locales/en.json
+++ b/public/Assets/locales/en.json
@@ -1433,5 +1433,12 @@
                 }
             }
         }
+    },
+    "avatar": {
+        "bodyColors": {
+            "addCustom": "Pick a custom color",
+            "savedColor": "{{hex}}, right click to remove",
+            "applyFailed": "Could not update your body colors. Try again in a moment."
+        }
     }
 }

--- a/src/content/core/apis/avatar.js
+++ b/src/content/core/apis/avatar.js
@@ -1,4 +1,4 @@
-import { callRobloxApiJson } from '../api.js';
+import { callRobloxApi, callRobloxApiJson } from '../api.js';
 
 const avatarCache = new Map();
 
@@ -33,4 +33,50 @@ export function clearUserAvatarCache(userId) {
         return;
     }
     avatarCache.delete(String(userId));
+}
+
+/**
+ * The six body part keys Roblox uses in the Avatar V2 `bodyColor3s` object.
+ * The order matches how the parts are listed in the avatar editor.
+ */
+export const BODY_COLOR_KEYS = [
+    'headColor3',
+    'torsoColor3',
+    'leftArmColor3',
+    'rightArmColor3',
+    'leftLegColor3',
+    'rightLegColor3',
+];
+
+/**
+ * Read the authenticated user's avatar without going through the shared
+ * `getUserAvatar` cache, so callers always see the current state after a write.
+ *
+ * @param {string|number} userId
+ * @returns {Promise<Object>}
+ */
+export function getCurrentAvatar(userId) {
+    if (!userId) throw new Error('userId is required');
+
+    return callRobloxApiJson({
+        subdomain: 'avatar',
+        endpoint: `/v2/avatar/users/${encodeURIComponent(String(userId))}/avatar`,
+        noCache: true,
+    });
+}
+
+/**
+ * Apply body colours to the authenticated user's avatar.
+ *
+ * @param {Object} bodyColor3s Object keyed by {@link BODY_COLOR_KEYS}.
+ * @returns {Promise<Response>}
+ */
+export function setBodyColors(bodyColor3s) {
+    return callRobloxApi({
+        subdomain: 'avatar',
+        endpoint: '/v2/avatar/set-body-colors',
+        method: 'POST',
+        body: bodyColor3s,
+        noCache: true,
+    });
 }

--- a/src/content/core/configs/userIds.js
+++ b/src/content/core/configs/userIds.js
@@ -1,6 +1,7 @@
 export const CREATOR_USER_ID = '447170745';
 
 export const CONTRIBUTOR_USER_IDS = [
+    '4489102289', // v6u1
     '1337447242',
     '109176680',
     '795922138',

--- a/src/content/core/settings/settingConfig.js
+++ b/src/content/core/settings/settingConfig.js
@@ -1472,6 +1472,17 @@ export const SETTINGS_CONFIG = {
                 type: 'checkbox',
                 default: true,
             },
+            bodyColorsEnabled: {
+                label: 'Custom Body Colors',
+                description: [
+                    "Adds a custom color to the body colors in the avatar editor, so you are not limited to Roblox's preset palette.",
+                    'Colors you pick are saved next to the presets so you can reuse them. Right click a saved color to remove it.',
+                ],
+                type: 'checkbox',
+                default: true,
+                storageKey: ['rovalra_body_color_presets'],
+                contributors: ['4489102289'],
+            },
             avatarRotatorEnabled: {
                 label: 'Avatar Rotator',
                 description: [

--- a/src/content/features/avatar/bodyColors.js
+++ b/src/content/features/avatar/bodyColors.js
@@ -1,0 +1,286 @@
+import {
+    observeElement,
+    observeChildren,
+    observeAttributes,
+} from '../../core/observer.js';
+import { settings } from '../../core/settings/getSettings.js';
+import { getAuthenticatedUserId } from '../../core/user.js';
+import {
+    BODY_COLOR_KEYS,
+    getCurrentAvatar,
+    setBodyColors,
+} from '../../core/apis/avatar.js';
+import { showSystemAlert } from '../../core/ui/roblox/alert.js';
+import { addTooltip } from '../../core/ui/tooltip.js';
+import { Icon } from '../../core/ui/buildericon.js';
+import { t, ts } from '../../core/locale/i18n.js';
+
+const PRESETS_STORAGE_KEY = 'rovalra_body_color_presets';
+const MAX_PRESETS = 12;
+const HEX_PATTERN = /^#[0-9a-fA-F]{6}$/;
+const DOT_MARKER = 'data-rovalra-body-color';
+
+function normalizeHex(value) {
+    if (typeof value !== 'string') return null;
+
+    let hex = value.trim();
+    if (!hex) return null;
+    if (!hex.startsWith('#')) hex = `#${hex}`;
+
+    if (hex.length === 4) {
+        hex = `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}`;
+    }
+
+    return HEX_PATTERN.test(hex) ? hex.toUpperCase() : null;
+}
+
+function loadPresets() {
+    return new Promise((resolve) => {
+        chrome.storage.local.get({ [PRESETS_STORAGE_KEY]: [] }, (data) => {
+            const stored = data?.[PRESETS_STORAGE_KEY];
+            resolve(
+                Array.isArray(stored)
+                    ? stored.map(normalizeHex).filter(Boolean)
+                    : [],
+            );
+        });
+    });
+}
+
+function savePresets(presets) {
+    return new Promise((resolve) => {
+        chrome.storage.local.set({ [PRESETS_STORAGE_KEY]: presets }, resolve);
+    });
+}
+
+// The editor won't notice a write made outside React, so use its redraw control.
+function refreshAvatarPreview() {
+    document.querySelector('.redraw-avatar button')?.click();
+}
+
+export function init() {
+    if (!window.location.pathname.includes('/my/avatar')) return;
+
+    let teardown = null;
+    let activeList = null;
+
+    const release = () => {
+        teardown?.();
+        teardown = null;
+    };
+
+    // Always after release(), otherwise the child observer puts them straight
+    // back.
+    const removeDots = (list) => {
+        for (const dot of (list || document).querySelectorAll(
+            `[${DOT_MARKER}]`,
+        )) {
+            dot.remove();
+        }
+    };
+
+    const build = async (list) => {
+        if (!(await settings.bodyColorsEnabled)) return;
+
+        release();
+        removeDots(list);
+
+        const userId = await getAuthenticatedUserId();
+        if (!userId) return;
+
+        let presets = await loadPresets();
+        let applying = false;
+        let activeHex = null;
+
+        const addHint = await t('avatar.bodyColors.addCustom');
+        const failedText = await t('avatar.bodyColors.applyFailed');
+
+        const picker = document.createElement('input');
+        picker.type = 'color';
+        picker.className = 'rovalra-body-colors-picker';
+        picker.setAttribute('aria-label', addHint);
+
+        const addDot = document.createElement('div');
+        addDot.className = 'color-dot rovalra-body-colors-add';
+        addDot.setAttribute(DOT_MARKER, 'add');
+        addDot.append(
+            Icon({ icon: 'add', size: 'small', material: true }),
+            picker,
+        );
+        addTooltip(addDot, addHint);
+
+        const apply = async (hex) => {
+            if (applying) return false;
+            applying = true;
+
+            const body = {};
+            for (const key of BODY_COLOR_KEYS) body[key] = hex;
+
+            try {
+                const response = await setBodyColors(body);
+                if (!response.ok) throw new Error(`HTTP ${response.status}`);
+                activeHex = hex;
+                syncActive();
+                refreshAvatarPreview();
+                return true;
+            } catch (error) {
+                console.error('RoValra: Failed to set body colours', error);
+                showSystemAlert(failedText, 'warning');
+                return false;
+            } finally {
+                applying = false;
+            }
+        };
+
+        const createDot = (hex) => {
+            const dot = document.createElement('div');
+            dot.className = 'color-dot';
+            dot.setAttribute(DOT_MARKER, 'saved');
+            dot.dataset.rovalraHex = hex;
+            dot.style.backgroundColor = hex;
+            addTooltip(dot, ts('avatar.bodyColors.savedColor', { hex }));
+
+            dot.addEventListener('click', () => apply(hex));
+            dot.addEventListener('contextmenu', async (event) => {
+                event.preventDefault();
+                if (activeHex === hex) activeHex = null;
+                presets = presets.filter((entry) => entry !== hex);
+                await savePresets(presets);
+                dot.remove();
+            });
+
+            return dot;
+        };
+
+        // The ring is drawn off the editor's own `active` class.
+        const syncActive = () => {
+            if (!activeHex) return;
+            for (const dot of list.querySelectorAll('.color-dot')) {
+                dot.classList.toggle(
+                    'active',
+                    dot.dataset.rovalraHex === activeHex,
+                );
+            }
+        };
+
+        // Moved by hand rather than left to the editor, which only rerenders when
+        // its own selection changes and still thinks a preset is selected.
+        const releaseActive = (event) => {
+            if (!activeHex) return;
+
+            const dot = event.target.closest('.color-dot');
+            if (!dot || dot.hasAttribute(DOT_MARKER)) return;
+
+            activeHex = null;
+            for (const active of list.querySelectorAll('.color-dot.active')) {
+                active.classList.remove('active');
+            }
+            dot.classList.add('active');
+        };
+
+        // The palette dims and locks its dots inline, so these have to follow.
+        const syncDisabled = () => {
+            const disabled = list.getAttribute('aria-disabled') === 'true';
+            for (const dot of list.querySelectorAll(`[${DOT_MARKER}]`)) {
+                dot.style.opacity = disabled ? '0.5' : '1';
+                dot.style.pointerEvents = disabled ? 'none' : 'auto';
+            }
+        };
+
+        // Rerenders drop these dots, so put them back. Only what's missing, or
+        // this would keep waking the observer that called it.
+        const syncDots = () => {
+            if (!list.isConnected) return;
+
+            if (!addDot.isConnected) list.appendChild(addDot);
+
+            const present = new Set();
+            for (const dot of list.querySelectorAll(
+                `[${DOT_MARKER}="saved"]`,
+            )) {
+                if (presets.includes(dot.dataset.rovalraHex)) {
+                    present.add(dot.dataset.rovalraHex);
+                } else {
+                    dot.remove();
+                }
+            }
+
+            for (const hex of presets) {
+                if (present.has(hex)) continue;
+                list.insertBefore(createDot(hex), addDot);
+            }
+
+            syncDisabled();
+            syncActive();
+        };
+
+        // Saved first because applying redraws, and the rebuild reads storage.
+        picker.addEventListener('change', async () => {
+            const hex = normalizeHex(picker.value);
+            if (!hex) return;
+
+            if (!presets.includes(hex)) {
+                presets = [hex, ...presets].slice(0, MAX_PRESETS);
+                await savePresets(presets);
+                syncDots();
+            }
+
+            await apply(hex);
+        });
+
+        syncDots();
+
+        list.addEventListener('click', releaseActive);
+
+        const children = observeChildren(list, syncDots);
+        const attributes = observeAttributes(list, syncDisabled, [
+            'aria-disabled',
+        ]);
+
+        teardown = () => {
+            list.removeEventListener('click', releaseActive);
+            children.disconnect();
+            attributes.disconnect();
+        };
+
+        try {
+            const avatar = await getCurrentAvatar(userId);
+            const current = normalizeHex(avatar?.bodyColor3s?.headColor3);
+            if (!current) return;
+
+            picker.value = current;
+
+            if (presets.includes(current)) {
+                activeHex = current;
+                syncActive();
+            }
+        } catch (error) {
+            console.error('RoValra: Failed to read body colours', error);
+        }
+    };
+
+    observeElement(
+        '#bodyColors .bodycolors-list',
+        (list) => {
+            activeList = list;
+            build(list);
+        },
+        {
+            onRemove: () => {
+                activeList = null;
+                release();
+            },
+        },
+    );
+
+    chrome.storage.onChanged.addListener((changes, namespace) => {
+        if (namespace !== 'local' || !changes.bodyColorsEnabled) return;
+
+        release();
+        removeDots(activeList);
+
+        if (changes.bodyColorsEnabled.newValue !== false && activeList) {
+            build(activeList);
+        }
+    });
+}

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -58,6 +58,7 @@ import { init as initAvatarFilters } from './features/avatar/filters.js';
 import { init as initR6Warning } from './features/avatar/R6Warning.js';
 import { init as initAvatarRotator } from './features/avatar/avatarRotator.js';
 import { init as initMultiEquip } from './features/avatar/multiEquip.js';
+import { init as initBodyColors } from './features/avatar/bodyColors.js';
 
 // Catalog
 import { init as initItemSales } from './features/catalog/itemsales.js';
@@ -367,6 +368,7 @@ const featureRoutes = [
             initR6Warning,
             initAvatarRotator,
             initMultiEquip,
+            initBodyColors,
         ],
     },
     // Roblox Plus Page

--- a/src/css/features/avatar/body_colors.scss
+++ b/src/css/features/avatar/body_colors.scss
@@ -1,0 +1,30 @@
+.rovalra-body-colors-add {
+    position: relative;
+    background-color: transparent;
+    border: 1px dashed var(--rovalra-border-color);
+}
+
+/* Centred against the dot itself rather than through the parent's layout, since
+   the palette owns how these dots are laid out. */
+.rovalra-body-colors-add icon {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    display: block;
+    color: var(--rovalra-secondary-text-color);
+    transform: translate(-50%, -50%);
+    pointer-events: none;
+}
+
+.rovalra-body-colors-picker {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    padding: 0;
+    background: transparent;
+    border: 0;
+    opacity: 0;
+    cursor: pointer;
+}

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -48,4 +48,5 @@
 @use 'features/sitewide/kids_theme_text.scss';
 @use 'features/plus/sendRobux.scss';
 @use 'features/sitewide/viewid.scss';
+@use 'features/avatar/body_colors.scss';
 @use 'components/dropdown.scss'


### PR DESCRIPTION
Redo of #210, styling should fit now.

Instead of its own panel it just adds a dot to the body colours list with a + on it. Click it, pick a colour, it gets applied to the whole body like the normal dots. Colours you pick are saved and sit next to the presets, right click to remove.

Didnt do per part colours, Advanced already does that.