### PR TITLE
feat: add Roblox telemetry blocking

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -1,5 +1,8 @@
 import { SETTINGS_CONFIG } from '../content/core/settings/settingConfig.js';
 import init from './settingsCompat.ts';
+import { initializeTelemetryBlocker } from './telemetryBlocker.js';
+
+initializeTelemetryBlocker();
 
 // --- Constants & State ---
 

--- a/src/background/telemetryBlocker.js
+++ b/src/background/telemetryBlocker.js
@@ -1,0 +1,140 @@
+export const NORMAL_TELEMETRY_RULES = [
+    { id: 7100, regexFilter: '^https?://ecsv2\\.roblox\\.com/' },
+    {
+        id: 7101,
+        regexFilter:
+            '^https://apis\\.roblox\\.com/experience-signals-ingest/public/v1/events/(single|optimized)([?]|$)',
+    },
+    {
+        id: 7102,
+        regexFilter:
+            '^https://apis\\.roblox\\.com/affiliate-links/v1/events/(authenticated-visit|qualified-signup)([?]|$)',
+    },
+    {
+        id: 7103,
+        regexFilter:
+            '^https://apis\\.roblox\\.com/modals-api/v1/prompts/impression([?]|$)',
+    },
+];
+
+export const AGGRESSIVE_TELEMETRY_RULES = [
+    {
+        id: 7200,
+        regexFilter:
+            '^https?://metrics\\.roblox\\.com/v1/thumbnails/(load|metadata)([?]|$)',
+    },
+    {
+        id: 7201,
+        regexFilter:
+            '^https?://apis\\.roblox\\.com/account-security-service/v1/metrics/record([?]|$)',
+    },
+    {
+        id: 7202,
+        regexFilter:
+            '^https://o293668\\.ingest\\.us\\.sentry\\.io/api/4509158985826304/(envelope|store)/([?]|$)',
+    },
+    {
+        id: 7203,
+        regexFilter:
+            '^https://metrics\\.roblox\\.com/v1/games/report-event([?]|$)',
+    },
+    {
+        id: 7204,
+        regexFilter:
+            '^https://assetgame\\.roblox\\.com/game/report-stats([?]|$)',
+    },
+    {
+        id: 7205,
+        regexFilter: '^https://www\\.roblox\\.com/game/report-event([?]|$)',
+    },
+    {
+        id: 7206,
+        regexFilter:
+            '^https://apis\\.roblox\\.com/user-heartbeats-api/pulse([?]|$)',
+    },
+    {
+        id: 7207,
+        regexFilter: '^https://tracing\\.roblox\\.com/v1/traces([?]|$)',
+    },
+    {
+        id: 7208,
+        regexFilter:
+            '^https://metrics\\.roblox\\.com/v1/bundle-metrics/report([?]|$)',
+    },
+    {
+        id: 7209,
+        regexFilter:
+            '^https://adconfiguration\\.roblox\\.com/v2/tracking/click([?]|$)',
+    },
+    {
+        id: 7210,
+        regexFilter: '^https://lms\\.roblox\\.com/report([?]|$)',
+    },
+    {
+        id: 7211,
+        regexFilter:
+            '^https://metrics\\.roblox\\.com/v1/performance/measurements([?]|$)',
+    },
+];
+
+export function getTelemetryRules(settings) {
+    if (settings.telemetryBlockerEnabled !== true) return [];
+
+    const definitions =
+        settings.telemetryBlockerAggressiveEnabled === true
+            ? [...NORMAL_TELEMETRY_RULES, ...AGGRESSIVE_TELEMETRY_RULES]
+            : NORMAL_TELEMETRY_RULES;
+
+    return definitions.map(({ id, regexFilter }) => ({
+        id,
+        priority: 1,
+        action: { type: 'block' },
+        condition: {
+            regexFilter,
+            initiatorDomains: ['roblox.com'],
+            resourceTypes: ['xmlhttprequest', 'ping', 'image', 'other'],
+        },
+    }));
+}
+
+export function initializeTelemetryBlocker() {
+    const removeRuleIds = [
+        ...NORMAL_TELEMETRY_RULES,
+        ...AGGRESSIVE_TELEMETRY_RULES,
+    ].map(({ id }) => id);
+    let pendingUpdate = Promise.resolve();
+
+    const synchronize = () => {
+        pendingUpdate = pendingUpdate
+            .then(async () => {
+                const settings = await chrome.storage.local.get({
+                    telemetryBlockerEnabled: false,
+                    telemetryBlockerAggressiveEnabled: false,
+                });
+                await chrome.declarativeNetRequest.updateDynamicRules({
+                    removeRuleIds,
+                    addRules: getTelemetryRules(settings),
+                });
+            })
+            .catch((error) => {
+                console.error(
+                    'RoValra: Failed to update telemetry blocking.',
+                    error,
+                );
+            });
+        return pendingUpdate;
+    };
+
+    chrome.storage.onChanged.addListener((changes, areaName) => {
+        if (
+            areaName === 'local' &&
+            (changes.telemetryBlockerEnabled ||
+                changes.telemetryBlockerAggressiveEnabled)
+        ) {
+            synchronize();
+        }
+    });
+    chrome.runtime.onInstalled.addListener(synchronize);
+    chrome.runtime.onStartup.addListener(synchronize);
+    return synchronize();
+}

