### PR TITLE
feat: Add block button to trade page

### DIFF
--- a/public/Assets/locales/en.json
+++ b/public/Assets/locales/en.json
@@ -968,6 +968,17 @@
         "exitBulkMode": "Exit Bulk Mode",
         "successMessage": "Successfully unfriended {{successCount}}/{{totalCount}} friends!"
     },
+    "blockUser": {
+        "block": "Block",
+        "unblock": "Unblock",
+        "blockTitle": "Block {{username}}",
+        "unblockTitle": "Unblock {{username}}",
+        "blockTitleGeneric": "Block User",
+        "unblockTitleGeneric": "Unblock User",
+        "blockMessage": "They will no longer be able to send you trades. You can still decline any existing trade, but you will not be able to accept or counter it.",
+        "unblockMessage": "They will be able to send you trades again, and you will be able to accept or counter any existing trades.",
+        "cancel": "Cancel"
+    },
     "unfriendDetector": {
         "title_one": "Unfriend Detected",
         "title_other": "Unfriends Detected",

--- a/src/content/core/configs/userIds.js
+++ b/src/content/core/configs/userIds.js
@@ -31,6 +31,7 @@ export const CONTRIBUTOR_USER_IDS = [
     '477516666', //return_request :3
     '4632962611', //coderpixel
     '2605032407', // walway
+    '1960518316', // lobberxv :3
 ];
 
 export const TESTER_USER_IDS = [

--- a/src/content/core/settings/settingConfig.js
+++ b/src/content/core/settings/settingConfig.js
@@ -1701,6 +1701,13 @@ export const SETTINGS_CONFIG = {
                 experimental:
                     "May be inaccurate. It isn't recommended to rely on this completely.",
             },
+            blockUserEnabled: {
+                label: 'Block User',
+                description: "Allows you to block users on the trade page, preventing them from sending you trade offers.",
+                type: 'checkbox',
+                default: false,
+                contributors: ['1960518316'],
+            },
         },
     },
     Plus: {

--- a/src/content/features/trading/blockUser.js
+++ b/src/content/features/trading/blockUser.js
@@ -1,0 +1,151 @@
+import { observeElement } from '../../core/observer.js';
+import { settings } from '../../core/settings/getSettings.js';
+import { getUserIdFromUrl } from '../../core/idExtractor.js';
+import { callRobloxApi } from '../../core/api.js';
+import { showConfirmationPrompt } from '../../core/ui/confirmationPrompt.js';
+import { t } from '../../core/locale/i18n.js';
+
+const MAX_PAGES = 20;
+let blockedIds = null;
+let observerRequest = null;
+let refreshListenerAttached = false;
+
+async function getBlockedIds() {
+    if (blockedIds) return blockedIds;
+
+    const ids = new Set();
+    let cursor = '';
+    let pages = 0;
+    do {
+        const response = await callRobloxApi({
+            subdomain: 'apis',
+            endpoint: `/user-blocking-api/v1/users/get-blocked-users?cursor=${cursor}&count=50`,
+        });
+        if (!response.ok) return ids;
+
+        const json = await response.json();
+        (json?.data?.blockedUserIds || []).forEach((id) => ids.add(String(id)));
+        cursor = json?.data?.cursor || '';
+        pages += 1;
+    } while (cursor && pages < MAX_PAGES);
+
+    blockedIds = ids;
+    return ids;
+}
+
+async function setUserBlocked(userId, blocked) {
+    const action = blocked ? 'block-user' : 'unblock-user';
+    const response = await callRobloxApi({
+        subdomain: 'apis',
+        endpoint: `/user-blocking-api/v1/users/${userId}/${action}`,
+        method: 'POST',
+    });
+    if (!response.ok) return false;
+
+    const ids = await getBlockedIds();
+    if (blocked) ids.add(userId);
+    else ids.delete(userId);
+    return true;
+}
+
+function getTradePartnerId(container) {
+    const link = container
+        .closest('.trades-list-detail')
+        ?.querySelector('.paired-name');
+    return link ? getUserIdFromUrl(link.href) : null;
+}
+
+function getTradePartnerName(container) {
+    const link = container
+        .closest('.trades-list-detail')
+        ?.querySelector('.paired-name');
+    if (!link) return null;
+
+    const parts = link.querySelectorAll('.element');
+    const displayName = parts[0]?.textContent?.trim();
+    const username = parts[1]?.textContent?.trim();
+    if (!displayName) return null;
+    return username ? `${displayName} (@${username})` : displayName;
+}
+
+async function addBlockButton(container) {
+    if (container.querySelector('.rovalra-block-button')) return;
+
+    const button = document.createElement('button');
+    button.className = 'btn-control-md rovalra-block-button';
+    Object.assign(button.style, {
+        color: 'var(--color-action-alert-foreground)',
+    });
+    const refreshLabel = async () => {
+        const userId = getTradePartnerId(container);
+        if (!userId) return;
+        const isBlocked = (await getBlockedIds()).has(userId);
+        button.textContent = isBlocked
+            ? await t('blockUser.unblock')
+            : await t('blockUser.block');
+    };
+
+    button.addEventListener('click', async (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const userId = getTradePartnerId(container);
+        if (!userId) return;
+
+        const isBlocked = (await getBlockedIds()).has(userId);
+        const username = getTradePartnerName(container);
+        const titleKey = isBlocked
+            ? username
+                ? 'blockUser.unblockTitle'
+                : 'blockUser.unblockTitleGeneric'
+            : username
+              ? 'blockUser.blockTitle'
+              : 'blockUser.blockTitleGeneric';
+        showConfirmationPrompt({
+            title: await t(titleKey, { username }),
+            message: isBlocked
+                ? await t('blockUser.unblockMessage')
+                : await t('blockUser.blockMessage'),
+            confirmText: isBlocked
+                ? await t('blockUser.unblock')
+                : await t('blockUser.block'),
+            cancelText: await t('blockUser.cancel'),
+            onConfirm: async () => {
+                button.disabled = true;
+                const ok = await setUserBlocked(userId, !isBlocked);
+                button.disabled = false;
+                await refreshLabel();
+                if (!ok) console.warn('[RoValra] Failed to update block state');
+            },
+        });
+    });
+
+    await refreshLabel();
+    container.appendChild(button);
+    if (!refreshListenerAttached) {
+        refreshListenerAttached = true;
+        document.addEventListener('click', (e) => {
+            if (e.target.closest('.trade-row')) {
+                setTimeout(refreshLabel, 100);
+            }
+        });
+    }
+}
+
+export async function init() {
+    if (!(await settings.blockUserEnabled)) return;
+
+    const path = window.location.pathname;
+    if (!path.startsWith('/trades')) {
+        if (observerRequest) {
+            observerRequest.active = false;
+            observerRequest = null;
+        }
+        return;
+    }
+    if (observerRequest) return;
+
+    observerRequest = observeElement('.trade-buttons', addBlockButton, {
+        multiple: true,
+    });
+}

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -108,6 +108,7 @@ import { init as initTradePreview } from './features/trading/tradePreview.js';
 import { init as initTradeFilter } from './features/trading/tradefilter.js';
 import { init as initTradeSearch } from './features/trading/tradeSearch.js';
 import { init as initTradeProof } from './features/trading/tradeProof.js';
+import { init as initBlockUser } from './features/trading/blockUser.js';
 // group
 import { init as initHiddenGroupGames } from './features/groups/hiddenGroupGames.js';
 import { init as initAntiBots } from './features/groups/Antibots.js';
@@ -448,6 +449,7 @@ const featureRoutes = [
             initTradeFilter,
             initTradeSearch,
             initTradeProof,
+            initBlockUser,
         ],
     },
 


### PR DESCRIPTION
Adds a button to easily block & unblock a user on the trade page. giving a prompt b4 any action.

Theres a toggle in rovalra trading settings.
<img width="1079" height="1003" alt="brave_GkaL6lFHxU" src="https://github.com/user-attachments/assets/8fef00ed-9b14-4990-96a2-55fc1c3e39d2" />