--- a/src/content/core/settings/settingConfig.js
+++ b/src/content/core/settings/settingConfig.js
@@ -2522,6 +2522,29 @@ export const SETTINGS_CONFIG = {
     AntiAccountTracking: {
         title: 'Privacy',
         settings: {
+            telemetryBlockerEnabled: {
+                label: 'Block Roblox Telemetry',
+                description:
+                    'Blocks some of the tracking, analytics, and data collection Roblox uses while you browse the website.',
+                type: 'checkbox',
+                default: false,
+                contributors: ['476449201'],
+                childSettings: {
+                    telemetryBlockerAggressiveEnabled: {
+                        label: 'Aggressive Blocking',
+                        condition: {
+                            parent: 'telemetryBlockerEnabled',
+                            value: true,
+                            hide: false,
+                        },
+                        description:
+                            'Blocks even more Roblox tracking, including additional performance metrics and error reports.',
+                        type: 'checkbox',
+                        default: false,
+                        experimental: 'This may affect some Roblox features.',
+                    },
+                },
+            },
             streamermode: {
                 label: 'Streamer Mode',
                 description: [


### PR DESCRIPTION
## Normal

| Endpoint | Purpose |
|---|---|
| `ecsv2.roblox.com/*` | Sends Roblox EventStream activity and usage events |
| `apis.roblox.com/experience-signals-ingest/public/v1/events/single` | Sends individual EventStream events |
| `apis.roblox.com/experience-signals-ingest/public/v1/events/optimized` | Sends batches of EventStream events |
| `apis.roblox.com/affiliate-links/v1/events/authenticated-visit` | Tracks visits from affiliate links |
| `apis.roblox.com/affiliate-links/v1/events/qualified-signup` | Tracks signups from affiliate links |
| `apis.roblox.com/modals-api/v1/prompts/impression` | Reports when a Roblox prompt is shown |

## Aggressive

| Endpoint | Purpose |
|---|---|
| `metrics.roblox.com/v1/thumbnails/load` | Reports thumbnail load times and timeouts |
| `metrics.roblox.com/v1/thumbnails/metadata` | Fetches thumbnail metrics settings and sampling data |
| `apis.roblox.com/account-security-service/v1/metrics/record` | Reports security challenge, captcha, iframe, and timing metrics |
| `o293668.ingest.us.sentry.io/api/4509158985826304/envelope/` | Sends browser errors and diagnostics to Roblox's Sentry project |
| `o293668.ingest.us.sentry.io/api/4509158985826304/store/` | Sends browser error events to the same Sentry project |
| `metrics.roblox.com/v1/games/report-event` | Reports game launch and client stats |
| `assetgame.roblox.com/game/report-stats` | Reports game-related statistics |
| `www.roblox.com/game/report-event` | Reports game launch events |
| `apis.roblox.com/user-heartbeats-api/pulse` | Sends page activity and session heartbeats |
| `tracing.roblox.com/v1/traces` | Sends sampled browser performance traces |
| `metrics.roblox.com/v1/bundle-metrics/report` | Reports failed bundle and resource loads |
| `adconfiguration.roblox.com/v2/tracking/click` | Tracks clicks on sponsored content |
| `lms.roblox.com/report` | Reports browser and CDN latency |
| `metrics.roblox.com/v1/performance/measurements` | Reports catalog and search performance issues |